### PR TITLE
adr: initial v1 decision records (0000-0014)

### DIFF
--- a/adr/0000-record-architecture-decisions.md
+++ b/adr/0000-record-architecture-decisions.md
@@ -1,0 +1,17 @@
+# ADR 0000: Record architecture decisions
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Darbaan is a security-sensitive project whose design was worked out in
+discussion. We want the reasoning behind each significant decision to be
+durable and reviewable, not lost in chat history.
+
+## Decision
+We use Architecture Decision Records. Each ADR is a numbered Markdown file in
+`adr/` with Status, Context, Decision, Consequences. ADRs are immutable once
+Accepted; a later ADR can supersede an earlier one.
+
+## Consequences
+Decisions are auditable and onboardable. Changing a decision is itself a
+recorded, deliberate act.

--- a/adr/0001-mail-proxy-not-http-api.md
+++ b/adr/0001-mail-proxy-not-http-api.md
@@ -1,0 +1,18 @@
+# ADR 0001: A mail proxy over IMAP/SMTP, not an HTTP API
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Agents need to read and send email under policy. We could expose a bespoke
+HTTP API, or speak the protocols mail already uses.
+
+## Decision
+Darbaan is a **proxy** that agents talk to over standard **IMAP** (read) and
+**SMTP** (send). It is not an HTTP service. Behind it sit the real mailboxes.
+
+## Consequences
+- Existing mail tooling works unchanged.
+- Rejections can use real email semantics (see ADR 0006), not custom error codes.
+- One local service hosts both the IMAP face and the SMTP face.
+- Public-library boundary follows Go convention: `pkg/` public API, `internal/`
+  private, thin CLI in `cmd/darbaan` (see ADR 0013).

--- a/adr/0002-policy-in-a-separate-box-credential-isolation.md
+++ b/adr/0002-policy-in-a-separate-box-credential-isolation.md
@@ -1,0 +1,19 @@
+# ADR 0002: Policy in a separate trusted box; credential isolation
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+The thing an email injection attacks is the agent's own judgment. Policy that
+lives in the agent's prompt or behaviour can be argued away. The real mailbox
+credentials, if held by the agent, can be exfiltrated.
+
+## Decision
+Policy lives in Darbaan, a separate component the agent does not control, and is
+enforced **mechanically**. Darbaan holds the **real** mailbox credentials; each
+agent only ever gets **Darbaan** credentials.
+
+## Consequences
+- Policy holds even if an agent is fully compromised.
+- An injection that steals an agent's credentials gets a box that is already
+  policy-limited, never the actual mailbox.
+- Darbaan is a trust boundary; its own integrity is the thing to protect.

--- a/adr/0002-policy-in-a-separate-box-credential-isolation.md
+++ b/adr/0002-policy-in-a-separate-box-credential-isolation.md
@@ -17,3 +17,10 @@ agent only ever gets **Darbaan** credentials.
 - An injection that steals an agent's credentials gets a box that is already
   policy-limited, never the actual mailbox.
 - Darbaan is a trust boundary; its own integrity is the thing to protect.
+
+## Amendment (2026-06-25, review)
+**Defining "Darbaan credentials" (how an agent authenticates).** Each agent
+authenticates to Darbaan's IMAP and SMTP faces with **per-agent credentials** (a
+username + secret/token) issued by Darbaan, over TLS. These identify the agent
+principal and grant **only** Darbaan access, never upstream access. v1 is
+single-agent (one credential set); the mechanism generalizes to many (ADR 0010).

--- a/adr/0003-outbound-sluice-trap-default-deny.md
+++ b/adr/0003-outbound-sluice-trap-default-deny.md
@@ -1,0 +1,20 @@
+# ADR 0003: The outbound sluice trap, fail-closed and default-deny
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Sending is the dangerous half: exfiltration and unauthorized action happen on
+the send path. Reading is recoverable; sending is not.
+
+## Decision
+Every outbound message is trapped in **the sluice** (the outbound hold/queue).
+Darbaan accepts the SMTP submission (250 OK) and enqueues it; nothing auto-sends.
+The default disposition is **block (default-deny)**: out of the box nothing
+sends, and every send-permitting path (approval chains, allowlists, any future
+auto-approve) is **human-configured**. The system is **fail-closed**: no
+approval never decays into "send later"; an unapproved message waits forever.
+
+## Consequences
+- Only the human's configuration can loosen sending, never the agent or an injection.
+- A message is released to the real upstream SMTP only after a full approval pass
+  (see ADR 0004).

