### PR TITLE
feat: DKIM-sign bounces (ed25519), fail-closed; dkim-pubkey

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/listener"
 	"github.com/yaad-index/darbaan/internal/policy"
+	"github.com/yaad-index/darbaan/internal/signer"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -48,6 +49,10 @@ type CLI struct {
 	InboundType string `name:"inbound-type" default:"bbolt" help:"Inbound (served mailbox) store backend." enum:"bbolt"`
 	InboundDB   string `name:"inbound-db" default:"darbaan-inbound.db" help:"Path to the inbound store database." type:"path"`
 
+	DKIMKeyFile  string `name:"dkim-key-file" help:"Path to the PEM-encoded ed25519 DKIM private key used to sign bounces (ADR 0007)." type:"path"`
+	DKIMSelector string `name:"dkim-selector" default:"darbaan" help:"DKIM selector for bounce signatures."`
+	DKIMDomain   string `name:"dkim-domain" help:"DKIM signing domain (d=) for bounce signatures."`
+
 	ListenerAddr          string `name:"listener-addr" default:":1465" help:"SMTP submission listen address."`
 	ListenerDomain        string `name:"listener-domain" default:"localhost" help:"SMTP greeting domain."`
 	ListenerTLSCert       string `name:"listener-tls-cert" help:"Path to the TLS certificate (PEM)." type:"path"`
@@ -59,9 +64,10 @@ type CLI struct {
 	ApprovalStrict []string `name:"approval-strict" default:"manual" help:"Approver chain for the strict path."`
 	ApprovalLight  []string `name:"approval-light" default:"manual" help:"Approver chain for the light path."`
 
-	Serve   ServeCmd   `cmd:"" help:"Run the SMTP submission face and sluice."`
-	Queue   QueueCmd   `cmd:"" help:"Inspect and decide held messages."`
-	Version VersionCmd `cmd:"" help:"Print version and exit."`
+	Serve      ServeCmd      `cmd:"" help:"Run the SMTP submission face and sluice."`
+	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages."`
+	DkimPubkey DkimPubkeyCmd `cmd:"" name:"dkim-pubkey" help:"Print the DKIM public-key record to pin to the agent."`
+	Version    VersionCmd    `cmd:"" help:"Print version and exit."`
 }
 
 func main() {
@@ -97,6 +103,30 @@ func (c *CLI) openStore() (sluice.MessageStore, func(), error) {
 // openInbound opens the inbound (served mailbox) store per config.
 func (c *CLI) openInbound() (inbound.InboundStore, error) {
 	return inbound.New(c.InboundType, c.InboundDB)
+}
+
+// openSigner loads the DKIM signer from config. It fails closed: bounce signing
+// is required (ADR 0007), so a missing or invalid key is an error rather than a
+// silently-unsigned bounce.
+func (c *CLI) openSigner() (*signer.Signer, error) {
+	return signer.New(c.DKIMKeyFile, c.DKIMSelector, c.DKIMDomain)
+}
+
+// bounceSigner signs a bounce before it is stored. *signer.Signer implements it.
+type bounceSigner interface {
+	Sign(raw []byte) ([]byte, error)
+}
+
+// DkimPubkeyCmd prints the DKIM public-key record for out-of-band pinning.
+type DkimPubkeyCmd struct{}
+
+func (*DkimPubkeyCmd) Run(cli *CLI) error {
+	s, err := cli.openSigner()
+	if err != nil {
+		return err
+	}
+	fmt.Println(s.PublicKeyTXT())
+	return nil
 }
 
 // VersionCmd prints the build version.
@@ -231,7 +261,7 @@ func (c *QueueApproveCmd) Run(cli *CLI) error {
 	defer closeStore()
 
 	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, cli.router(),
-		nil, "", c.ID, approver.Verdict{Disposition: approver.Approve})
+		nil, nil, "", c.ID, approver.Verdict{Disposition: approver.Approve})
 	if err != nil {
 		return err
 	}
@@ -268,8 +298,15 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 	}
 	defer func() { _ = inbox.Close() }()
 
+	// Bounce signing is required (ADR 0007): fail closed if the key is not set
+	// or invalid, rather than emit a bounce the agent will not trust.
+	sgn, err := cli.openSigner()
+	if err != nil {
+		return err
+	}
+
 	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, cli.router(),
-		inbox, cli.ListenerDomain, c.ID, approver.Verdict{Disposition: approver.Reject, Reason: c.Reason, Retryable: c.Retryable})
+		inbox, sgn, cli.ListenerDomain, c.ID, approver.Verdict{Disposition: approver.Reject, Reason: c.Reason, Retryable: c.Retryable})
 	if err != nil {
 		return err
 	}
