### PR TITLE
feat: approval pipeline (approver, registry, router, manual approver)

### DIFF
--- a/cmd/darbaan/approvers.go
+++ b/cmd/darbaan/approvers.go
@@ -1,0 +1,9 @@
+//go:build !no_manual_approver
+
+package main
+
+// Compile in the manual (human) approver by registering it via blank import
+// (ADR 0004). Build with -tags no_manual_approver to exclude it; with no
+// approver compiled in, the approval chain fails closed and nothing can be
+// approved.
+import _ "github.com/yaad-index/darbaan/internal/approver/manual"

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -2,15 +2,18 @@
 //
 // Subcommands:
 //
-//	darbaan serve            run the SMTP submission face + sluice
-//	darbaan queue ls         list held (pending) outbound messages
-//	darbaan queue show <id>  dump a held message's raw RFC 822
-//	darbaan version          print version
+//	darbaan serve                       run the SMTP submission face + sluice
+//	darbaan queue ls                    list held outbound messages
+//	darbaan queue show <id>             dump a held message's raw RFC 822
+//	darbaan queue approve <id>          approve a held message (runs the chain)
+//	darbaan queue reject -reason "" <id>  reject a held message
+//	darbaan version                     print version
 //
 // See the adr/ directory for the design.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"flag"
@@ -22,7 +25,10 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/yaad-index/darbaan/internal/approver"
+	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/listener"
+	"github.com/yaad-index/darbaan/internal/policy"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -55,8 +61,10 @@ func main() {
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage: darbaan <serve|queue|version> [flags]")
 	fmt.Fprintln(os.Stderr, "  serve            run the SMTP submission face + sluice")
-	fmt.Fprintln(os.Stderr, "  queue ls         list held (pending) outbound messages")
+	fmt.Fprintln(os.Stderr, "  queue ls         list held outbound messages")
 	fmt.Fprintln(os.Stderr, "  queue show <id>  dump a held message's raw RFC 822")
+	fmt.Fprintln(os.Stderr, "  queue approve <id>            approve a held message")
+	fmt.Fprintln(os.Stderr, "  queue reject -reason \"\" <id>   reject a held message")
 	fmt.Fprintln(os.Stderr, "  version          print version")
 }
 