--- a/adr/0004-pluggable-approval-pipeline.md
+++ b/adr/0004-pluggable-approval-pipeline.md
@@ -20,3 +20,10 @@ agent approvers never edit.
 - New approval surfaces are added without touching the core.
 - The audit log keeps both the agent's original draft and any human-edited
   version (see ADR 0011).
+
+## Amendment (2026-06-25, review)
+**Approver timeout = fail-closed.** If no approver acts within a configured
+window, the message is **not** sent; it stays queued. A timeout never
+auto-sends, consistent with default-deny (ADR 0003). Operators may configure
+escalation or an explicit expiry-to-rejected (which then bounces per ADR 0006),
+but the default on timeout is "keep waiting," never "send."

--- a/adr/0004-pluggable-approval-pipeline.md
+++ b/adr/0004-pluggable-approval-pipeline.md
@@ -1,0 +1,22 @@
+# ADR 0004: Pluggable, multi-level approval pipeline
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Approval may come from a person via different surfaces, or from an automated
+check. We do not want the gate wired to a single mechanism.
+
+## Decision
+Approvers implement one contract: `(message + metadata) -> verdict`. A web UI, a
+Telegram bot, a chat react, or an agent are all implementations. Approvers are
+selectable at **runtime and compile time** (Go build tags, blank-import
+registry), so a binary can ship with only the approvers wanted. Chaining gives
+**multi-level** approval (every stage must pass). **Edit-before-release** is a
+per-approver capability: an approver that supports it (web) may edit a draft
+inline and release; others only approve/reject. Editing is **human-only**;
+agent approvers never edit.
+
+## Consequences
+- New approval surfaces are added without touching the core.
+- The audit log keeps both the agent's original draft and any human-edited
+  version (see ADR 0011).

--- a/adr/0005-agent-prescreener-plugin-risk-routing.md
+++ b/adr/0005-agent-prescreener-plugin-risk-routing.md
@@ -1,0 +1,19 @@
+# ADR 0005: Agent pre-screener as a compile-time plugin; risk routing
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+An automated agent can pre-screen queued mail for injection/exfiltration smell
+before a human looks. But the core must not depend on an AI runtime.
+
+## Decision
+The agent pre-screener is **just another approver plugin**, selected via build
+tag (ADR 0004). Darbaan's core carries **no AI dependency** and can be built
+human-only. The pre-screener emits a **coarse** result: a level
+(low/medium/high), reasons, and boolean flags (touches-secret, new-recipient,
+external-domain, has-attachment). Routing: low with no flags takes the light
+path (one human tap); medium/high or any flag takes the strict path.
+
+## Consequences
+- Coarse buckets avoid false precision; refine once real traffic is seen.
+- Deployments choose their own AI dependency posture at build time.

--- a/adr/0005-agent-prescreener-plugin-risk-routing.md
+++ b/adr/0005-agent-prescreener-plugin-risk-routing.md
@@ -17,3 +17,11 @@ path (one human tap); medium/high or any flag takes the strict path.
 ## Consequences
 - Coarse buckets avoid false precision; refine once real traffic is seen.
 - Deployments choose their own AI dependency posture at build time.
+
+## Amendment (2026-06-25, review)
+**How the risk result selects a chain.** A **router** consumes the pre-screener
+verdict and picks the approval chain: low + no flags → the **light** chain;
+medium/high or any flag → the **strict** chain, per a configured routing table.
+The pre-screener runs as the mandatory first stage when compiled in. **If it is
+not compiled in, the router defaults to the strict chain** (fail-safe) — absence
+of a risk signal is treated as "could be risky," never as "low."