@@ -292,7 +329,7 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 // message is marked approved and handed to the (stubbed) Sender; the send result
 // is recorded and audited, never silently dropped (ADR 0003). On rejection the
 // reason is recorded. A Hold leaves the message pending.
-func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.Sender, router *policy.Router, inbox inbound.InboundStore, domain string, id string, human approver.Verdict) (sluice.Message, error) {
+func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.Sender, router *policy.Router, inbox inbound.InboundStore, sgn bounceSigner, domain string, id string, human approver.Verdict) (sluice.Message, error) {
 	msg, err := q.Get(id)
 	if err != nil {
 		return sluice.Message{}, err
@@ -345,8 +382,17 @@ func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.S
 			if err != nil {
 				return sluice.Message{}, fmt.Errorf("generate bounce: %w", err)
 			}
+			// Sign before store (ADR 0007): the stored bounce is already signed,
+			// so the IMAP face serves it verbatim. Fail closed if no signer.
+			if sgn == nil {
+				return sluice.Message{}, fmt.Errorf("deliver bounce: signing required but no signer configured")
+			}
+			signed, err := sgn.Sign(b.Raw)
+			if err != nil {
+				return sluice.Message{}, fmt.Errorf("sign bounce: %w", err)
+			}
 			if _, err := inbox.Add(inbound.Delivery{
-				Owner: b.Owner, From: b.From, To: b.To, Subject: b.Subject, Raw: b.Raw,
+				Owner: b.Owner, From: b.From, To: b.To, Subject: b.Subject, Raw: signed,
 			}); err != nil {
 				return sluice.Message{}, fmt.Errorf("deliver bounce: %w", err)
 			}

--- a/cmd/darbaan/main_test.go
+++ b/cmd/darbaan/main_test.go
@@ -2,6 +2,11 @@ package main
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,6 +18,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/policy"
+	"github.com/yaad-index/darbaan/internal/signer"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -39,7 +45,7 @@ func TestApproveReachesStubSenderAndNothingLeaves(t *testing.T) {
 	q, id := newSeededSluice(t)
 
 	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, "", id, approver.Verdict{Disposition: approver.Approve})
+		nil, nil, "", id, approver.Verdict{Disposition: approver.Approve})
 	require.NoError(t, err)
 
 	assert.Equal(t, sluice.StatusApproved, out.Status)
@@ -55,12 +61,13 @@ func TestRejectGeneratesBounceIntoInbound(t *testing.T) {
 	defer func() { _ = inbox.Close() }()
 
 	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		inbox, "darbaan.test", id, approver.Verdict{Disposition: approver.Reject, Reason: "smells like exfiltration", Retryable: false})
+		inbox, testSigner(t), "darbaan.test", id, approver.Verdict{Disposition: approver.Reject, Reason: "smells like exfiltration", Retryable: false})
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusRejected, out.Status)
 	assert.Equal(t, "smells like exfiltration", out.Reason)
 
