### PR TITLE
chore: bootstrap Go module skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Build output
+/darbaan
+/dist/
+*.exe
+
+# Go test / coverage artifacts
+*.test
+*.out
+coverage.*
+
+# Local secrets and age identities — never commit (ADR 0012)
+*.age
+*.key
+*.pem
+age-identity*
+.env
+*.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Darbaan
+
+Darbaan is a mail-gate proxy. Agents talk to it over standard IMAP (read) and
+SMTP (send), and it enforces policy mechanically in front of the real mailboxes.
+Outbound mail is trapped in a default-deny sluice and released only after an
+approval pass; inbound mail is filtered by declarative rules. Darbaan holds the
+real mailbox credentials and the bounce-signing key, so a compromised agent only
+ever holds Darbaan credentials — never the upstream mailbox.
+
+This repository is the v1 skeleton; no behavior is wired yet. The design is
+recorded as Architecture Decision Records in [`adr/`](adr/) — start with
+[ADR 0001](adr/0001-mail-proxy-not-http-api.md).
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -1,0 +1,32 @@
+// Command darbaan is the Darbaan mail-gate proxy CLI.
+//
+// This is the thin entry point: it parses flags and loads configuration only.
+// All behavior lives in the library packages under internal/ and pkg/. See the
+// adr/ directory for the design.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// version is the build version, overridden at link time via -ldflags.
+var version = "dev"
+
+func main() {
+	configPath := flag.String("config", "", "path to the configuration file")
+	showVersion := flag.Bool("version", false, "print version and exit")
+	flag.Parse()
+
+	if *showVersion {
+		fmt.Println("darbaan", version)
+		return
+	}
+
+	// Wiring of the listeners, sluice, approver pipeline, backends, and audit
+	// log lands with their respective components. The skeleton has no behavior.
+	_ = configPath
+	fmt.Fprintln(os.Stderr, "darbaan: not yet implemented")
+	os.Exit(1)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/yaad-index/darbaan
+
+go 1.24

--- a/internal/approver/doc.go
+++ b/internal/approver/doc.go
@@ -1,0 +1,6 @@
+// Package approver is the approval registry and pipeline. Approvers implement
+// one contract, (message + metadata) -> verdict, are selectable at compile time
+// and runtime, and chain for multi-level approval where every stage must pass.
+// Timeout is fail-closed: a message with no verdict stays queued, never sends
+// (ADR 0004, 0005).
+package approver

--- a/internal/audit/doc.go
+++ b/internal/audit/doc.go
@@ -1,0 +1,5 @@
+// Package audit is the append-only, hash-chained audit log keyed by agent
+// identity: every queued draft, verdict, approver, retry, and both the original
+// and any human-edited draft. The hash chain makes tampering or truncation
+// evident (ADR 0011).
+package audit

--- a/internal/backend/doc.go
+++ b/internal/backend/doc.go
@@ -1,0 +1,5 @@
+// Package backend is the pluggable upstream-connectivity layer. Backends
+// advertise capabilities so features check support before use; v1 targets a
+// generic IMAP/SMTP baseline and a Gmail provider. Non-safety rules degrade to
+// a no-op on a missing capability, while safety rules fail closed (ADR 0009).
+package backend

--- a/internal/filter/doc.go
+++ b/internal/filter/doc.go
@@ -1,0 +1,6 @@
+// Package filter applies the inbound rules: declarative YAML matched top-down,
+// first match wins, with actions hide | allow | hold-for-human and a
+// configurable no-match default. It controls read-time noise and attack
+// surface; it does not stop an injection from an allowed sender — the outbound
+// sluice does (ADR 0008).
+package filter

--- a/internal/listener/doc.go
+++ b/internal/listener/doc.go
@@ -1,0 +1,5 @@
+// Package listener hosts Darbaan's IMAP (read) and SMTP (submission) faces: the
+// protocol endpoints agents connect to. Agents authenticate here with per-agent
+// Darbaan credentials over TLS and never reach the upstream mailbox directly
+// (ADR 0001, 0002).
+package listener

--- a/internal/policy/doc.go
+++ b/internal/policy/doc.go
@@ -1,0 +1,5 @@
+// Package policy holds Darbaan's permission and routing decisions: the risk
+// router that picks which approval chain a queued message takes (light vs
+// strict, defaulting to strict when no pre-screener is compiled in) and the
+// mechanical policy an agent cannot argue away (ADR 0002, 0005).
+package policy

--- a/internal/signer/doc.go
+++ b/internal/signer/doc.go
@@ -1,0 +1,5 @@
+// Package signer issues and signs Darbaan's bounces so an agent trusts only a
+// rejection Darbaan itself produced. Signing is DKIM over a dedicated selector;
+// Darbaan holds the private signing key and each agent holds only the pinned
+// public key (ADR 0006, 0007).
+package signer

--- a/internal/sluice/doc.go
+++ b/internal/sluice/doc.go
@@ -1,0 +1,6 @@
+// Package sluice is the outbound hold/queue: the trap every submitted message
+// enters. Submission is accepted (250 OK) and enqueued; nothing auto-sends. The
+// default disposition is block (default-deny) and the queue is fail-closed — an
+// unapproved message waits forever and never decays into "send later"
+// (ADR 0003).
+package sluice

--- a/pkg/darbaan/doc.go
+++ b/pkg/darbaan/doc.go
@@ -1,0 +1,5 @@
+// Package darbaan is the public, embeddable API surface for the Darbaan
+// mail-gate proxy: the stable entry point for hosting Darbaan in-process. The
+// implementation lives under internal/ and is not part of this contract. See
+// the adr/ directory for the design.
+package darbaan


### PR DESCRIPTION
Bootstrap the empty Go module skeleton so later components have a home. Stubs only — no behavior.

## What's here
- `go.mod` — module `github.com/yaad-index/darbaan`, Go 1.24.
- `cmd/darbaan/` — thin CLI: `-config` / `-version` flags, no logic.
- `internal/` stub packages, each a `doc.go` stating its responsibility (ADR 0013):
  `listener` (IMAP+SMTP faces), `sluice` (outbound hold/queue), `filter` (inbound rules),
  `approver` (registry + pipeline), `backend` (generic + provider iface), `signer` (bounce
  signing), `audit` (append-only log), `policy` (permission/routing).
- `pkg/darbaan/` — public embeddable API stub (`doc.go`).
- `.gitignore` (Go defaults + build output + local age identities/secrets per ADR 0012), `README` stub.

Each package comment cites the ADR it derives from, so the responsibility split is traceable.

## Verification
- `go build ./...` — green.
- `go vet ./...` — green.
- `gofmt -l .` — clean.

## Out of scope
No behavior, no interfaces beyond the package homes — library selection and contracts come with each component's own issue (ADR 0014). Sluice queue and IMAP/SMTP listeners are the next issues.

closes #2