--- a/adr/0006-rejection-as-async-dsn-bounce.md
+++ b/adr/0006-rejection-as-async-dsn-bounce.md
@@ -1,0 +1,21 @@
+# ADR 0006: Rejection modelled as an asynchronous DSN bounce
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Approval is asynchronous; a human may take hours. You cannot hold an SMTP
+connection open that long, and a custom async API would break ADR 0001.
+
+## Decision
+Darbaan accepts the submission, then if the message is rejected it delivers a
+**MAILER-DAEMON-style bounce** to the agent's inbox, original attached as
+`message/rfc822`, reason in the body, using real **DSN** status codes (RFC 3464):
+**4.x.x transient** = revise and resubmit; **5.x.x permanent** = drop, do not
+retry. A **retry cap** bounds fix-and-resubmit loops. Every **permanent (5xx)**
+rejection is a **security signal**, logged and surfaced to the operator. The
+rejection reason always originates from Darbaan/the approver and **never echoes
+the attacker's email text**.
+
+## Consequences
+- The agent's existing read loop handles rejections; no custom protocol.
+- The correction loop closes naturally for transient rejections.

--- a/adr/0007-signed-bounce-trust.md
+++ b/adr/0007-signed-bounce-trust.md
@@ -1,0 +1,19 @@
+# ADR 0007: Signed bounces as the trust anchor
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Because rejections arrive as inbound mail (ADR 0006), a forged bounce is an
+obvious attack: an outsider mails a fake MAILER-DAEMON telling the agent to
+resend elsewhere with changes.
+
+## Decision
+Darbaan **signs every bounce** it issues (DKIM-style or a detached signature
+header). Agents hold only the **verify (public) key**; Darbaan holds the
+**signing (private) key**. An agent trusts **only** a rejection Darbaan itself
+signed. Darbaan, being each agent's sole IMAP source, quarantines any external
+mail posing as a bounce.
+
+## Consequences
+- Agents can confirm authenticity but never forge a bounce.
+- The signing key is a critical secret (see ADR 0012).

--- a/adr/0007-signed-bounce-trust.md
+++ b/adr/0007-signed-bounce-trust.md
@@ -17,3 +17,11 @@ mail posing as a bounce.
 ## Consequences
 - Agents can confirm authenticity but never forge a bounce.
 - The signing key is a critical secret (see ADR 0012).
+
+## Amendment (2026-06-25, review)
+**One mechanism + key distribution.** Darbaan signs bounces using **DKIM**
+(RFC 6376) over a dedicated signing domain/selector — email-native and
+verifiable with standard tooling (chosen over an ad-hoc detached header).
+**Key distribution:** Darbaan holds the private key; each agent is provisioned
+**out of band** with Darbaan's public key **pinned** at setup and verifies every
+bounce against it. Key rotation is an operator action that re-pins.

--- a/adr/0008-inbound-filter-yaml-rules.md
+++ b/adr/0008-inbound-filter-yaml-rules.md
@@ -18,3 +18,10 @@ deferred post-v1.
 - The rule engine stays small and auditable.
 - Inbound filtering is privacy/noise/surface control; it does **not** stop an
   injection from an allowed sender — the outbound trap (ADR 0003) does.
+
+## Amendment (2026-06-25, review)
+**Default action on no match: `allow`** (the agent sees the message). Rationale:
+inbound reading is recoverable and the outbound trap (ADR 0003) is the real
+containment, so hiding is opt-in. The no-match default is **configurable** — an
+operator wanting a stricter posture can set it to `hold-for-human`. The default
+is always explicit in config, never implicit.

--- a/adr/0008-inbound-filter-yaml-rules.md
+++ b/adr/0008-inbound-filter-yaml-rules.md
@@ -1,0 +1,20 @@
+# ADR 0008: Inbound filter — declarative YAML rules
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+On read, Darbaan should hide noise and reduce attack surface, and sometimes ask
+the human whether the agent may see a message at all.
+
+## Decision
+Inbound filtering uses **declarative YAML** rules, matched on fields (from, to,
+subject, label, header), evaluated **top-down, first match wins**. v1 actions:
+**hide | allow | hold-for-human**. `hold-for-human` is the inbound mirror of the
+outbound trap: hold the message and ask the human "expose this to the agent?",
+reusing the approver plumbing (ADR 0004). **Redaction** (altering contents) is
+deferred post-v1.
+
+## Consequences
+- The rule engine stays small and auditable.
+- Inbound filtering is privacy/noise/surface control; it does **not** stop an
+  injection from an allowed sender — the outbound trap (ADR 0003) does.

