### PR TITLE
feat: IMAP read face — serve signed bounces from the inbound store

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -59,6 +59,8 @@ type CLI struct {
 	ListenerTLSKey        string `name:"listener-tls-key" help:"Path to the TLS private key (PEM)." type:"path"`
 	ListenerAllowInsecure bool   `name:"listener-allow-insecure" help:"Allow AUTH over plaintext (local testing only)."`
 
+	IMAPAddr string `name:"imap-addr" default:":1143" help:"IMAP read-face listen address (serves the agent's bounces); reuses the agent credential and listener TLS."`
+
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
 	ApprovalStrict []string `name:"approval-strict" default:"manual" help:"Approver chain for the strict path."`
@@ -167,7 +169,15 @@ func (*ServeCmd) Run(cli *CLI) error {
 	}
 	defer closeStore()
 
-	srv, err := listener.NewServer(listener.ServerConfig{
+	inbox, err := cli.openInbound()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = inbox.Close() }()
+
+	// One local service hosts both faces (ADR 0001): the SMTP submission face
+	// (outbound trap) and the IMAP read face (the agent reads its bounces).
+	smtpSrv, err := listener.NewServer(listener.ServerConfig{
 		Addr:          cli.ListenerAddr,
 		Domain:        cli.ListenerDomain,
 		TLSConfig:     tlsConfig,
@@ -176,19 +186,42 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
+	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
+		Addr:          cli.IMAPAddr,
+		TLSConfig:     tlsConfig,
+		AllowInsecure: cli.ListenerAllowInsecure,
+	}, cred, inbox)
+	if err != nil {
+		return err
+	}
 
 	go func() {
 		sig := make(chan os.Signal, 1)
 		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 		<-sig
-		_ = srv.Close()
+		_ = smtpSrv.Close()
+		_ = imapSrv.Close()
 	}()
 
-	fmt.Fprintf(os.Stderr, "darbaan: SMTP submission face on %s (db %s)\n", cli.ListenerAddr, cli.SluiceDB)
-	if err := srv.ListenAndServe(); err != nil && !errors.Is(err, net.ErrClosed) {
+	ignoreClosed := func(err error) error {
+		if errors.Is(err, net.ErrClosed) {
+			return nil
+		}
 		return err
 	}
-	return nil
+	errs := make(chan error, 2)
+	go func() { errs <- ignoreClosed(smtpSrv.ListenAndServe()) }()
+	go func() { errs <- ignoreClosed(imapSrv.ListenAndServe(cli.IMAPAddr)) }()
+
+	fmt.Fprintf(os.Stderr, "darbaan: SMTP on %s, IMAP on %s (sluice %s, inbound %s)\n",
+		cli.ListenerAddr, cli.IMAPAddr, cli.SluiceDB, cli.InboundDB)
+
+	// Return on the first face to exit; close the other and drain it.
+	err = <-errs
+	_ = smtpSrv.Close()
+	_ = imapSrv.Close()
+	<-errs
+	return err
 }
 
 // QueueCmd groups the queue inspection and decision subcommands.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -40,6 +40,11 @@ listener-tls-cert: ""          # path to the TLS certificate (PEM)
 listener-tls-key: ""           # path to the TLS private key (PEM)
 listener-allow-insecure: false # permit AUTH over plaintext — local testing only
 
+# IMAP read face: the agent reads its Darbaan-generated messages (bounces) from
+# the inbound store over standard IMAP. One service hosts both faces (ADR 0001);
+# the IMAP face reuses the agent credential and the listener TLS above.
+imap-addr: ":1143"
+
 # The agent's Darbaan SMTP username. The password is NOT configured here: it is
 # supplied out-of-band via DARBAAN_AGENT_PASS, a reference to the encrypted
 # store (ADR 0012). Secrets are never inlined in config.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/alecthomas/kong v1.15.0
 	github.com/alecthomas/kong-yaml v0.2.0
+	github.com/emersion/go-imap/v2 v2.0.0-beta.8
 	github.com/emersion/go-message v0.18.2
 	github.com/emersion/go-msgauth v0.7.0
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW5
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/emersion/go-imap/v2 v2.0.0-beta.8 h1:5IXZK1E33DyeP526320J3RS7eFlCYGFgtbrfapqDPug=
+github.com/emersion/go-imap/v2 v2.0.0-beta.8/go.mod h1:dhoFe2Q0PwLrMD7oZw8ODuaD0vLYPe5uj2wcOMnvh48=
 github.com/emersion/go-message v0.18.2 h1:rl55SQdjd9oJcIoQNhubD2Acs1E6IzlZISRTK7x/Lpg=
 github.com/emersion/go-message v0.18.2/go.mod h1:XpJyL70LwRvq2a8rVbHXikPgKj8+aI0kGdHlg16ibYA=
 github.com/emersion/go-msgauth v0.7.0 h1:vj2hMn6KhFtW41kshIBTXvp6KgYSqpA/ZN9Pv4g1INc=

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -90,6 +90,37 @@ func (s *bboltStore) List(owner string) ([]Message, error) {
 	return out, nil
 }
 
+func (s *bboltStore) SetSeen(owner, id string, seen bool) error {
+	seq, err := strconv.ParseUint(id, 10, 64)
+	if err != nil {
+		return fmt.Errorf("%w: invalid id %q", ErrNotFound, id)
+	}
+	key := seqkey.Encode(seq)
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketInbound)
+		v := b.Get(key)
+		if v == nil {
+			return ErrNotFound
+		}
+		var m Message
+		if err := json.Unmarshal(v, &m); err != nil {
+			return err
+		}
+		if m.Owner != owner {
+			return ErrNotFound // do not touch another owner's message
+		}
+		if m.Seen == seen {
+			return nil
+		}
+		m.Seen = seen
+		enc, err := json.Marshal(m)
+		if err != nil {
+			return err
+		}
+		return b.Put(key, enc)
+	})
+}
+
 func (s *bboltStore) Get(owner, id string) (Message, error) {
 	seq, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -46,6 +46,9 @@ type InboundStore interface {
 	List(owner string) ([]Message, error)
 	// Get returns one of the owner's messages, or ErrNotFound.
 	Get(owner, id string) (Message, error)
+	// SetSeen sets or clears the \Seen flag on the owner's message — the only
+	// mutable flag the v1 IMAP face persists. Owner-scoped like Get.
+	SetSeen(owner, id string, seen bool) error
 	// Close releases the underlying resources.
 	Close() error
 }

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -61,3 +61,24 @@ func TestUnknownTypeErrors(t *testing.T) {
 	_, err := inbound.New("does-not-exist", "x.db")
 	require.Error(t, err)
 }
+
+func TestSetSeen(t *testing.T) {
+	s := newStore(t)
+	m, err := s.Add(inbound.Delivery{Owner: "agent", Raw: []byte("x")})
+	require.NoError(t, err)
+	require.False(t, m.Seen)
+
+	require.NoError(t, s.SetSeen("agent", m.ID, true))
+	got, err := s.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.True(t, got.Seen)
+
+	require.NoError(t, s.SetSeen("agent", m.ID, false))
+	got, err = s.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Seen)
+
+	// owner-scoped + not-found
+	require.ErrorIs(t, s.SetSeen("other", m.ID, true), inbound.ErrNotFound)
+	require.ErrorIs(t, s.SetSeen("agent", "999", true), inbound.ErrNotFound)
+}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -1,0 +1,330 @@
+package listener
+
+import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-message/textproto"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// imapMailbox is the only mailbox the v1 read face exposes.
+const imapMailbox = "INBOX"
+
+// errReadOnly is returned for every mutating IMAP operation: the v1 face serves
+// Darbaan-generated bounces read-only (ADR 0006), it is not a managed mailbox.
+var errReadOnly = errors.New("imap: read-only mailbox (serves Darbaan-generated messages only)")
+
+// IMAPServerConfig configures the IMAP read face.
+type IMAPServerConfig struct {
+	Addr          string
+	TLSConfig     *tls.Config // enables STARTTLS; required unless AllowInsecure
+	AllowInsecure bool        // permit AUTH over plaintext — local/testing only
+}
+
+// IMAPServer serves the agent's mailbox (the InboundStore) over IMAP as a
+// translation adapter (ADR 0016): the store is canonical, there is no upstream
+// IMAP proxy and no upstream fetch in v1.
+type IMAPServer struct {
+	imap *imapserver.Server
+}
+
+// NewIMAPServer wires the IMAP read face. TLS is required unless AllowInsecure
+// is set (local/testing), mirroring the SMTP face.
+func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore) (*IMAPServer, error) {
+	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
+		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
+	}
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return &imapSession{cred: cred, store: store}, nil, nil
+		},
+		TLSConfig:    cfg.TLSConfig,
+		InsecureAuth: cfg.AllowInsecure,
+	})
+	return &IMAPServer{imap: srv}, nil
+}
+
+// ListenAndServe binds addr and serves until Close is called.
+func (s *IMAPServer) ListenAndServe(addr string) error { return s.imap.ListenAndServe(addr) }
+
+// Serve serves on an already-open listener (used by tests).
+func (s *IMAPServer) Serve(l net.Listener) error { return s.imap.Serve(l) }
+
+// Close stops the server.
+func (s *IMAPServer) Close() error { return s.imap.Close() }
+
+// imapSession is one IMAP connection, hard-scoped after Login to the
+// authenticated agent (owner). Every store access is owner-keyed, so a session
+// can only ever see the agent's own messages.
+type imapSession struct {
+	cred     Credential
+	store    inbound.InboundStore
+	owner    string
+	authed   bool
+	selected []inbound.Message // snapshot taken at Select
+}
+
+func (s *imapSession) Close() error { return nil }
+
+func (s *imapSession) Login(username, password string) error {
+	if !constEqual(username, s.cred.Username) || !constEqual(password, s.cred.Password) {
+		return imapserver.ErrAuthFailed
+	}
+	s.owner = username
+	s.authed = true
+	return nil
+}
+
+func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.SelectData, error) {
+	if mailbox != imapMailbox {
+		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
+	}
+	msgs, err := s.store.List(s.owner)
+	if err != nil {
+		return nil, err
+	}
+	s.selected = msgs
+
+	var firstUnseen, uidNext uint32
+	for i, m := range msgs {
+		uid := uint32(uidOf(m))
+		if uid >= uidNext {
+			uidNext = uid + 1
+		}
+		if !m.Seen && firstUnseen == 0 {
+			firstUnseen = uint32(i) + 1
+		}
+	}
+	return &imap.SelectData{
+		Flags:             []imap.Flag{imap.FlagSeen},
+		PermanentFlags:    []imap.Flag{imap.FlagSeen},
+		NumMessages:       uint32(len(msgs)),
+		FirstUnseenSeqNum: firstUnseen,
+		UIDNext:           imap.UID(uidNext),
+		UIDValidity:       1,
+	}, nil
+}
+
+func (s *imapSession) Unselect() error {
+	s.selected = nil
+	return nil
+}
+
+func (s *imapSession) Status(mailbox string, options *imap.StatusOptions) (*imap.StatusData, error) {
+	if mailbox != imapMailbox {
+		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
+	}
+	msgs, err := s.store.List(s.owner)
+	if err != nil {
+		return nil, err
+	}
+	data := &imap.StatusData{Mailbox: mailbox}
+	if options.NumMessages {
+		n := uint32(len(msgs))
+		data.NumMessages = &n
+	}
+	if options.NumUnseen {
+		var unseen uint32
+		for _, m := range msgs {
+			if !m.Seen {
+				unseen++
+			}
+		}
+		data.NumUnseen = &unseen
+	}
+	var uidNext uint32
+	for _, m := range msgs {
+		if u := uint32(uidOf(m)); u >= uidNext {
+			uidNext = u + 1
+		}
+	}
+	if options.UIDNext {
+		data.UIDNext = imap.UID(uidNext)
+	}
+	if options.UIDValidity {
+		data.UIDValidity = 1
+	}
+	return data, nil
+}
+
+func (s *imapSession) List(w *imapserver.ListWriter, _ string, patterns []string, _ *imap.ListOptions) error {
+	if len(patterns) == 0 {
+		return nil // LIST "" "" is a delimiter query; nothing to enumerate
+	}
+	return w.WriteList(&imap.ListData{
+		Mailbox: imapMailbox,
+		Delim:   '/',
+	})
+}
+
+func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error {
+	markSeen := false
+	for _, bs := range options.BodySection {
+		if !bs.Peek {
+			markSeen = true
+			break
+		}
+	}
+
+	var ferr error
+	s.forEach(numSet, func(seqNum uint32, m inbound.Message) {
+		if ferr != nil {
+			return
+		}
+		if markSeen && !m.Seen {
+			if err := s.store.SetSeen(s.owner, m.ID, true); err != nil {
+				ferr = err
+				return
+			}
+			m.Seen = true
+		}
+		ferr = fetchMessage(w.CreateMessage(seqNum), m, options)
+	})
+	return ferr
+}
+
+func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, _ *imap.StoreOptions) error {
+	seen, touchesSeen := seenFromStoreFlags(flags)
+
+	var serr error
+	s.forEach(numSet, func(seqNum uint32, m inbound.Message) {
+		if serr != nil {
+			return
+		}
+		if touchesSeen && m.Seen != seen {
+			if err := s.store.SetSeen(s.owner, m.ID, seen); err != nil {
+				serr = err
+				return
+			}
+			m.Seen = seen
+		}
+		if flags.Silent {
+			return
+		}
+		rw := w.CreateMessage(seqNum)
+		rw.WriteUID(uidOf(m))
+		rw.WriteFlags(flagList(m))
+		if err := rw.Close(); err != nil {
+			serr = err
+		}
+	})
+	return serr
+}
+
+// forEach calls fn for each selected message matching numSet, computing its
+// sequence number (position) and resolving UID vs sequence membership.
+func (s *imapSession) forEach(numSet imap.NumSet, fn func(seqNum uint32, m inbound.Message)) {
+	for i, m := range s.selected {
+		seqNum := uint32(i) + 1
+		var match bool
+		switch set := numSet.(type) {
+		case imap.SeqSet:
+			match = set.Contains(seqNum)
+		case imap.UIDSet:
+			match = set.Contains(uidOf(m))
+		}
+		if match {
+			fn(seqNum, m)
+		}
+	}
+}
+
+// The mutating operations are unsupported: the v1 face is a read-only view of
+// Darbaan-generated messages.
+func (s *imapSession) Create(string, *imap.CreateOptions) error              { return errReadOnly }
+func (s *imapSession) Delete(string) error                                   { return errReadOnly }
+func (s *imapSession) Rename(string, string, *imap.RenameOptions) error      { return errReadOnly }
+func (s *imapSession) Subscribe(string) error                                { return errReadOnly }
+func (s *imapSession) Unsubscribe(string) error                              { return errReadOnly }
+func (s *imapSession) Expunge(*imapserver.ExpungeWriter, *imap.UIDSet) error { return errReadOnly }
+func (s *imapSession) Copy(imap.NumSet, string) (*imap.CopyData, error)      { return nil, errReadOnly }
+
+func (s *imapSession) Append(string, imap.LiteralReader, *imap.AppendOptions) (*imap.AppendData, error) {
+	return nil, errReadOnly
+}
+
+func (s *imapSession) Search(imapserver.NumKind, *imap.SearchCriteria, *imap.SearchOptions) (*imap.SearchData, error) {
+	return nil, errors.New("imap: SEARCH not supported in v1 (FETCH 1:* instead)")
+}
+
+// No mailbox changes happen out-of-band, so polling and idling are no-ops.
+func (s *imapSession) Poll(*imapserver.UpdateWriter, bool) error { return nil }
+
+func (s *imapSession) Idle(_ *imapserver.UpdateWriter, stop <-chan struct{}) error {
+	<-stop
+	return nil
+}
+
+func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions) error {
+	w.WriteUID(uidOf(m))
+	if options.Flags {
+		w.WriteFlags(flagList(m))
+	}
+	if options.InternalDate {
+		w.WriteInternalDate(m.ReceivedAt)
+	}
+	if options.RFC822Size {
+		w.WriteRFC822Size(int64(len(m.Raw)))
+	}
+	if options.Envelope {
+		if h, err := textproto.ReadHeader(bufio.NewReader(bytes.NewReader(m.Raw))); err == nil {
+			w.WriteEnvelope(imapserver.ExtractEnvelope(h))
+		}
+	}
+	if options.BodyStructure != nil {
+		w.WriteBodyStructure(imapserver.ExtractBodyStructure(bytes.NewReader(m.Raw)))
+	}
+	for _, bs := range options.BodySection {
+		buf := imapserver.ExtractBodySection(bytes.NewReader(m.Raw), bs)
+		wc := w.WriteBodySection(bs, int64(len(buf)))
+		_, writeErr := wc.Write(buf)
+		closeErr := wc.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+	}
+	return w.Close()
+}
+
+func flagList(m inbound.Message) []imap.Flag {
+	if m.Seen {
+		return []imap.Flag{imap.FlagSeen}
+	}
+	return []imap.Flag{}
+}
+
+func seenFromStoreFlags(sf *imap.StoreFlags) (seen, touches bool) {
+	hasSeen := false
+	for _, f := range sf.Flags {
+		if f == imap.FlagSeen {
+			hasSeen = true
+		}
+	}
+	switch sf.Op {
+	case imap.StoreFlagsAdd:
+		return true, hasSeen
+	case imap.StoreFlagsDel:
+		return false, hasSeen
+	case imap.StoreFlagsSet:
+		// SET replaces all flags, so \Seen's presence is the target value.
+		return hasSeen, true
+	}
+	return false, false
+}
+
+func uidOf(m inbound.Message) imap.UID {
+	n, _ := strconv.ParseUint(m.ID, 10, 32)
+	return imap.UID(n)
+}

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -1,0 +1,103 @@
+package listener_test
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/listener"
+)
+
+func seedInbound(t *testing.T) inbound.InboundStore {
+	t.Helper()
+	s, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	_, err = s.Add(inbound.Delivery{
+		Owner:   "agent",
+		From:    "MAILER-DAEMON@darbaan.test",
+		To:      "sender@local",
+		Subject: "Undelivered Mail Returned to Sender",
+		Raw:     []byte("From: MAILER-DAEMON@darbaan.test\r\nSubject: Undelivered Mail\r\n\r\nrefused-marker\r\n"),
+	})
+	require.NoError(t, err)
+	return s
+}
+
+func startIMAP(t *testing.T, store inbound.InboundStore) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
+		listener.Credential{Username: "agent", Password: "pw"}, store)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+func TestIMAPFetchMarksSeenAndPersists(t *testing.T) {
+	store := seedInbound(t)
+	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+
+	require.NoError(t, c.Login("agent", "pw").Wait())
+
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), sel.NumMessages)
+
+	// Non-peek BODY[] fetch returns the bounce and marks it \Seen.
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		UID:         true,
+		Flags:       true,
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, string(msgs[0].FindBodySection(&imap.FetchItemBodySection{})), "refused-marker")
+
+	got, err := store.Get("agent", "1")
+	require.NoError(t, err)
+	assert.True(t, got.Seen) // \Seen persisted across the fetch
+}
+
+func TestIMAPStoreUnsetSeenPersists(t *testing.T) {
+	store := seedInbound(t)
+	require.NoError(t, store.SetSeen("agent", "1", true))
+
+	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	_, err = c.Store(imap.SeqSetNum(1),
+		&imap.StoreFlags{Op: imap.StoreFlagsDel, Flags: []imap.Flag{imap.FlagSeen}}, nil).Collect()
+	require.NoError(t, err)
+
+	got, err := store.Get("agent", "1")
+	require.NoError(t, err)
+	assert.False(t, got.Seen) // \Seen cleared and persisted
+}
+
+func TestIMAPBadAuthRejected(t *testing.T) {
+	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.Error(t, c.Login("agent", "wrong").Wait())
+}
+
+func TestIMAPRequiresTLS(t *testing.T) {
+	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
+		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t))
+	require.Error(t, err)
+}