@@ -123,15 +131,24 @@ func runServe(args []string) error {
 }
 
 func runQueue(args []string) error {
-	fs := flag.NewFlagSet("queue", flag.ExitOnError)
+	if len(args) == 0 {
+		return errors.New("usage: darbaan queue <ls|show|approve|reject> [flags] [id]")
+	}
+	sub := args[0]
+
+	// Flags precede the positional id, e.g. `queue reject -reason "no" <id>`.
+	fs := flag.NewFlagSet("queue "+sub, flag.ExitOnError)
 	dbPath := fs.String("db", "darbaan.db", "path to the sluice database file")
-	if err := fs.Parse(args); err != nil {
+	var reason string
+	var retryable bool
+	if sub == "reject" {
+		fs.StringVar(&reason, "reason", "", "rejection reason (required)")
+		fs.BoolVar(&retryable, "retryable", false, "mark the rejection transient (revise & resubmit) rather than permanent")
+	}
+	if err := fs.Parse(args[1:]); err != nil {
 		return err
 	}
-	rest := fs.Args()
-	if len(rest) == 0 {
-		return errors.New("usage: darbaan queue <ls|show <id>> [-db path]")
-	}
+	id := fs.Arg(0)
 
 	q, err := sluice.Open(*dbPath)
 	if err != nil {
@@ -139,16 +156,125 @@ func runQueue(args []string) error {
 	}
 	defer func() { _ = q.Close() }()
 
-	switch rest[0] {
+	switch sub {
 	case "ls":
 		return queueList(q)
 	case "show":
-		if len(rest) < 2 {
+		if id == "" {
 			return errors.New("usage: darbaan queue show <id>")
 		}
-		return queueShow(q, rest[1])
+		return queueShow(q, id)
+	case "approve":
+		if id == "" {
+			return errors.New("usage: darbaan queue approve <id>")
+		}
+		return runApprove(q, id)
+	case "reject":
+		if id == "" || reason == "" {
+			return errors.New(`usage: darbaan queue reject -reason "..." <id>`)
+		}
+		return runReject(q, id, reason, retryable)
 	default:
-		return fmt.Errorf("unknown queue subcommand %q", rest[0])
+		return fmt.Errorf("unknown queue subcommand %q", sub)
+	}
+}
+
+// defaultStrictChain and defaultLightChain are the v1 approval chains. Both
+// resolve to the manual approver until a pre-screener and more approvers land;
+// these become operator-configurable later. If a named approver is not compiled
+// in, the chain fails closed (nothing can be approved).
+var (
+	defaultStrictChain = []string{"manual"}
+	defaultLightChain  = []string{"manual"}
+)
+
+func runApprove(q *sluice.Sluice, id string) error {
+	m, err := decideAndApply(context.Background(), q, backend.StubSender{},
+		policy.NewRouter(defaultStrictChain, defaultLightChain),
+		id, approver.Verdict{Disposition: approver.Approve})
+	if err != nil {
+		return err
+	}
+	switch m.Status {
+	case sluice.StatusApproved:
+		fmt.Printf("message %s approved by %s\n", m.ID, m.DecidedBy)
+		if m.SendErr != "" {
+			fmt.Printf("  send: %s — nothing left Darbaan\n", m.SendErr)
+		}
+	default:
+		fmt.Printf("message %s: still %s, no verdict applied\n", m.ID, m.Status)
+	}
+	return nil
+}
+
+func runReject(q *sluice.Sluice, id, reason string, retryable bool) error {
+	m, err := decideAndApply(context.Background(), q, backend.StubSender{},
+		policy.NewRouter(defaultStrictChain, defaultLightChain),
+		id, approver.Verdict{Disposition: approver.Reject, Reason: reason, Retryable: retryable})
+	if err != nil {
+		return err
+	}
+	switch m.Status {
+	case sluice.StatusRejected:
+		kind := "permanent"
+		if m.Retryable {
+			kind = "transient"
+		}
+		fmt.Printf("message %s rejected by %s (%s): %s\n", m.ID, m.DecidedBy, kind, m.Reason)
+	default:
+		fmt.Printf("message %s: still %s, no verdict applied\n", m.ID, m.Status)
+	}
+	return nil
+}
+
+// decideAndApply runs the approval chain for one message and applies the
+// outcome. The human verdict is injected into the human stage of the chain — it
+// is one stage, never an override of the others (ADR 0004). On approval the
+// message is marked approved and handed to the (stubbed) Sender; the send result
+// is recorded and audited, never silently dropped (ADR 0003). On rejection the
+// reason is recorded. A Hold leaves the message pending.
+func decideAndApply(ctx context.Context, q *sluice.Sluice, sender backend.Sender, router *policy.Router, id string, human approver.Verdict) (sluice.Message, error) {
+	msg, err := q.Get(id)
+	if err != nil {
+		return sluice.Message{}, err
+	}
+	if msg.Status != sluice.StatusPending {
+		return sluice.Message{}, fmt.Errorf("message %s is %s, not pending", id, msg.Status)
+	}
+
+	// No pre-screener exists, so the router runs with no risk signal and
+	// returns the strict chain (the ADR 0005 fail-safe).
+	_, names := router.Select(nil)
+	stages := make([]approver.Approver, 0, len(names))
+	for _, name := range names {
+		a, err := approver.New(name)
+		if err != nil {
+			return sluice.Message{}, err
+		}
+		if h, ok := a.(approver.HumanApprover); ok {
+			h.SetVerdict(human)
+		}
+		stages = append(stages, a)
+	}
+
+	outcome, err := approver.Run(ctx, msg, stages)
+	if err != nil {
+		return sluice.Message{}, err
+	}
+
+	switch outcome.Disposition {
+	case approver.Approve:
+		if _, err := q.Approve(id, outcome.DecidedBy, outcome.Released); err != nil {
+			return sluice.Message{}, err
+		}
+		// Attempt the (stubbed) upstream send; record the result either way.
+		approved, _ := q.Get(id)
+		sendErr := sender.Send(ctx, approved)
+		return q.RecordSendAttempt(id, sendErr)
+	case approver.Reject:
+		return q.Reject(id, outcome.DecidedBy, outcome.Reason, outcome.Retryable)
+	default: // Hold — stays pending, fail-closed
+		return msg, nil
 	}
 }
 

--- a/cmd/darbaan/main_test.go
+++ b/cmd/darbaan/main_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/approver"
+	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/policy"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// The manual approver is compiled in via approvers.go (default build), so the
+// strict chain resolves and these tests exercise the real wiring.
+
+func newSeededSluice(t *testing.T) (*sluice.Sluice, string) {
+	t.Helper()
+	q, err := sluice.Open(filepath.Join(t.TempDir(), "sluice.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", From: "a@local", Rcpt: []string{"b@x.test"}, Raw: []byte("orig")})
+	require.NoError(t, err)
+	return q, m.ID
+}
+
+func router() *policy.Router {
+	return policy.NewRouter(defaultStrictChain, defaultLightChain)
+}
+
+func TestApproveReachesStubSenderAndNothingLeaves(t *testing.T) {
+	q, id := newSeededSluice(t)
+
+	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Approve})
+	require.NoError(t, err)
+
+	assert.Equal(t, sluice.StatusApproved, out.Status)
+	assert.Equal(t, "manual", out.DecidedBy)
+	// The stub Sender ran but nothing left: the send error is recorded, not dropped.
+	assert.Equal(t, backend.ErrSendPending.Error(), out.SendErr)
+	require.NoError(t, q.VerifyAudit())
+}
+
+func TestRejectRecordsReason(t *testing.T) {
+	q, id := newSeededSluice(t)
+
+	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Reject, Reason: "smells like exfiltration", Retryable: false})
+	require.NoError(t, err)
+
+	assert.Equal(t, sluice.StatusRejected, out.Status)
+	assert.Equal(t, "smells like exfiltration", out.Reason)
+	require.NoError(t, q.VerifyAudit())
+}
+
+func TestNoDecisionLeavesPending(t *testing.T) {
+	q, id := newSeededSluice(t)
+
+	// A Hold verdict (the human took no action) must leave the message pending —
+	// fail-closed.
+	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Hold})
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusPending, out.Status)
+
+	got, err := q.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusPending, got.Status)
+}
+
+func TestApproveTwiceIsRefused(t *testing.T) {
+	q, id := newSeededSluice(t)
+
+	_, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Approve})
+	require.NoError(t, err)
+
+	_, err = decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Approve})
+	require.Error(t, err) // already approved, not pending
+}