-	// A DSN bounce was delivered to the agent's inbound mailbox (ADR 0006).
+	// A DSN bounce was delivered to the agent's inbound mailbox (ADR 0006),
+	// already DKIM-signed (ADR 0007).
 	msgs, err := inbox.List("agent") // owner = original submitting agent
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
@@ -69,7 +76,22 @@ func TestRejectGeneratesBounceIntoInbound(t *testing.T) {
 	assert.Equal(t, "a@local", b.To) // returned to the original submitter
 	assert.False(t, b.Seen)          // lands unseen
 	assert.Contains(t, string(b.Raw), "smells like exfiltration")
-	assert.Contains(t, string(b.Raw), "5.7.1") // permanent policy reject
+	assert.Contains(t, string(b.Raw), "5.7.1")           // permanent policy reject
+	assert.Contains(t, string(b.Raw), "DKIM-Signature:") // signed before store
+}
+
+func testSigner(t *testing.T) *signer.Signer {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "dkim.pem")
+	require.NoError(t, os.WriteFile(path,
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600))
+	s, err := signer.New(path, "darbaan", "darbaan.test")
+	require.NoError(t, err)
+	return s
 }
 
 func TestNoDecisionLeavesPending(t *testing.T) {
@@ -78,7 +100,7 @@ func TestNoDecisionLeavesPending(t *testing.T) {
 	// A Hold verdict (the human took no action) must leave the message pending —
 	// fail-closed.
 	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, "", id, approver.Verdict{Disposition: approver.Hold})
+		nil, nil, "", id, approver.Verdict{Disposition: approver.Hold})
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusPending, out.Status)
 
@@ -91,10 +113,10 @@ func TestApproveTwiceIsRefused(t *testing.T) {
 	q, id := newSeededSluice(t)
 
 	_, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, "", id, approver.Verdict{Disposition: approver.Approve})
+		nil, nil, "", id, approver.Verdict{Disposition: approver.Approve})
 	require.NoError(t, err)
 
 	_, err = decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, "", id, approver.Verdict{Disposition: approver.Approve})
+		nil, nil, "", id, approver.Verdict{Disposition: approver.Approve})
 	require.Error(t, err) // already approved, not pending
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -22,6 +22,17 @@ audit-db: darbaan-audit.db
 inbound-type: bbolt
 inbound-db: darbaan-inbound.db
 
+# DKIM signing of bounces (ADR 0007). Every Darbaan-issued bounce is signed so
+# the agent, holding only the pinned public key, trusts only bounces Darbaan
+# produced. The key is a PEM-encoded ed25519 private key FILE (PKCS#8); only its
+# path is config — the file is the secret (ADR 0012), never inlined here.
+# Required for the reject/bounce path (fail-closed). Generate with:
+#   openssl genpkey -algorithm ed25519 -out dkim.pem
+# Publish/pin the public record from: darbaan dkim-pubkey
+dkim-key-file: ""            # path to the ed25519 private key (PEM)
+dkim-selector: darbaan
+dkim-domain: ""              # signing domain (d=); typically the listener domain
+
 # SMTP submission face.
 listener-addr: ":1465"
 listener-domain: localhost

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/alecthomas/kong-yaml v0.2.0
 	github.com/emersion/go-message v0.18.2
+	github.com/emersion/go-msgauth v0.7.0
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
 	github.com/stretchr/testify v1.11.1
@@ -16,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7x/Lpg=
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
+github.com/emersion/go-msgauth v0.7.0 h1:vj2hMn6KhFtW41kshIBTXvp6KgYSqpA/ZN9Pv4g1INc=
+github.com/emersion/go-msgauth v0.7.0/go.mod h1:mmS9I6HkSovrNgq0HNXTeu8l3sRAAuQ9RMvbM4KU7Ck=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3DfFi4EXdT+B+gTtzx8GC9xsc26Znk=
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/emersion/go-smtp v0.24.0 h1:g6AfoF140mvW0vLNPD/LuCBLEAdlxOjIXqbIkJIS6Wk=
@@ -30,6 +32,8 @@ go.etcd.io/bbolt v1.5.0 h1:S7GAl7Fxv12yohbwFfIbQCGDWbQbtDGPET4P/bD4lxU=
 go.etcd.io/bbolt v1.5.0/go.mod h1:mkltfYE5aUHQxUct9N9V+Kp7aSjFqjgrhcXIS70Lrdk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -1,0 +1,80 @@
