### PR TITLE
ci: build/vet/gofmt/test gate on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Track the version pinned in go.mod (currently Go 1.26) so CI and the
+          # module stay in lockstep — single source of truth.
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Gofmt
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-formatted:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
Add a GitHub Actions workflow so PRs to main are gated automatically instead of relying on local checks.

## Workflow (`.github/workflows/ci.yml`)
Runs on `pull_request` → `main`, one `check` job on `ubuntu-latest`:
- `go build ./...`
- `go vet ./...`
- `gofmt -l .` — fails (exit 1) and prints the offending files if anything is unformatted
- `go test ./...`

Least-privilege `permissions: contents: read`. Pinned actions (`checkout@v4`, `setup-go@v5`).

## Go version
The issue body says "Pin Go 1.24", but that predates the Go 1.26 bump (#5); main's `go.mod` is now `go 1.26`. The workflow uses `go-version-file: go.mod` so CI tracks the module's pinned version (currently 1.26) — single source of truth, no drift if it bumps again.

## Self-validating
Because it triggers on `pull_request`, this workflow runs on its own PR — so its first green run is the proof it works.

## Verification
Ran the exact steps locally against the current tree: build, vet, `gofmt -l .` (clean), `go test ./...` (pass). YAML structure validated.

## Possible follow-up (not in this PR)
I've been running `golangci-lint` (v2.11.4) locally on the Go PRs; adding it as a CI step would catch errcheck/etc. automatically. Left out to keep this PR to the dispatched scope — happy to add in a follow-up if wanted.

closes #4