--- a/internal/approver/approver.go
+++ b/internal/approver/approver.go
@@ -1,0 +1,130 @@
+// Package approver decides a held message's fate (ADR 0004, 0005). It defines
+// the Approver contract, a registry for compile-time selection (blank-import +
+// build-tag pattern), and the fail-closed chain runner. It contains no I/O:
+// applying an outcome to the sluice and attempting the send live in the caller.
+package approver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// Disposition is the kind of decision an approver returns. The zero value is
+// Hold ("no decision"), so an unset or absent verdict keeps a message pending —
+// fail-closed by construction (ADR 0003).
+type Disposition int
+
+const (
+	Hold Disposition = iota // no decision — message stays pending
+	Approve
+	Reject
+)
+
+func (d Disposition) String() string {
+	switch d {
+	case Approve:
+		return "approve"
+	case Reject:
+		return "reject"
+	default:
+		return "hold"
+	}
+}
+
+// Verdict is one approver's decision about a message.
+type Verdict struct {
+	Disposition Disposition
+	Reason      string // required for Reject; the rejection reason (never echoes attacker text, ADR 0006)
+	Retryable   bool   // Reject only: transient (revise+resubmit) vs permanent (drop)
+	// Amended, when non-nil on an Approve, is an edited body an edit-capable
+	// (human) approver chose to release instead of the original (ADR 0004).
+	// Agent approvers never set this.
+	Amended []byte
+}
+
+// Approver decides a pending message's fate. Implementations register for
+// compile-time selection via build tags.
+type Approver interface {
+	// Name identifies the approver in config and the audit trail.
+	Name() string
+	// CanEdit reports whether this approver may return an amended body. Editing
+	// is human-only; agent approvers return false (ADR 0004).
+	CanEdit() bool
+	// Decide returns a Verdict for msg. The zero Verdict (Hold) means "no
+	// decision" and leaves the message pending.
+	Decide(ctx context.Context, msg sluice.Message) (Verdict, error)
+}
+
+// HumanApprover is an Approver whose verdict is supplied externally (a person
+// acting through a surface such as the CLI) rather than computed from the
+// message. The caller sets the verdict before running the chain. This keeps the
+// human a single stage in the chain — never an override of other stages.
+type HumanApprover interface {
+	Approver
+	SetVerdict(Verdict)
+}
+
+// Outcome is the result of running an approval chain over a message.
+type Outcome struct {
+	Disposition Disposition
+	Reason      string
+	Retryable   bool
+	Released    []byte // body to release on Approve: the original, or an edited version
+	DecidedBy   string // the approver that produced the terminal disposition
+}
+
+// Run evaluates the stages in order and enforces "every stage must pass"
+// (ADR 0004): the message is approved only if every stage approves. The first
+// stage to Reject rejects the message; any Hold or approver error leaves it
+// pending — fail-closed (ADR 0003). A human Approve does not override an earlier
+// stage's Reject, because the first non-approve disposition wins. An
+// edit-capable stage may amend the body that later stages see and that is
+// ultimately released.
+//
+// Run makes no decision of its own when the chain is empty: no configured
+// approval path means nothing can ever pass, so it Holds.
+func Run(ctx context.Context, msg sluice.Message, stages []Approver) (Outcome, error) {
+	if len(stages) == 0 {
+		return Outcome{Disposition: Hold}, nil
+	}
+
+	released := msg.Raw
+	working := msg
+	for _, st := range stages {
+		v, err := st.Decide(ctx, working)
+		if err != nil {
+			// Fail-closed: an approver error never approves.
+			return Outcome{Disposition: Hold, DecidedBy: st.Name()},
+				fmt.Errorf("approver %q: %w", st.Name(), err)
+		}
+		switch v.Disposition {
+		case Reject:
+			return Outcome{
+				Disposition: Reject,
+				Reason:      v.Reason,
+				Retryable:   v.Retryable,
+				DecidedBy:   st.Name(),
+			}, nil
+		case Hold:
+			return Outcome{Disposition: Hold, DecidedBy: st.Name()}, nil
+		case Approve:
+			if v.Amended != nil {
+				if !st.CanEdit() {
+					return Outcome{}, fmt.Errorf("approver %q returned an edit but is not edit-capable", st.Name())
+				}
+				released = v.Amended
+				working.Raw = v.Amended
+			}
+		default:
+			return Outcome{}, fmt.Errorf("approver %q returned unknown disposition %d", st.Name(), v.Disposition)
+		}
+	}
+
+	return Outcome{
+		Disposition: Approve,
+		Released:    released,
+		DecidedBy:   stages[len(stages)-1].Name(),
+	}, nil
+}

