### PR TITLE
adr: amend 0011/0014, add 0015 from maintainer review

### DIFF
--- a/adr/0011-append-only-audit-log.md
+++ b/adr/0011-append-only-audit-log.md
@@ -19,3 +19,19 @@ both the original and any human-edited version of a draft (ADR 0004).
 previous, so tampering or truncation is evident. This is in v1 (cheap, high
 value). **Retention:** configurable; v1 default is keep-all. Rotation/retention
 is an operator setting; any rotation must preserve the chain across segments.
+
+## Amendment (2026-06-26, review) — pluggable + optional audit
+Auditing is a **pluggable component** (registry + config, the same pattern as
+approvers and backends), selected by `audit.type`. v1 ships two implementations:
+- **null** — no-op; audit disabled (for a simple single-agent, single-approval
+  deployment where the chain is more than the user needs).
+- **bbolt** — the hash-chained, tamper-evident log, in **its own store**,
+  separate from the message store.
+
+Putting the audit log in its own store (no longer inside the message store's
+write transaction) **drops the prior atomic enqueue+audit guarantee**: audit
+becomes **best-effort**, written after the operation, with the message store as
+the source of truth. This is a deliberate trade for the off-switch and
+modularity. The hash chain stays tamper-evident (blockchain-like, not a
+blockchain — no consensus); pluggability leaves room for a stronger external
+append-only sink later without touching call sites.

--- a/adr/0014-prefer-established-libraries.md
+++ b/adr/0014-prefer-established-libraries.md
@@ -24,3 +24,11 @@ avoid trivial micro-dependencies that add supply-chain surface for little gain.
 - All dependencies must be license-compatible with MIT.
 - We accept some supply-chain surface as the price of protocol/crypto correctness,
   and keep that surface deliberate rather than incidental.
+
+## Amendment (2026-06-26, review)
+The library-first rule covers **commodity concerns**, not only protocol and
+crypto. **CLI/argument parsing** (kong) and **configuration** (file/env/flags
+layering) are library work too, not in-house logic. In-house code is reserved
+for Darbaan's actual domain logic: the sluice, the approver pipeline, routing,
+policy. Hand-rolling arg-parsing or config layering is out of scope — reach for
+the vetted library.

--- a/adr/0015-storage-abstraction.md
+++ b/adr/0015-storage-abstraction.md
@@ -1,0 +1,28 @@
+# ADR 0015: Abstract storage behind interfaces; config-selected backend
+
+**Status:** Accepted (2026-06-26)
+
+## Context
+v1 uses bbolt for both the message store and the audit log. The storage engine
+should be swappable for another later (SQLite, Postgres, a remote KV, ...) by a
+**simple config change**, without rewiring call sites. Requirement from the
+maintainer, 2026-06-26: make it possible for the future, do not build the
+alternatives now.
+
+## Decision
+Persistence sits behind interfaces:
+- **`MessageStore`** — the sluice: enqueue / list / get / set-status.
+- **`AuditLog`** — append / verify (ADR 0011).
+
+Each is chosen by a **config-selected factory** (`store.type`, `audit.type`),
+the same registry pattern as approvers (ADR 0004) and backends (ADR 0009). v1
+implements **bbolt only** for `MessageStore`, and **null + bbolt** for
+`AuditLog` (ADR 0011). No other backends are built now — only the seam. Call
+sites depend on the interfaces, never on bbolt directly.
+
+## Consequences
+- A future store is an implementation plus a config value, no call-site changes.
+- Only the seam ships in v1; alternative backends are explicitly out of scope
+  until a real need arises.
+- Message store and audit log are **separate stores** (ADR 0011 amendment), so a
+  deployment can disable audit (`audit.type: null`) independently.

--- a/adr/README.md
+++ b/adr/README.md
@@ -4,7 +4,8 @@ Darbaan records its significant decisions as ADRs. Each file is one decision:
 its context, the decision, and the consequences. ADRs are immutable once
 Accepted — to change one, add a new ADR that supersedes it.
 
-These initial records (0001–0013) capture the v1 design locked on 2026-06-25.
+These records (0001–0015) capture the v1 design, locked 2026-06-25 and amended
+through 2026-06-26 (maintainer review).
 
 | ADR | Title |
 |---|---|
@@ -21,5 +22,6 @@ These initial records (0001–0013) capture the v1 design locked on 2026-06-25.
 | [0010](0010-multi-mailbox-v1-multi-agent-deferred.md) | Multi-mailbox in v1; multi-agent deferred |
 | [0011](0011-append-only-audit-log.md) | Append-only audit log |
 | [0012](0012-deployment-and-secrets-at-rest.md) | Deployment and secrets at rest |
-| [0013](0013-go-and-mit.md) | Go 1.24+, MIT license |
+| [0013](0013-go-and-mit.md) | Go (latest stable), MIT license |
 | [0014](0014-prefer-established-libraries.md) | Prefer established libraries over reinventing |
+| [0015](0015-storage-abstraction.md) | Abstract storage behind interfaces; config-selected backend |


### PR DESCRIPTION
Documents the 2026-06-26 maintainer review decisions that issues #15/#16/#17 implement. ADR-only, no code.

- **0014** amended: the library-first rule explicitly covers commodity concerns (CLI parsing via kong, config layering), not only protocol/crypto.
- **0011** amended: auditing is a pluggable component (registry + `audit.type`), v1 ships null + bbolt, audit is its own store and optional; notes the deliberate loss of the atomic enqueue+audit guarantee (best-effort, message store is source of truth).
- **0015** new: storage behind `MessageStore`/`AuditLog` interfaces with a config-selected factory (`store.type`/`audit.type`); bbolt the only v1 impl, swappable later via config, no other backends built now.

cc @sora-rubigd for review.