### PR TITLE
fix: DARBAAN_CONFIG file selection + []string env splitting

### DIFF
--- a/cmd/darbaan/config.go
+++ b/cmd/darbaan/config.go
@@ -27,11 +27,46 @@ func envResolver() kong.Resolver {
 	replacer := strings.NewReplacer("-", "_", ".", "_")
 	return kong.ResolverFunc(func(_ *kong.Context, _ *kong.Path, flag *kong.Flag) (any, error) {
 		name := envPrefix + strings.ToUpper(replacer.Replace(flag.Name))
-		if v, ok := os.LookupEnv(name); ok {
-			return v, nil
+		v, ok := os.LookupEnv(name)
+		if !ok {
+			return nil, nil
 		}
-		return nil, nil
+		// kong does not split a single resolver string into slice elements, so
+		// for slice flags (e.g. approval-strict) split the comma-separated env
+		// value ourselves — matching how the YAML and repeated-flag paths build
+		// multi-element chains. Without this, DARBAAN_APPROVAL_STRICT="a,b" would
+		// collapse to a single "a,b" element.
+		if flag.IsSlice() {
+			// kong's slice decoder splits the returned string on the flag's
+			// separator (comma) but does not trim, so normalize first: trim and
+			// drop empties, then rejoin for kong to re-split. A comma-separated
+			// env value such as DARBAAN_APPROVAL_STRICT="a, b" thus yields a
+			// clean multi-element chain ["a","b"]; an empty value does not
+			// override a non-empty default with an empty chain.
+			parts := splitComma(v)
+			if len(parts) == 0 {
+				return nil, nil
+			}
+			return strings.Join(parts, ","), nil
+		}
+		return v, nil
 	})
+}
+
+// splitComma splits a comma-separated env value into trimmed, non-empty
+// elements. An empty (or whitespace-only) value yields no elements.
+func splitComma(v string) []string {
+	if strings.TrimSpace(v) == "" {
+		return nil
+	}
+	parts := strings.Split(v, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // kongOptions builds the parser options that establish the file < env < flag
@@ -52,9 +87,12 @@ func kongOptions(extraConfigPath string) []kong.Option {
 	}
 }
 
-// configPathFromArgs scans for --config so its file can be added to the loader
-// paths before kong parses (the loader paths are fixed at construction time).
-func configPathFromArgs(args []string) string {
+// resolveConfigPath determines which config file to add to the loader paths
+// before kong parses (the loader paths are fixed at construction time, so this
+// runs before the resolvers). The --config flag wins; otherwise DARBAAN_CONFIG
+// is honored, so an operator can select the config file by env as well — flag
+// over env, consistent with the rest of the layering.
+func resolveConfigPath(args []string) string {
 	for i, a := range args {
 		switch {
 		case a == "--config" && i+1 < len(args):
@@ -63,5 +101,5 @@ func configPathFromArgs(args []string) string {
 			return strings.TrimPrefix(a, "--config=")
 		}
 	}
-	return ""
+	return os.Getenv(envPrefix + "CONFIG")
 }

--- a/cmd/darbaan/config_test.go
+++ b/cmd/darbaan/config_test.go
@@ -49,3 +49,52 @@ func TestConfigPrecedence(t *testing.T) {
 			resolveAddr(t, "from-file", "", []string{"--listener-addr", "from-flag"}))
 	})
 }
+
+// parseCLI builds and parses a CLI, resolving the config path the same way main
+// does (so DARBAAN_CONFIG is honored).
+func parseCLI(t *testing.T, args []string) CLI {
+	t.Helper()
+	var cli CLI
+	parser, err := kong.New(&cli, kongOptions(resolveConfigPath(args))...)
+	require.NoError(t, err)
+	_, err = parser.Parse(args)
+	require.NoError(t, err)
+	return cli
+}
+
+// TestConfigFileSelectableByEnv covers #21(1): DARBAAN_CONFIG selects which
+// config file loads, and --config still wins over it.
+func TestConfigFileSelectableByEnv(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), "env.yaml")
+	require.NoError(t, os.WriteFile(envFile, []byte("listener-addr: from-env-config\n"), 0o600))
+
+	t.Run("DARBAAN_CONFIG selects the file", func(t *testing.T) {
+		t.Setenv("DARBAAN_CONFIG", envFile)
+		cli := parseCLI(t, []string{"version"})
+		require.Equal(t, "from-env-config", cli.ListenerAddr)
+	})
+
+	t.Run("--config wins over DARBAAN_CONFIG", func(t *testing.T) {
+		flagFile := filepath.Join(t.TempDir(), "flag.yaml")
+		require.NoError(t, os.WriteFile(flagFile, []byte("listener-addr: from-flag-config\n"), 0o600))
+		t.Setenv("DARBAAN_CONFIG", envFile)
+		cli := parseCLI(t, []string{"--config", flagFile, "version"})
+		require.Equal(t, "from-flag-config", cli.ListenerAddr)
+	})
+}
+
+// TestSliceEnvSplitting covers #21(2): a comma-separated env value sets a
+// multi-element slice flag (so env-set approval chains don't collapse).
+func TestSliceEnvSplitting(t *testing.T) {
+	t.Run("comma-separated, trimmed", func(t *testing.T) {
+		t.Setenv("DARBAAN_APPROVAL_STRICT", "alpha, beta ,gamma")
+		cli := parseCLI(t, []string{"version"})
+		require.Equal(t, []string{"alpha", "beta", "gamma"}, cli.ApprovalStrict)
+	})
+
+	t.Run("empty env does not override default", func(t *testing.T) {
+		t.Setenv("DARBAAN_APPROVAL_STRICT", "")
+		cli := parseCLI(t, []string{"version"})
+		require.Equal(t, []string{"manual"}, cli.ApprovalStrict) // default preserved
+	})
+}

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -61,7 +61,7 @@ type CLI struct {
 
 func main() {
 	var cli CLI
-	parser, err := kong.New(&cli, kongOptions(configPathFromArgs(os.Args[1:]))...)
+	parser, err := kong.New(&cli, kongOptions(resolveConfigPath(os.Args[1:]))...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The two non-blocking config notes from #20.

1. **`DARBAAN_CONFIG` file selection** — was a silent no-op (loader paths are fixed at `kong.New`, before resolvers fire). `resolveConfigPath` now honors `DARBAAN_CONFIG` as the config-file path; `--config` still wins over it.
2. **`[]string` env splitting** — kong splits a slice env value on comma but does not trim, so the env resolver normalizes (trim + drop-empty) before returning; `DARBAAN_APPROVAL_STRICT="a, b"` -> `["a","b"]`. An empty env value does not override a non-empty default with an empty chain.

Both covered by new tests in `config_test.go`. Touches only `cmd/darbaan`. build/vet/gofmt/race/golangci-lint clean.

closes #21