--- a/internal/approver/manual/manual.go
+++ b/internal/approver/manual/manual.go
@@ -1,0 +1,44 @@
+// Package manual is the v1 human approver: a person decides through a surface
+// (the CLI) and the verdict is injected before the chain runs. Web and chat
+// approvers come later behind the same Approver contract. Blank-import this
+// package to compile it in (ADR 0004).
+package manual
+
+import (
+	"context"
+
+	"github.com/yaad-index/darbaan/internal/approver"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// Name is the registry key for the manual approver.
+const Name = "manual"
+
+func init() {
+	approver.Register(Name, func() approver.Approver { return &Manual{} })
+}
+
+// Manual is a human approver. Its verdict is set externally (SetVerdict) by the
+// surface the human acted through; Decide just returns it. The zero value
+// returns Hold, so a constructed-but-unset manual approver keeps the message
+// pending — fail-closed.
+type Manual struct {
+	verdict approver.Verdict
+}
+
+// New returns a Manual carrying v, for callers that construct it directly.
+func New(v approver.Verdict) *Manual { return &Manual{verdict: v} }
+
+// SetVerdict supplies the human's decision before the chain runs.
+func (m *Manual) SetVerdict(v approver.Verdict) { m.verdict = v }
+
+// Name identifies the approver.
+func (m *Manual) Name() string { return Name }
+
+// CanEdit is true: a human may edit a draft before releasing it (ADR 0004).
+func (m *Manual) CanEdit() bool { return true }
+
+// Decide returns the human's verdict, independent of the message contents.
+func (m *Manual) Decide(_ context.Context, _ sluice.Message) (approver.Verdict, error) {
+	return m.verdict, nil
+}

--- a/internal/approver/manual/manual_test.go
+++ b/internal/approver/manual/manual_test.go
@@ -1,0 +1,37 @@
+package manual_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/approver"
+	"github.com/yaad-index/darbaan/internal/approver/manual"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+func TestManualRegistersAndDefaultsHold(t *testing.T) {
+	a, err := approver.New(manual.Name)
+	require.NoError(t, err)
+	assert.True(t, a.CanEdit())
+
+	// A constructed-but-unset manual approver returns Hold — fail-closed.
+	v, err := a.Decide(context.Background(), sluice.Message{})
+	require.NoError(t, err)
+	assert.Equal(t, approver.Hold, v.Disposition)
+}
+
+func TestManualReturnsSetVerdict(t *testing.T) {
+	m := manual.New(approver.Verdict{Disposition: approver.Approve})
+	v, err := m.Decide(context.Background(), sluice.Message{})
+	require.NoError(t, err)
+	assert.Equal(t, approver.Approve, v.Disposition)
+
+	m.SetVerdict(approver.Verdict{Disposition: approver.Reject, Reason: "no"})
+	v, err = m.Decide(context.Background(), sluice.Message{})
+	require.NoError(t, err)
+	assert.Equal(t, approver.Reject, v.Disposition)
+	assert.Equal(t, "no", v.Reason)
+}

--- a/internal/approver/pipeline_test.go
+++ b/internal/approver/pipeline_test.go
@@ -1,0 +1,97 @@
+package approver_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/approver"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+type fakeApprover struct {
+	name    string
+	canEdit bool
+	verdict approver.Verdict
+	err     error
+}
+
+func (f fakeApprover) Name() string  { return f.name }
+func (f fakeApprover) CanEdit() bool { return f.canEdit }
+func (f fakeApprover) Decide(context.Context, sluice.Message) (approver.Verdict, error) {
+	return f.verdict, f.err
+}
+
+func approve(name string) fakeApprover {
+	return fakeApprover{name: name, verdict: approver.Verdict{Disposition: approver.Approve}}
+}
+
+var msg = sluice.Message{ID: "1", Raw: []byte("orig")}
+
+func TestRunAllApprove(t *testing.T) {
+	out, err := approver.Run(context.Background(), msg, []approver.Approver{approve("a"), approve("b")})
+	require.NoError(t, err)
+	assert.Equal(t, approver.Approve, out.Disposition)
+	assert.Equal(t, []byte("orig"), out.Released)
+	assert.Equal(t, "b", out.DecidedBy)
+}
+
+func TestRunRejectWinsOverLaterApprove(t *testing.T) {
+	// An earlier Reject is the terminal verdict; a later (human) Approve does
+	// not override it — every stage must pass (ADR 0004).
+	stages := []approver.Approver{
+		fakeApprover{name: "screen", verdict: approver.Verdict{Disposition: approver.Reject, Reason: "blocked", Retryable: false}},
+		approve("human"),
+	}
+	out, err := approver.Run(context.Background(), msg, stages)
+	require.NoError(t, err)
+	assert.Equal(t, approver.Reject, out.Disposition)
+	assert.Equal(t, "blocked", out.Reason)
+	assert.Equal(t, "screen", out.DecidedBy)
+}
+
+func TestRunHoldStaysPending(t *testing.T) {
+	// The zero Verdict is Hold ("no decision"), so a stage that returns it keeps
+	// the message pending even though an earlier stage approved.
+	out, err := approver.Run(context.Background(), msg, []approver.Approver{approve("a"), fakeApprover{name: "h"}})
+	require.NoError(t, err)
+	assert.Equal(t, approver.Hold, out.Disposition)
+}
+
+func TestRunEmptyChainHolds(t *testing.T) {
+	out, err := approver.Run(context.Background(), msg, nil)
+	require.NoError(t, err)
+	assert.Equal(t, approver.Hold, out.Disposition)
+}
+
+func TestRunApproverErrorFailsClosed(t *testing.T) {
+	stages := []approver.Approver{fakeApprover{name: "boom", err: errors.New("backend down")}}
+	out, err := approver.Run(context.Background(), msg, stages)
+	require.Error(t, err)
+	assert.Equal(t, approver.Hold, out.Disposition)
+}
+
+func TestRunEditCapableAmendsReleasedBody(t *testing.T) {
+	editor := fakeApprover{
+		name:    "human",
+		canEdit: true,
+		verdict: approver.Verdict{Disposition: approver.Approve, Amended: []byte("edited")},
+	}
+	out, err := approver.Run(context.Background(), msg, []approver.Approver{editor})
+	require.NoError(t, err)
+	assert.Equal(t, approver.Approve, out.Disposition)
+	assert.Equal(t, []byte("edited"), out.Released)
+}
+
+func TestRunEditFromNonEditCapableIsError(t *testing.T) {
+	bad := fakeApprover{
+		name:    "agent",
+		canEdit: false,
+		verdict: approver.Verdict{Disposition: approver.Approve, Amended: []byte("sneaky")},
+	}
+	_, err := approver.Run(context.Background(), msg, []approver.Approver{bad})
+	require.Error(t, err)
+}

