### PR TITLE
adr: record store-canonical translation-faces architecture (0016)

### DIFF
--- a/adr/0001-mail-proxy-not-http-api.md
+++ b/adr/0001-mail-proxy-not-http-api.md
@@ -16,3 +16,10 @@ Darbaan is a **proxy** that agents talk to over standard **IMAP** (read) and
 - One local service hosts both the IMAP face and the SMTP face.
 - Public-library boundary follows Go convention: `pkg/` public API, `internal/`
   private, thin CLI in `cmd/darbaan` (see ADR 0013).
+
+## Amendment (2026-06-26)
+"Proxy" here means a **translation adapter over a canonical store**, not a live
+pass-through. The store is the single source of truth; each protocol face
+(SMTP submit, IMAP read) reads/writes the store rather than proxying a live
+upstream connection (see ADR 0016). Live IMAP pass-through with selective hiding
+was rejected as a UID/sequence-number/state hazard.

--- a/adr/0011-append-only-audit-log.md
+++ b/adr/0011-append-only-audit-log.md
@@ -35,3 +35,9 @@ the source of truth. This is a deliberate trade for the off-switch and
 modularity. The hash chain stays tamper-evident (blockchain-like, not a
 blockchain — no consensus); pluggability leaves room for a stronger external
 append-only sink later without touching call sites.
+
+`Verify()` proves chain **integrity** (the prev-hash links of existing entries),
+**not completeness**: because audit is best-effort and out-of-transaction, a
+crash between the message-store commit and the audit write leaves a gap that
+`Verify()` cannot detect. Gap detection, if ever needed, is a separate
+message-store-to-audit cross-reference, not part of `Verify()`.

--- a/adr/0016-store-canonical-translation-faces.md
+++ b/adr/0016-store-canonical-translation-faces.md
@@ -1,0 +1,33 @@
+# ADR 0016: Store-canonical architecture; protocol faces are translation adapters
+
+**Status:** Accepted (2026-06-26)
+
+## Context
+Darbaan must filter, hold (hold-for-human), and serve both Darbaan-generated
+messages (bounces) and, later, upstream inbound mail. A live IMAP pass-through
+that selectively hides messages is a UID / sequence-number / state hazard and
+hard to get right.
+
+## Decision
+The **store is the single source of truth.** Each protocol face is a thin
+**translation adapter** over the store, never a live proxy:
+- The **SMTP submit** face writes submissions into the store (the trap, ADR 0003).
+- The **IMAP read** face reads from the store and translates to IMAP.
+- Future faces (JMAP, a local API) are additional adapters over the same store.
+
+This refines the word "proxy" in ADR 0001 (adapter-over-store, not pass-through).
+
+**MVP scope:** the IMAP read face serves **only Darbaan-generated messages** (the
+signed bounces / notifications, ADR 0006/0007); it needs **no upstream inbound
+fetch**. Syncing real upstream inbound mail into the store and filtering it
+(ADR 0008) is a **later layer**, served through the same adapter (post-MVP).
+
+## Consequences
+- Filtering and hold-for-human are tractable on owned data; there is no
+  live-proxy IMAP state to manage.
+- New protocols are new adapters, not new proxies.
+- Costs: sync lag (for the later upstream layer) and storing fetched mail
+  (at-rest encryption, ADR 0012).
+- Bounces (ADR 0006) are the first content the read face serves, enabling a
+  minimal end-to-end MVP (SMTP in, IMAP out for bounces) with no upstream read
+  integration.

--- a/adr/README.md
+++ b/adr/README.md
@@ -4,7 +4,7 @@ Darbaan records its significant decisions as ADRs. Each file is one decision:
 its context, the decision, and the consequences. ADRs are immutable once
 Accepted — to change one, add a new ADR that supersedes it.
 
-These records (0001–0015) capture the v1 design, locked 2026-06-25 and amended
+These records (0001–0016) capture the v1 design, locked 2026-06-25 and amended
 through 2026-06-26 (maintainer review).
 
 | ADR | Title |
@@ -25,3 +25,4 @@ through 2026-06-26 (maintainer review).
 | [0013](0013-go-and-mit.md) | Go (latest stable), MIT license |
 | [0014](0014-prefer-established-libraries.md) | Prefer established libraries over reinventing |
 | [0015](0015-storage-abstraction.md) | Abstract storage behind interfaces; config-selected backend |
+| [0016](0016-store-canonical-translation-faces.md) | Store-canonical architecture; protocol faces are translation adapters |


### PR DESCRIPTION
Records the v1 read-side architecture: the store is the single source of truth and protocol faces (SMTP submit, IMAP read) are translation adapters over it, not live proxies. ADR-only.

- 0016 (new): store-canonical; faces are adapters; MVP IMAP serves only Darbaan-generated bounces; upstream inbound sync is a post-MVP layer over the same seam.
- 0001 amended: clarifies that proxy means adapter-over-store, not pass-through.
- 0011 amended: Verify() proves integrity, not completeness; gap detection is a separate store-to-audit cross-reference.

Frames the MVP roadmap issues #25/#26/#27 and gated #30. cc sora-rubigd.