--- a/adr/0009-pluggable-backends-capability-negotiation.md
+++ b/adr/0009-pluggable-backends-capability-negotiation.md
@@ -1,0 +1,18 @@
+# ADR 0009: Pluggable backends with capability negotiation
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Plain IMAP/SMTP is universal but limited; providers like Gmail expose richer
+features (labels, server-side search) we want to use when available.
+
+## Decision
+Upstream connectivity is a **pluggable backend interface**. v1 ships **two**: a
+**generic IMAP/SMTP** baseline and a **Gmail** provider backend. Backends
+**advertise capabilities**; the rule/feature layer checks capability before use,
+so a Gmail-label rule runs on Gmail and **gracefully degrades** (no-op or
+load-time warning) on the generic backend. Rules degrade, they do not break.
+
+## Consequences
+- New providers (Outlook/Graph, JMAP) are added behind the same interface later.
+- Features are written once against capabilities, not per-provider forks.

--- a/adr/0009-pluggable-backends-capability-negotiation.md
+++ b/adr/0009-pluggable-backends-capability-negotiation.md
@@ -16,3 +16,12 @@ load-time warning) on the generic backend. Rules degrade, they do not break.
 ## Consequences
 - New providers (Outlook/Graph, JMAP) are added behind the same interface later.
 - Features are written once against capabilities, not per-provider forks.
+
+## Amendment (2026-06-25, review)
+**Graceful degradation does not apply to safety rules.** A rule may be marked
+**`safety: true`**. A safety rule must **never** silently degrade: if the active
+backend cannot enforce it (capability missing), Darbaan **fails closed** — it
+refuses to expose the affected messages (or errors at load) rather than no-op.
+Only **non-safety** rules (noise/convenience) degrade to a no-op with a warning.
+A capability gap can never silently switch off a security-relevant filter.
+(Supersedes the unqualified "rules degrade, they do not break" above.)

--- a/adr/0010-multi-mailbox-v1-multi-agent-deferred.md
+++ b/adr/0010-multi-mailbox-v1-multi-agent-deferred.md
@@ -15,3 +15,12 @@ pre-screener (ADR 0005) does not require multi-agent tenancy.
 
 ## Consequences
 - v1 stays simple while leaving room for per-agent isolation later.
+
+## Amendment (2026-06-25, review) — the deferred sketch
+When multi-agent is added: each agent gets its own Darbaan credentials (ADR 0002)
+identifying a principal; a **permission matrix** maps `(agent, account,
+direction)` → allow/deny + which approval chain applies; per-agent credential
+scoping ensures one agent's compromise cannot reach another's mailboxes; an
+approver can itself be an agent principal. **None of this is built in v1.** It is
+recorded so v1 schemas (agent identity on the audit log, per-account policy)
+leave room for it without rework.

--- a/adr/0010-multi-mailbox-v1-multi-agent-deferred.md
+++ b/adr/0010-multi-mailbox-v1-multi-agent-deferred.md
@@ -1,0 +1,17 @@
+# ADR 0010: Multi-mailbox in v1; multi-agent deferred
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Darbaan should front several mailboxes. Supporting several independent agent
+principals is desirable but adds identity/permission machinery.
+
+## Decision
+**v1 is multi-mailbox + single-agent.** Darbaan fronts N upstream accounts, each
+with its own credentials, filter rules, and approval policy. **Multi-agent**
+(per-agent logins + an `agent x account x direction x gate` permission matrix)
+is **deferred post-v1**, sketched so v1 does not foreclose it. The agent
+pre-screener (ADR 0005) does not require multi-agent tenancy.
+
+## Consequences
+- v1 stays simple while leaving room for per-agent isolation later.

--- a/adr/0011-append-only-audit-log.md
+++ b/adr/0011-append-only-audit-log.md
@@ -13,3 +13,9 @@ both the original and any human-edited version of a draft (ADR 0004).
 ## Consequences
 - Full provenance for every send and rejection.
 - The log is a record to protect and, for permanent rejections, to surface (ADR 0006).
