### PR TITLE
ci: run the race detector in the test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,6 @@ jobs:
           fi
 
       - name: Test
-        run: go test ./...
+        # -race: the listener + bbolt code is concurrent, so the gate runs the
+        # race detector.
+        run: go test -race ./...


### PR DESCRIPTION
Change the CI test step to `go test -race ./...`.

The listener + bbolt code is concurrent, so the race detector belongs in the gate now that CI is the formal PR check. Passes locally across all packages.

closes #13