--- a/internal/approver/registry.go
+++ b/internal/approver/registry.go
@@ -1,0 +1,40 @@
+package approver
+
+import (
+	"fmt"
+	"sort"
+)
+
+// registry holds approver constructors keyed by name. Approvers add themselves
+// from init() in build-tag-guarded packages, blank-imported by the binary, so a
+// build ships only the approvers it wants compiled in (ADR 0004).
+var registry = map[string]func() Approver{}
+
+// Register adds a named approver constructor. It panics on a duplicate name,
+// since that is a build-wiring error, not a runtime condition.
+func Register(name string, ctor func() Approver) {
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("approver: duplicate registration %q", name))
+	}
+	registry[name] = ctor
+}
+
+// New constructs a fresh instance of the named approver, or an error if no such
+// approver is compiled in.
+func New(name string) (Approver, error) {
+	ctor, ok := registry[name]
+	if !ok {
+		return nil, fmt.Errorf("approver %q is not compiled in", name)
+	}
+	return ctor(), nil
+}
+
+// Registered returns the names of all compiled-in approvers, sorted.
+func Registered() []string {
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/approver/registry_test.go
+++ b/internal/approver/registry_test.go
@@ -1,0 +1,31 @@
+package approver_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/approver"
+)
+
+func TestRegistryNewAndList(t *testing.T) {
+	approver.Register("test-reg", func() approver.Approver { return approve("test-reg") })
+
+	a, err := approver.New("test-reg")
+	require.NoError(t, err)
+	assert.Equal(t, "test-reg", a.Name())
+	assert.Contains(t, approver.Registered(), "test-reg")
+}
+
+func TestRegistryUnknownErrors(t *testing.T) {
+	_, err := approver.New("nope-not-compiled-in")
+	require.Error(t, err)
+}
+
+func TestRegistryDuplicatePanics(t *testing.T) {
+	approver.Register("test-dup", func() approver.Approver { return approve("test-dup") })
+	assert.Panics(t, func() {
+		approver.Register("test-dup", func() approver.Approver { return approve("test-dup") })
+	})
+}

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -20,6 +20,7 @@ type Record struct {
 	Event     string `json:"event"`
 	Agent     string `json:"agent"`
 	MessageID string `json:"message_id"`
+	Detail    string `json:"detail,omitempty"` // e.g. reject reason, send-attempt result
 }
 
 // Entry is a persisted, hash-chained audit log entry. Hash binds PrevHash and