+
+## Amendment (2026-06-25, review)
+**Integrity:** the log is **hash-chained** — each entry carries the hash of the
+previous, so tampering or truncation is evident. This is in v1 (cheap, high
+value). **Retention:** configurable; v1 default is keep-all. Rotation/retention
+is an operator setting; any rotation must preserve the chain across segments.

--- a/adr/0011-append-only-audit-log.md
+++ b/adr/0011-append-only-audit-log.md
@@ -1,0 +1,15 @@
+# ADR 0011: Append-only audit log
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+For trust, it must always be visible what was sent and who or what authorized it.
+
+## Decision
+Darbaan keeps an **append-only** audit log keyed by **agent identity**: every
+queued draft, every verdict, who/what approved or rejected, every retry, and
+both the original and any human-edited version of a draft (ADR 0004).
+
+## Consequences
+- Full provenance for every send and rejection.
+- The log is a record to protect and, for permanent rejections, to surface (ADR 0006).

--- a/adr/0012-deployment-and-secrets-at-rest.md
+++ b/adr/0012-deployment-and-secrets-at-rest.md
@@ -1,0 +1,19 @@
+# ADR 0012: Deployment and secrets at rest
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Darbaan holds every mailbox's real credentials and its bounce-signing key. A
+disk image or repo leak must not yield usable secrets. It is not yet hardened to
+face the open internet.
+
+## Decision
+Darbaan runs on a **local trusted host** and is **not** published as an
+internet-ready service in v1. Upstream credentials and the signing key are
+**encrypted at rest** (age/sops or OS keyring); the decryption key is supplied
+**at startup**; secrets live in memory only while running. Nothing secret is
+stored plaintext on disk or in the repo.
+
+## Consequences
+- A stolen disk image or leaked repo yields nothing usable.
+- **Post-v1:** full at-rest encryption of the entire message store, not just secrets.

--- a/adr/0012-deployment-and-secrets-at-rest.md
+++ b/adr/0012-deployment-and-secrets-at-rest.md
@@ -17,3 +17,11 @@ stored plaintext on disk or in the repo.
 ## Consequences
 - A stolen disk image or leaked repo yields nothing usable.
 - **Post-v1:** full at-rest encryption of the entire message store, not just secrets.
+
+## Amendment (2026-06-25, review)
+**Resolving the two open choices.** At-rest encryption uses **age** (portable,
+scriptable, simple file-based identities) rather than an OS keyring — keyring
+support can come later as an option. The **startup decryption key** is delivered
+as an **age identity file** whose path is given via config/env, or an
+interactive passphrase prompt; the key/identity is never written by Darbaan and
+lives in memory only while running.

--- a/adr/0013-go-and-mit.md
+++ b/adr/0013-go-and-mit.md
@@ -1,0 +1,18 @@
+# ADR 0013: Go 1.24+, MIT license
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+We need a language and license for an open-source, embeddable, single-binary
+proxy with compile-time plugin selection (ADR 0004).
+
+## Decision
+**Go 1.24+**, module `github.com/yaad-index/darbaan`. Layout: `cmd/darbaan/`
+(thin CLI), `internal/` (private packages: listeners, sluice/queue, filter,
+approver registry, backends, signer, audit), `pkg/` (public embeddable API),
+`adr/`. Build-tag plugin pattern for compile-time approver/backend selection.
+License: **MIT**.
+
+## Consequences
+- Single static binary, trivial to deploy on the local host.
+- Compile-time plugin selection is idiomatic via build tags.