+package signer
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/emersion/go-msgauth/dkim"
+)
+
+// Signer signs Darbaan-issued bounces with DKIM (RFC 6376; ed25519 per RFC 8463)
+// so an agent holding only the pinned public key trusts only bounces Darbaan
+// produced (ADR 0007). The private key is held in memory only.
+type Signer struct {
+	opts   dkim.SignOptions
+	pubKey ed25519.PublicKey
+}
+
+// New loads the PEM-encoded ed25519 private key at keyFile and builds a Signer
+// for the selector and domain. It fails closed: a missing, unreadable, or
+// non-ed25519 key is an error, so Darbaan never emits an unsigned bounce
+// (ADR 0007). The key is read once and kept in memory only — the path is
+// config, the file is the secret (ADR 0012); the key is never logged.
+func New(keyFile, selector, domain string) (*Signer, error) {
+	if keyFile == "" {
+		return nil, fmt.Errorf("signer: dkim-key-file is required for bounce signing")
+	}
+	if selector == "" || domain == "" {
+		return nil, fmt.Errorf("signer: dkim-selector and dkim-domain are required")
+	}
+	pemBytes, err := os.ReadFile(keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("signer: read key file: %w", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("signer: %s is not PEM-encoded", keyFile)
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("signer: parse private key: %w", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("signer: key is %T, want ed25519 (RFC 8463)", key)
+	}
+
+	return &Signer{
+		opts: dkim.SignOptions{
+			Domain:                 domain,
+			Selector:               selector,
+			Signer:                 priv,
+			Hash:                   crypto.SHA256,
+			HeaderCanonicalization: dkim.CanonicalizationRelaxed,
+			BodyCanonicalization:   dkim.CanonicalizationRelaxed,
+		},
+		pubKey: priv.Public().(ed25519.PublicKey),
+	}, nil
+}
+
+// Sign returns the message with a prepended DKIM-Signature header.
+func (s *Signer) Sign(raw []byte) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := dkim.Sign(&buf, bytes.NewReader(raw), &s.opts); err != nil {
+		return nil, fmt.Errorf("signer: dkim sign: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// PublicKeyTXT returns the DKIM public-key record — the value an operator
+// publishes at <selector>._domainkey.<domain> (or pins to the agent
+// out-of-band) so the agent can verify Darbaan's bounces.
+func (s *Signer) PublicKeyTXT() string {
+	return "v=DKIM1; k=ed25519; p=" + base64.StdEncoding.EncodeToString(s.pubKey)
+}

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -1,0 +1,96 @@
+package signer_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/emersion/go-msgauth/dkim"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/signer"
+)
+
+func writeKey(t *testing.T, key any) string {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "key.pem")
+	require.NoError(t, os.WriteFile(path,
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600))
+	return path
+}
+
+func writeEd25519(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return writeKey(t, priv)
+}
+
+func TestSignAndVerifyWithPinnedKey(t *testing.T) {
+	s, err := signer.New(writeEd25519(t), "darbaan", "darbaan.test")
+	require.NoError(t, err)
+
+	msg := []byte("From: MAILER-DAEMON@darbaan.test\r\nTo: a@b.test\r\nSubject: x\r\n\r\nbody\r\n")
+	signed, err := s.Sign(msg)
+	require.NoError(t, err)
+	assert.Contains(t, string(signed), "DKIM-Signature:")
+
+	// Agent-side verification against the pinned key (no DNS — LookupTXT returns
+	// the record from PublicKeyTXT).
+	vs, err := dkim.VerifyWithOptions(bytes.NewReader(signed), &dkim.VerifyOptions{
+		LookupTXT: func(domain string) ([]string, error) {
+			require.Equal(t, "darbaan._domainkey.darbaan.test", domain)
+			return []string{s.PublicKeyTXT()}, nil
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, vs, 1)
+	require.NoError(t, vs[0].Err)
+	assert.Equal(t, "darbaan.test", vs[0].Domain)
+}
+
+func TestVerifyFailsOnTamper(t *testing.T) {
+	s, err := signer.New(writeEd25519(t), "darbaan", "darbaan.test")
+	require.NoError(t, err)
+	signed, err := s.Sign([]byte("From: m@darbaan.test\r\nSubject: x\r\n\r\nbody\r\n"))
+	require.NoError(t, err)
+
+	tampered := bytes.Replace(signed, []byte("body"), []byte("evil"), 1)
+	vs, err := dkim.VerifyWithOptions(bytes.NewReader(tampered), &dkim.VerifyOptions{
+		LookupTXT: func(string) ([]string, error) { return []string{s.PublicKeyTXT()}, nil },
+	})
+	require.NoError(t, err)
+	require.Len(t, vs, 1)
+	assert.Error(t, vs[0].Err) // body changed → signature no longer verifies
+}
+
+func TestPublicKeyTXTFormat(t *testing.T) {
+	s, err := signer.New(writeEd25519(t), "sel", "dom")
+	require.NoError(t, err)
+	txt := s.PublicKeyTXT()
+	assert.Contains(t, txt, "v=DKIM1")
+	assert.Contains(t, txt, "k=ed25519")
+	assert.Contains(t, txt, "p=")
+}
+
+func TestFailClosed(t *testing.T) {
+	_, err := signer.New("", "s", "d")
+	require.Error(t, err) // no key file
+
+	_, err = signer.New(filepath.Join(t.TempDir(), "nope.pem"), "s", "d")
+	require.Error(t, err) // missing file
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	_, err = signer.New(writeKey(t, rsaKey), "s", "d")
+	require.Error(t, err) // non-ed25519 key rejected
+}


### PR DESCRIPTION
Sign every Darbaan-issued bounce with DKIM so an agent holding only the pinned public key trusts only bounces Darbaan produced (ADR 0007). Builds on #25.

## `internal/signer`
DKIM signing (RFC 6376; **ed25519** per RFC 8463) via `emersion/go-msgauth/dkim` — composing a vetted crypto library, no hand-rolling (ADR 0014).
- Loads a **PEM-encoded ed25519 private key file** once at startup, held in memory only, never logged.
- **Fail-closed**: a missing, unreadable, or non-ed25519 key is an error — Darbaan never emits an unsigned bounce.
- `PublicKeyTXT()` emits the DKIM public-key record (`v=DKIM1; k=ed25519; p=<base64>`) for out-of-band pinning.

## Key-loading spec (as pinned)
- Source of truth = a PEM ed25519 private key file; the **path** is config (`dkim-key-file`), the **file** is the secret (ADR 0012, config-references-not-inlines). Layered config applies (file/env/flag).
- `dkim-selector` and `dkim-domain` are config. (Flat naming to match the existing config surface.)
- Read once, parsed, memory-only, never logged.

## cmd wiring
- The **reject path** loads the signer and **fails closed** if the key is missing/invalid, rather than emit a bounce the agent won't trust.
- The bounce is **signed before it is stored**, so the IMAP face (#27) serves it verbatim.
- New **`darbaan dkim-pubkey`** prints the record to pin to the agent.

## Why ed25519 over RSA
The lib supports both; the verifier is the agent's **out-of-band pinned key** (a closed system — no public-DNS interop concern), so ed25519's smaller keys/signatures win. Confirmed working with an `openssl genpkey -algorithm ed25519` key.

## Verification
- `go build`/`vet`/`gofmt -l` clean; `go test -race ./...` green; `golangci-lint` (v2.11.4) 0 issues.
- signer tests: **sign → verify against the pinned key** (no DNS, via `VerifyWithOptions` LookupTXT returning `PublicKeyTXT()`); tamper detection (body change → verification fails); fail-closed (no key / missing file / RSA key rejected); TXT format.
- cmd reject test asserts the stored bounce carries a `DKIM-Signature:` header.
- Smoke: `dkim-pubkey` prints a valid record; reject without a key errors.

## Hard constraint
Sender stays stubbed; nothing sends. Next: #27 IMAP read face serves these signed bounces.

closes #26
