### PR TITLE
fix: audit hash must-panic + dedupe itob into seqkey

### DIFF
--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -2,13 +2,14 @@ package audit
 
 import (
 	"crypto/sha256"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
 
 	"go.etcd.io/bbolt"
+
+	"github.com/yaad-index/darbaan/internal/seqkey"
 )
 
 // bucketName is the bbolt bucket holding the hash-chained log.
@@ -68,7 +69,7 @@ func Append(tx *bbolt.Tx, rec Record) (Entry, error) {
 	if err != nil {
 		return Entry{}, err
 	}
-	if err := b.Put(itob(seq), enc); err != nil {
+	if err := b.Put(seqkey.Encode(seq), enc); err != nil {
 		return Entry{}, err
 	}
 	return e, nil
@@ -107,16 +108,17 @@ func computeHash(prevHash string, e Entry) string {
 		Time   time.Time `json:"time"`
 		Record Record    `json:"record"`
 	}{e.Seq, e.Time, e.Record}
-	pj, _ := json.Marshal(payload)
+	pj, err := json.Marshal(payload)
+	if err != nil {
+		// payload is a fixed struct of marshalable types, so this cannot fail
+		// in practice. But a security hash must never silently fall back to
+		// hashing an empty payload: that would yield a wrong-but-internally-
+		// consistent chain that still passes Verify. Fail loud instead.
+		panic(fmt.Sprintf("audit: marshal hash payload: %v", err))
+	}
 
 	h := sha256.New()
 	h.Write([]byte(prevHash))
 	h.Write(pj)
 	return hex.EncodeToString(h.Sum(nil))
-}
-
-func itob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
 }

--- a/internal/seqkey/seqkey.go
+++ b/internal/seqkey/seqkey.go
@@ -1,0 +1,14 @@
+// Package seqkey encodes uint64 sequence numbers as fixed-width, big-endian
+// keys, so a bbolt cursor iterates records in sequence (i.e. receive) order.
+// Shared by the audit log and the sluice, which both key buckets by sequence.
+package seqkey
+
+import "encoding/binary"
+
+// Encode returns the 8-byte big-endian encoding of seq, suitable as an ordered
+// bbolt key.
+func Encode(seq uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, seq)
+	return b
+}

--- a/internal/seqkey/seqkey_test.go
+++ b/internal/seqkey/seqkey_test.go
@@ -1,0 +1,24 @@
+package seqkey_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/seqkey"
+)
+
+func TestEncodeFixedWidthBigEndian(t *testing.T) {
+	assert.Equal(t, []byte{0, 0, 0, 0, 0, 0, 0, 1}, seqkey.Encode(1))
+	assert.Len(t, seqkey.Encode(0), 8)
+}
+
+func TestEncodeOrdersBySequence(t *testing.T) {
+	// Lexicographic byte order must match numeric order, including across the
+	// 8-bit boundary, so a bbolt cursor yields records in sequence order.
+	for _, p := range [][2]uint64{{1, 2}, {255, 256}, {999, 1000}} {
+		assert.Negative(t, bytes.Compare(seqkey.Encode(p[0]), seqkey.Encode(p[1])),
+			"Encode(%d) should sort before Encode(%d)", p[0], p[1])
+	}
+}

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -1,7 +1,6 @@
 package sluice
 
 import (
-	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +10,7 @@ import (
 	"go.etcd.io/bbolt"
 
 	"github.com/yaad-index/darbaan/internal/audit"
+	"github.com/yaad-index/darbaan/internal/seqkey"
 )
 
 // bucketMessages holds the pending outbound messages, keyed by big-endian
@@ -108,7 +108,7 @@ func (s *Sluice) Enqueue(sub Submission) (Message, error) {
 		if err != nil {
 			return err
 		}
-		if err := b.Put(itob(seq), enc); err != nil {
+		if err := b.Put(seqkey.Encode(seq), enc); err != nil {
 			return err
 		}
 		_, err = audit.Append(tx, audit.Record{
@@ -159,7 +159,7 @@ func (s *Sluice) Get(id string) (Message, error) {
 	}
 	var msg Message
 	err = s.db.View(func(tx *bbolt.Tx) error {
-		v := tx.Bucket(bucketMessages).Get(itob(seq))
+		v := tx.Bucket(bucketMessages).Get(seqkey.Encode(seq))
 		if v == nil {
 			return ErrNotFound
 		}
@@ -176,10 +176,4 @@ func (s *Sluice) VerifyAudit() error {
 	return s.db.View(func(tx *bbolt.Tx) error {
 		return audit.Verify(tx)
 	})
-}
-
-func itob(v uint64) []byte {
-	b := make([]byte, 8)
-	binary.BigEndian.PutUint64(b, v)
-	return b
 }


### PR DESCRIPTION
The two review nits from #7.

## Changes
1. **`computeHash` fails loud** (`internal/audit`) — panics on a `json.Marshal` error instead of discarding it. The inputs are controlled today so it's latent, but in security hash code a silent discard would hash an empty payload into a wrong-but-internally-consistent chain that still passes `Verify`. The panic carries the error and an inline note on the failure mode.
2. **`itob` deduped** — the 8-byte big-endian uint64 key encoder is extracted from `internal/audit` and `internal/sluice` into a new `internal/seqkey` package (`seqkey.Encode`). Both encode their bbolt keys through it now, so the next package that needs ordered sequence keys has a home — no third copy.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `go test -race ./...` — green (added `seqkey` ordering/width tests).
- `golangci-lint run` (v2.11.4) — 0 issues.

closes #8