--- a/internal/backend/sender.go
+++ b/internal/backend/sender.go
@@ -1,0 +1,28 @@
+package backend
+
+import (
+	"context"
+	"errors"
+
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// Sender releases an approved message to the real upstream. It is the only
+// component that can cause mail to leave Darbaan, which is why it is a distinct
+// seam: until a real Sender is wired (a later issue), default-deny is structural
+// — an approved message reaches this seam and goes no further (ADR 0003).
+type Sender interface {
+	Send(ctx context.Context, msg sluice.Message) error
+}
+
+// ErrSendPending is returned by the stub Sender: approval reaches the send seam,
+// but no upstream backend exists yet, so nothing is delivered.
+var ErrSendPending = errors.New("upstream send pending")
+
+// StubSender is the v1 placeholder Sender. It always returns ErrSendPending, so
+// nothing is ever actually sent. The approval still records and audits the
+// attempt; the message is never quietly dropped.
+type StubSender struct{}
+
+// Send always fails with ErrSendPending.
+func (StubSender) Send(context.Context, sluice.Message) error { return ErrSendPending }

--- a/internal/backend/sender_test.go
+++ b/internal/backend/sender_test.go
@@ -1,0 +1,16 @@
+package backend_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+func TestStubSenderNeverSends(t *testing.T) {
+	err := backend.StubSender{}.Send(context.Background(), sluice.Message{ID: "1"})
+	assert.ErrorIs(t, err, backend.ErrSendPending)
+}

--- a/internal/policy/router.go
+++ b/internal/policy/router.go
@@ -1,0 +1,49 @@
+package policy
+
+// Chain names an approval path. The router selects one from a risk verdict; the
+// chain then resolves to an ordered list of approver names (ADR 0005).
+type Chain string
+
+const (
+	// StrictChain is the cautious path (medium/high risk, or any flag, or no
+	// risk signal at all).
+	StrictChain Chain = "strict"
+	// LightChain is the low-friction path (low risk, no flags).
+	LightChain Chain = "light"
+)
+
+// Risk is the coarse pre-screener verdict that selects a chain (ADR 0005). v1
+// has no pre-screener, so the router is always called with a nil Risk.
+type Risk struct {
+	Level string   // "low" | "medium" | "high"
+	Flags []string // e.g. touches-secret, new-recipient, external-domain, has-attachment
+}
+
+// Router maps a risk verdict to an approval chain and resolves the chain to its
+// approver names. The name lists are configured; v1 wires both chains to the
+// single manual approver.
+type Router struct {
+	strict []string
+	light  []string
+}
+
+// NewRouter builds a router with the approver-name lists for each chain.
+func NewRouter(strict, light []string) *Router {
+	return &Router{strict: strict, light: light}
+}
+
+// Select returns the chain for the given risk and its ordered approver names.
+//
+// A nil risk means no pre-screener is compiled in. Absence of a risk signal is
+// treated as "could be risky," never as low: the router returns the strict
+// chain (the fail-safe of ADR 0005). A non-nil low risk with no flags takes the
+// light chain; anything else takes strict.
+func (r *Router) Select(risk *Risk) (Chain, []string) {
+	if risk == nil {
+		return StrictChain, r.strict
+	}
+	if risk.Level == "low" && len(risk.Flags) == 0 {
+		return LightChain, r.light
+	}
+	return StrictChain, r.strict
+}

--- a/internal/policy/router_test.go
+++ b/internal/policy/router_test.go
@@ -1,0 +1,37 @@
+package policy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/policy"
+)
+
+func TestRouterNilRiskIsStrict(t *testing.T) {
+	r := policy.NewRouter([]string{"manual"}, []string{"light-only"})
+	chain, names := r.Select(nil)
+	assert.Equal(t, policy.StrictChain, chain)
+	assert.Equal(t, []string{"manual"}, names)
+}
+
+func TestRouterLowNoFlagsIsLight(t *testing.T) {
+	r := policy.NewRouter([]string{"manual"}, []string{"light-only"})
+	chain, names := r.Select(&policy.Risk{Level: "low"})
+	assert.Equal(t, policy.LightChain, chain)
+	assert.Equal(t, []string{"light-only"}, names)
+}
+
+func TestRouterLowWithFlagIsStrict(t *testing.T) {
+	r := policy.NewRouter([]string{"manual"}, []string{"light-only"})
+	chain, _ := r.Select(&policy.Risk{Level: "low", Flags: []string{"touches-secret"}})
+	assert.Equal(t, policy.StrictChain, chain)
+}
+
+func TestRouterElevatedRiskIsStrict(t *testing.T) {
+	r := policy.NewRouter([]string{"manual"}, []string{"light-only"})
+	for _, lvl := range []string{"medium", "high"} {
+		chain, _ := r.Select(&policy.Risk{Level: lvl})
+		assert.Equal(t, policy.StrictChain, chain, "level %s", lvl)
+	}
+}

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -1,6 +1,7 @@
 package sluice
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,12 +21,22 @@ var bucketMessages = []byte("messages")
 // ErrNotFound is returned by Get when no message has the given id.
 var ErrNotFound = errors.New("sluice: message not found")
 
-// Status is the disposition of a queued message. v1 only ever holds Pending:
-// the sluice is default-deny and nothing is released without an approval pass
-// (ADR 0003), which lands in a later component.
+// ErrNotPending is returned when a verdict is applied to a message that is no
+// longer pending (already approved or rejected) — fail-closed against double
+// decisions.
+var ErrNotPending = errors.New("sluice: message is not pending")
+
+// Status is the disposition of a queued message. New messages are Pending;
+// the approval pipeline transitions them to Approved or Rejected. Default-deny
+// means nothing leaves on Approved either until a real Sender is wired
+// (ADR 0003) — Approved records the verdict, it does not imply "sent".
 type Status string
 