--- a/adr/0014-prefer-established-libraries.md
+++ b/adr/0014-prefer-established-libraries.md
@@ -1,0 +1,26 @@
+# ADR 0014: Prefer established libraries over reinventing
+
+**Status:** Accepted (2026-06-25)
+
+## Context
+Darbaan touches protocols and cryptography: SMTP and IMAP (server and client
+sides), MIME / `message/rfc822`, DSN bounce generation, DKIM-style signing and
+verification, YAML rules, and secret encryption at rest. Hand-rolling protocol
+or crypto code is error-prone, and bugs there are security bugs.
+
+## Decision
+**Build on well-established, maintained, MIT-compatible external libraries as
+much as possible.** Specifically, do **not** hand-roll protocol or cryptographic
+code — use vetted libraries for IMAP/SMTP, MIME/message parsing, DSN, DKIM
+sign/verify, YAML, and encryption (e.g. age/sops or an OS keyring). Reserve
+in-house code for Darbaan's **own** logic: the sluice, the approver registry and
+pipeline, routing, policy, the audit log. Prefer the standard library where it
+suffices; reach for a vetted third-party library rather than reimplement; but
+avoid trivial micro-dependencies that add supply-chain surface for little gain.
+
+## Consequences
+- Less protocol/crypto risk; faster to a correct v1.
+- Notable dependency choices are themselves decisions and should be recorded.
+- All dependencies must be license-compatible with MIT.
+- We accept some supply-chain surface as the price of protocol/crypto correctness,
+  and keep that surface deliberate rather than incidental.

--- a/adr/README.md
+++ b/adr/README.md
@@ -1,0 +1,25 @@
+# Architecture Decision Records
+
+Darbaan records its significant decisions as ADRs. Each file is one decision:
+its context, the decision, and the consequences. ADRs are immutable once
+Accepted — to change one, add a new ADR that supersedes it.
+
+These initial records (0001–0013) capture the v1 design locked on 2026-06-25.
+
+| ADR | Title |
+|---|---|
+| [0000](0000-record-architecture-decisions.md) | Record architecture decisions |
+| [0001](0001-mail-proxy-not-http-api.md) | A mail proxy over IMAP/SMTP, not an HTTP API |
+| [0002](0002-policy-in-a-separate-box-credential-isolation.md) | Policy in a separate trusted box; credential isolation |
+| [0003](0003-outbound-sluice-trap-default-deny.md) | The outbound sluice trap, fail-closed and default-deny |
+| [0004](0004-pluggable-approval-pipeline.md) | Pluggable, multi-level approval pipeline |
+| [0005](0005-agent-prescreener-plugin-risk-routing.md) | Agent pre-screener as a compile-time plugin; risk routing |
+| [0006](0006-rejection-as-async-dsn-bounce.md) | Rejection modelled as an asynchronous DSN bounce |
+| [0007](0007-signed-bounce-trust.md) | Signed bounces as the trust anchor |
+| [0008](0008-inbound-filter-yaml-rules.md) | Inbound filter: declarative YAML rules |
+| [0009](0009-pluggable-backends-capability-negotiation.md) | Pluggable backends with capability negotiation |
+| [0010](0010-multi-mailbox-v1-multi-agent-deferred.md) | Multi-mailbox in v1; multi-agent deferred |
+| [0011](0011-append-only-audit-log.md) | Append-only audit log |
+| [0012](0012-deployment-and-secrets-at-rest.md) | Deployment and secrets at rest |
+| [0013](0013-go-and-mit.md) | Go 1.24+, MIT license |
+| [0014](0014-prefer-established-libraries.md) | Prefer established libraries over reinventing |


### PR DESCRIPTION
First build step for Darbaan: the v1 design (locked 2026-06-25) split into Architecture Decision Records.

## What's here
15 ADRs under `adr/` (0000 meta + 0001–0014), plus an index README.

- 0000 record architecture decisions
- 0001 mail proxy over IMAP/SMTP, not an HTTP API
- 0002 policy in a separate box; credential isolation
- 0003 outbound sluice trap, fail-closed + default-deny
- 0004 pluggable, multi-level approval pipeline
- 0005 agent pre-screener as a compile-time plugin; risk routing
- 0006 rejection as an async DSN bounce
- 0007 signed-bounce trust
- 0008 inbound filter: declarative YAML rules
- 0009 pluggable backends with capability negotiation
- 0010 multi-mailbox v1; multi-agent deferred
- 0011 append-only audit log
- 0012 deployment + secrets at rest
- 0013 Go 1.24+, MIT
- 0014 prefer established libraries over reinventing

## Roles
admin: yaad-rubigd (this PR) · reviewer: sora-rubigd · coder: forge-rubigd.

@sora-rubigd — review pass please. Next up after merge: Go skeleton (go.mod, cmd/darbaan, internal/, pkg/) and the first batch of issues for @forge-rubigd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)