### PR DESCRIPTION
The IMAP read face — the agent reads its Darbaan-generated bounces over standard IMAP. Closes the end-to-end MVP: **send → trap → approve/reject → signed bounce → read it back** (ADR 0001, 0006).

## `internal/listener` — the IMAP face
A `go-imap/v2` (`imapserver`) face serving the **InboundStore** as a translation adapter (ADR 0016): the store is canonical, **no upstream IMAP proxy and no upstream fetch** in v1.
- A **read-only, owner-scoped session**: `Login` binds the session to the authenticated agent; `Select` / `Status` / `List` / `Fetch` over `INBOX`; `Store \Seen` → `SetSeen`. Every mutating op (`Create`/`Delete`/`Rename`/`Subscribe`/`Append`/`Expunge`/`Copy`) returns read-only; `Search` is not supported in v1 (FETCH 1:* instead).
- **Owner isolation**: the session is hard-scoped to the authenticated agent and every store access is owner-keyed, so it can only ever serve the agent's own mail.
- TLS + per-agent auth, mirroring the SMTP face.
- FETCH item handling (envelope / body sections / bodystructure) is done with go-imap's `Extract*` helpers — no hand-rolled MIME (ADR 0014).

## 2-package touch (called out per the issue)
- **`internal/inbound`** — `SetSeen(owner, id, seen)` added to the interface + bbolt impl. **\Seen is the only mutable flag persisted in v1** (no delete/expunge, no other flags — deferred post-MVP).
- **`internal/listener`** — the IMAP face (new `imap.go`).
- (cmd) `serve` now hosts **both faces** concurrently (ADR 0001); new `imap-addr` config, reusing the agent credential + listener TLS (single-agent/single-host, ADR 0010).

## Library
`emersion/go-imap/v2` v2.0.0-beta.8 — the current v2 server API (v1's is legacy); pinned in go.mod (deliberate bumps only). Adapted the `imapmemserver` reference.

## Verification
- `go build`/`vet`/`gofmt -l` clean; `go test -race ./...` green; `golangci-lint` (v2.11.4) 0 issues.
- listener IMAP tests (real go-imap client over a localhost listener): FETCH BODY[] returns the bounce and **marks \Seen persisted**; STORE -\Seen clears it persisted; bad auth rejected; TLS-required invariant. inbound `SetSeen` test covers set/clear + owner-scope.
- Smoke: `serve` binds **both** the SMTP and IMAP faces.

## Hard constraint
Sender stays stubbed; nothing sends. This is the last MVP increment — the loop is now end-to-end.

closes #27