-const StatusPending Status = "pending"
+const (
+	StatusPending  Status = "pending"
+	StatusApproved Status = "approved"
+	StatusRejected Status = "rejected"
+)
 
 // Submission is a new outbound message to trap, as captured from the SMTP face.
 type Submission struct {
@@ -44,6 +55,13 @@ type Message struct {
 	Raw        []byte    `json:"raw"`
 	ReceivedAt time.Time `json:"received_at"`
 	Status     Status    `json:"status"`
+
+	// Set on a terminal transition (approved/rejected):
+	DecidedBy string `json:"decided_by,omitempty"` // approver that decided
+	Reason    string `json:"reason,omitempty"`     // rejection reason
+	Retryable bool   `json:"retryable,omitempty"`  // rejection: transient vs permanent
+	Released  []byte `json:"released,omitempty"`   // edited body approved instead of Raw (ADR 0004); nil = original
+	SendErr   string `json:"send_err,omitempty"`   // result of the last send attempt (e.g. "upstream send pending")
 }
 
 // Meta is the listing view of a queued message: everything but the raw body.
@@ -153,17 +171,11 @@ func (s *Sluice) List() ([]Meta, error) {
 
 // Get returns the full message (including the raw body) for id, or ErrNotFound.
 func (s *Sluice) Get(id string) (Message, error) {
-	seq, err := strconv.ParseUint(id, 10, 64)
-	if err != nil {
-		return Message{}, fmt.Errorf("%w: invalid id %q", ErrNotFound, id)
-	}
 	var msg Message
-	err = s.db.View(func(tx *bbolt.Tx) error {
-		v := tx.Bucket(bucketMessages).Get(seqkey.Encode(seq))
-		if v == nil {
-			return ErrNotFound
-		}
-		return json.Unmarshal(v, &msg)
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		var e error
+		msg, _, e = loadMessage(tx, id)
+		return e
 	})
 	if err != nil {
 		return Message{}, err
@@ -171,9 +183,125 @@ func (s *Sluice) Get(id string) (Message, error) {
 	return msg, nil
 }
 
+// Approve marks a pending message approved, recording the deciding approver and
+// (when edited) the released body, plus a hash-chained audit entry — all in one
+// transaction. It does NOT send: releasing upstream is a separate, stubbed seam,
+// so default-deny stays structural (ADR 0003). Approving a non-pending message
+// returns ErrNotPending.
+func (s *Sluice) Approve(id, decidedBy string, released []byte) (Message, error) {
+	return s.transitionFromPending(id, "approve", decidedBy, func(m *Message) {
+		m.Status = StatusApproved
+		m.DecidedBy = decidedBy
+		if released != nil && !bytes.Equal(released, m.Raw) {
+			m.Released = released
+		}
+	})
+}
+
+// Reject marks a pending message rejected with a reason and retryable flag, plus
+// a hash-chained audit entry, in one transaction. Rejecting a non-pending
+// message returns ErrNotPending.
+func (s *Sluice) Reject(id, decidedBy, reason string, retryable bool) (Message, error) {
+	return s.transitionFromPending(id, "reject", reason, func(m *Message) {
+		m.Status = StatusRejected
+		m.DecidedBy = decidedBy
+		m.Reason = reason
+		m.Retryable = retryable
+	})
+}
+
+// RecordSendAttempt records the result of attempting to release an approved
+// message to the upstream Sender, with an audit entry. While the Sender is
+// stubbed this always records the pending-send error; the message is never
+// quietly dropped (ADR 0003).
+func (s *Sluice) RecordSendAttempt(id string, sendErr error) (Message, error) {
+	var out Message
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		m, key, err := loadMessage(tx, id)
+		if err != nil {
+			return err
+		}
+		detail := "sent"
+		if sendErr != nil {
+			detail = sendErr.Error()
+			m.SendErr = sendErr.Error()
+		}
+		if err := putMessage(tx, key, m); err != nil {
+			return err
+		}
+		if _, err := audit.Append(tx, audit.Record{
+			Event: "send_attempt", Agent: m.Agent, MessageID: id, Detail: detail,
+		}); err != nil {
+			return err
+		}
+		out = m
+		return nil
+	})
+	if err != nil {
+		return Message{}, fmt.Errorf("sluice: record send attempt: %w", err)
+	}
+	return out, nil
+}
+
+// transitionFromPending loads a pending message, applies mutate, stores it, and
+// appends an audit entry (event, with detail) — atomically. It errors if the
+// message is not pending, so a verdict can never be applied twice.
+func (s *Sluice) transitionFromPending(id, event, detail string, mutate func(*Message)) (Message, error) {
+	var out Message
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		m, key, err := loadMessage(tx, id)
+		if err != nil {
+			return err
+		}
+		if m.Status != StatusPending {
+			return fmt.Errorf("%w: %s is %s", ErrNotPending, id, m.Status)
+		}
+		mutate(&m)
+		if err := putMessage(tx, key, m); err != nil {
+			return err
+		}
+		if _, err := audit.Append(tx, audit.Record{
+			Event: event, Agent: m.Agent, MessageID: id, Detail: detail,
+		}); err != nil {
+			return err
+		}
+		out = m
+		return nil
+	})
+	if err != nil {
+		return Message{}, fmt.Errorf("sluice: %s: %w", event, err)
+	}
+	return out, nil
+}
+
 // VerifyAudit walks the audit chain and reports the first inconsistency, if any.
 func (s *Sluice) VerifyAudit() error {
 	return s.db.View(func(tx *bbolt.Tx) error {
 		return audit.Verify(tx)
 	})
+}
+
+func loadMessage(tx *bbolt.Tx, id string) (Message, []byte, error) {
+	seq, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return Message{}, nil, fmt.Errorf("%w: invalid id %q", ErrNotFound, id)
+	}
+	key := seqkey.Encode(seq)
+	v := tx.Bucket(bucketMessages).Get(key)
+	if v == nil {
+		return Message{}, nil, ErrNotFound
+	}
+	var m Message
+	if err := json.Unmarshal(v, &m); err != nil {
+		return Message{}, nil, err
+	}
+	return m, key, nil
+}
+
+func putMessage(tx *bbolt.Tx, key []byte, m Message) error {
+	enc, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+	return tx.Bucket(bucketMessages).Put(key, enc)
 }

--- a/internal/sluice/sluice_test.go
+++ b/internal/sluice/sluice_test.go
@@ -1,6 +1,7 @@
 package sluice_test
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -74,5 +75,74 @@ func TestEnqueueRecordsAuditChain(t *testing.T) {
 		_, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("x")})
 		require.NoError(t, err)
 	}
+	require.NoError(t, q.VerifyAudit())
+}
+
+func TestApproveTransitionsAndAudits(t *testing.T) {
+	q := newSluice(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+
+	approved, err := q.Approve(m.ID, "manual", nil)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, approved.Status)
+	assert.Equal(t, "manual", approved.DecidedBy)
+	assert.Nil(t, approved.Released) // no edit → original body released
+
+	got, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, got.Status)
+	require.NoError(t, q.VerifyAudit()) // chain still intact across the transition
+}
+
+func TestApproveStoresEditedBody(t *testing.T) {
+	q := newSluice(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+
+	approved, err := q.Approve(m.ID, "manual", []byte("edited"))
+	require.NoError(t, err)
+	assert.Equal(t, []byte("edited"), approved.Released)
+}
+
+func TestRejectRecordsReason(t *testing.T) {
+	q := newSluice(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+
+	rejected, err := q.Reject(m.ID, "manual", "looks like exfiltration", false)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusRejected, rejected.Status)
+	assert.Equal(t, "looks like exfiltration", rejected.Reason)
+	assert.False(t, rejected.Retryable)
+	require.NoError(t, q.VerifyAudit())
+}
+
+func TestDoubleDecisionRejected(t *testing.T) {
+	q := newSluice(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+
+	_, err = q.Approve(m.ID, "manual", nil)
+	require.NoError(t, err)
+
+	// A second verdict on an already-decided message is refused — fail-closed
+	// against double decisions.
+	_, err = q.Approve(m.ID, "manual", nil)
+	require.ErrorIs(t, err, sluice.ErrNotPending)
+	_, err = q.Reject(m.ID, "manual", "too late", false)
+	require.ErrorIs(t, err, sluice.ErrNotPending)
+}
+
+func TestRecordSendAttemptStoresError(t *testing.T) {
+	q := newSluice(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+	_, err = q.Approve(m.ID, "manual", nil)
+	require.NoError(t, err)
+
+	out, err := q.RecordSendAttempt(m.ID, errors.New("upstream send pending"))
+	require.NoError(t, err)
+	assert.Equal(t, "upstream send pending", out.SendErr)
 	require.NoError(t, q.VerifyAudit())
 }


### PR DESCRIPTION
The machinery that decides a held message's fate (ADR 0004, 0005). Fail-closed throughout; **nothing actually sends this round** — the Sender is a stub.

## What it does
- **`internal/approver`** — the `Approver` contract (`Decide(ctx, Message) (Verdict, error)`; `Verdict` = Approve / Reject(reason, retryable) / Hold; `CanEdit` + amended-body for human edits, ADR 0004), a **registry** with the build-tag/blank-import selection pattern, and the **chain runner**: every stage must approve; the first Reject rejects; any Hold or approver error leaves the message pending. The zero `Verdict` is Hold, so "no decision" is fail-closed by construction.
- **`internal/approver/manual`** — the v1 human approver. Its verdict is injected by the surface the human acted through (the CLI); it self-registers and is compiled in via blank import.
- **`internal/policy`** — the **router**. No pre-screener exists, so it runs with no risk signal and returns the **strict** chain (the ADR 0005 fail-safe: absence of a risk signal is treated as "could be risky", never low).
- **`cmd/darbaan`** — `queue approve <id>` / `queue reject -reason "..." <id>` run the chain for one message and apply the outcome. The human is **one stage** in the chain, never an override of an earlier reject.

## The send seam stays stubbed (hard constraint)
On approval the message is marked approved and handed to a `Sender` — **`internal/backend.StubSender`**, which always returns `ErrSendPending` ("upstream send pending"). The attempt is recorded and audited; the message is never quietly dropped. No outbound SMTP client exists in the diff, so default-deny remains **structural** until the upstream backend lands.

## Audit
Every verdict and every send attempt is a hash-chained audit entry (ADR 0011), written in the **same bbolt transaction** as the status transition. Double decisions are refused (`ErrNotPending`).

## Cross-package touch
This component is inherently multi-package; each change is bounded:
- `internal/approver` (+ `/manual`) — **new**, the bulk of the logic.
- `internal/policy` — **new** router only.
- `internal/backend` — **new** `Sender` interface + stub only (no real connectivity).
- `internal/sluice` — adds `approved`/`rejected` statuses, the transition methods, and `RecordSendAttempt`; the existing enqueue/list/get/audit are untouched in behavior.
- `internal/audit` — one new optional `Detail` field on `Record`.
- `cmd/darbaan` — the `queue approve/reject` wiring + a build-tag blank-import.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l .` — clean.
- `go test -race ./...` — green. Covers: chain semantics (every-stage-must-pass, reject-wins-over-later-approve, hold/empty/error fail-closed, edit only from edit-capable), registry, router buckets, sluice transitions + double-decision refusal, and the end-to-end CLI path (approve reaches the stub Sender and nothing leaves; reject records the reason; no-decision stays pending).
- `golangci-lint run` (v2.11.4) — 0 issues.
- `go build -tags no_manual_approver ./cmd/darbaan` — builds with no approver compiled in (then approval fails closed).

## Out of scope (separate issues)
Real upstream backend + send-on-approval; DSN bounce on reject (ADR 0006) + signing (ADR 0007); IMAP read face; the agent pre-screener (the risk-at-enqueue seam is left, not implemented).

closes #9
