### PR TITLE
fix: distinguish bounce-delivery failure from reject failure

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -294,7 +294,7 @@ func (c *QueueApproveCmd) Run(cli *CLI) error {
 	defer closeStore()
 
 	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, cli.router(),
-		nil, nil, "", c.ID, approver.Verdict{Disposition: approver.Approve})
+		c.ID, approver.Verdict{Disposition: approver.Approve})
 	if err != nil {
 		return err
 	}
@@ -339,19 +339,50 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 	}
 
 	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, cli.router(),
-		inbox, sgn, cli.ListenerDomain, c.ID, approver.Verdict{Disposition: approver.Reject, Reason: c.Reason, Retryable: c.Retryable})
+		c.ID, approver.Verdict{Disposition: approver.Reject, Reason: c.Reason, Retryable: c.Retryable})
 	if err != nil {
 		return err
 	}
-	switch m.Status {
-	case sluice.StatusRejected:
-		kind := "permanent"
-		if m.Retryable {
-			kind = "transient"
-		}
-		fmt.Printf("message %s rejected by %s (%s): %s\n", m.ID, m.DecidedBy, kind, m.Reason)
-	default:
+	if m.Status != sluice.StatusRejected {
 		fmt.Printf("message %s: still %s, no verdict applied\n", m.ID, m.Status)
+		return nil
+	}
+
+	// The rejection has committed; report it first. Bounce delivery is a
+	// distinct, downstream step.
+	kind := "permanent"
+	if m.Retryable {
+		kind = "transient"
+	}
+	fmt.Printf("message %s rejected by %s (%s): %s\n", m.ID, m.DecidedBy, kind, m.Reason)
+
+	if err := deliverBounce(inbox, sgn, m, cli.ListenerDomain); err != nil {
+		// The reject stuck; only the bounce failed. Surface it as its own signal
+		// — the agent was NOT notified and the bounce needs redelivery — never as
+		// a reject failure (ADR 0006).
+		return fmt.Errorf("message %s rejected, but bounce delivery FAILED (agent not notified, needs redelivery): %w", m.ID, err)
+	}
+	fmt.Printf("  bounce delivered to %s\n", m.Agent)
+	return nil
+}
+
+// deliverBounce generates, signs, and delivers the DSN bounce for an
+// already-rejected message. It is a distinct step from the rejection: a failure
+// here means "rejected, but the agent was not notified," not a reject failure
+// (ADR 0006). Signing is required (ADR 0007).
+func deliverBounce(inbox inbound.InboundStore, sgn bounceSigner, m sluice.Message, domain string) error {
+	b, err := bounce.Generate(m, m.Reason, m.Retryable, domain)
+	if err != nil {
+		return fmt.Errorf("generate: %w", err)
+	}
+	signed, err := sgn.Sign(b.Raw)
+	if err != nil {
+		return fmt.Errorf("sign: %w", err)
+	}
+	if _, err := inbox.Add(inbound.Delivery{
+		Owner: b.Owner, From: b.From, To: b.To, Subject: b.Subject, Raw: signed,
+	}); err != nil {
+		return fmt.Errorf("store: %w", err)
 	}
 	return nil
 }
@@ -362,7 +393,7 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 // message is marked approved and handed to the (stubbed) Sender; the send result
 // is recorded and audited, never silently dropped (ADR 0003). On rejection the
 // reason is recorded. A Hold leaves the message pending.
-func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.Sender, router *policy.Router, inbox inbound.InboundStore, sgn bounceSigner, domain string, id string, human approver.Verdict) (sluice.Message, error) {
+func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.Sender, router *policy.Router, id string, human approver.Verdict) (sluice.Message, error) {
 	msg, err := q.Get(id)
 	if err != nil {
 		return sluice.Message{}, err
@@ -403,34 +434,10 @@ func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.S
 		sendErr := sender.Send(ctx, approved)
 		return q.RecordSendAttempt(id, sendErr)
 	case approver.Reject:
-		rejected, err := q.Reject(id, outcome.DecidedBy, outcome.Reason, outcome.Retryable)
-		if err != nil {
-			return sluice.Message{}, err
-		}
-		// Generate the DSN bounce and deliver it to the agent's mailbox
-		// (ADR 0006). The rejected submission stays in the sluice; the bounce is
-		// a separate inbound object the IMAP face serves (#27).
-		if inbox != nil {
-			b, err := bounce.Generate(rejected, outcome.Reason, outcome.Retryable, domain)
-			if err != nil {
-				return sluice.Message{}, fmt.Errorf("generate bounce: %w", err)
-			}
-			// Sign before store (ADR 0007): the stored bounce is already signed,
-			// so the IMAP face serves it verbatim. Fail closed if no signer.
-			if sgn == nil {
-				return sluice.Message{}, fmt.Errorf("deliver bounce: signing required but no signer configured")
-			}
-			signed, err := sgn.Sign(b.Raw)
-			if err != nil {
-				return sluice.Message{}, fmt.Errorf("sign bounce: %w", err)
-			}
-			if _, err := inbox.Add(inbound.Delivery{
-				Owner: b.Owner, From: b.From, To: b.To, Subject: b.Subject, Raw: signed,
-			}); err != nil {
-				return sluice.Message{}, fmt.Errorf("deliver bounce: %w", err)
-			}
-		}
-		return rejected, nil
+		// Commit the rejection. The DSN bounce is a distinct, downstream step
+		// (deliverBounce) so a delivery failure is never mistaken for a reject
+		// failure (ADR 0006).
+		return q.Reject(id, outcome.DecidedBy, outcome.Reason, outcome.Retryable)
 	default: // Hold — stays pending, fail-closed
 		return msg, nil
 	}

--- a/cmd/darbaan/main_test.go
+++ b/cmd/darbaan/main_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -45,7 +46,7 @@ func TestApproveReachesStubSenderAndNothingLeaves(t *testing.T) {
 	q, id := newSeededSluice(t)
 
 	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, nil, "", id, approver.Verdict{Disposition: approver.Approve})
+		id, approver.Verdict{Disposition: approver.Approve})
 	require.NoError(t, err)
 
 	assert.Equal(t, sluice.StatusApproved, out.Status)
@@ -54,17 +55,18 @@ func TestApproveReachesStubSenderAndNothingLeaves(t *testing.T) {
 	assert.Equal(t, backend.ErrSendPending.Error(), out.SendErr)
 }
 
-func TestRejectGeneratesBounceIntoInbound(t *testing.T) {
+func TestRejectCommitsAndBounceDelivers(t *testing.T) {
 	q, id := newSeededSluice(t)
 	inbox, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
 	require.NoError(t, err)
 	defer func() { _ = inbox.Close() }()
 
-	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		inbox, testSigner(t), "darbaan.test", id, approver.Verdict{Disposition: approver.Reject, Reason: "smells like exfiltration", Retryable: false})
+	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Reject, Reason: "smells like exfiltration", Retryable: false})
 	require.NoError(t, err)
-	assert.Equal(t, sluice.StatusRejected, out.Status)
-	assert.Equal(t, "smells like exfiltration", out.Reason)
+	require.Equal(t, sluice.StatusRejected, m.Status)
+
+	require.NoError(t, deliverBounce(inbox, testSigner(t), m, "darbaan.test"))
 
 	// A DSN bounce was delivered to the agent's inbound mailbox (ADR 0006),
 	// already DKIM-signed (ADR 0007).
@@ -79,6 +81,39 @@ func TestRejectGeneratesBounceIntoInbound(t *testing.T) {
 	assert.Contains(t, string(b.Raw), "5.7.1")           // permanent policy reject
 	assert.Contains(t, string(b.Raw), "DKIM-Signature:") // signed before store
 }
+
+// TestBounceFailureDistinctFromReject covers #35: a bounce-delivery failure
+// must not look like a reject failure — the reject commits regardless.
+func TestBounceFailureDistinctFromReject(t *testing.T) {
+	q, id := newSeededSluice(t)
+
+	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+		id, approver.Verdict{Disposition: approver.Reject, Reason: "no", Retryable: false})
+	require.NoError(t, err)
+	require.Equal(t, sluice.StatusRejected, m.Status)
+
+	// Bounce delivery to a failing store errors distinctly...
+	require.Error(t, deliverBounce(failingInbound{}, testSigner(t), m, "darbaan.test"))
+
+	// ...but the reject already stuck (the store still shows it rejected).
+	got, err := q.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusRejected, got.Status)
+}
+
+// failingInbound errors on Add, to prove a bounce-delivery failure is reported
+// distinctly from the (already-committed) reject.
+type failingInbound struct{}
+
+func (failingInbound) Add(inbound.Delivery) (inbound.Message, error) {
+	return inbound.Message{}, errors.New("inbound store down")
+}
+func (failingInbound) List(string) ([]inbound.Message, error) { return nil, nil }
+func (failingInbound) Get(string, string) (inbound.Message, error) {
+	return inbound.Message{}, inbound.ErrNotFound
+}
+func (failingInbound) SetSeen(string, string, bool) error { return nil }
+func (failingInbound) Close() error                       { return nil }
 
 func testSigner(t *testing.T) *signer.Signer {
 	t.Helper()
@@ -100,7 +135,7 @@ func TestNoDecisionLeavesPending(t *testing.T) {
 	// A Hold verdict (the human took no action) must leave the message pending —
 	// fail-closed.
 	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, nil, "", id, approver.Verdict{Disposition: approver.Hold})
+		id, approver.Verdict{Disposition: approver.Hold})
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusPending, out.Status)
 
@@ -113,10 +148,10 @@ func TestApproveTwiceIsRefused(t *testing.T) {
 	q, id := newSeededSluice(t)
 
 	_, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, nil, "", id, approver.Verdict{Disposition: approver.Approve})
+		id, approver.Verdict{Disposition: approver.Approve})
 	require.NoError(t, err)
 
 	_, err = decideAndApply(context.Background(), q, backend.StubSender{}, router(),
-		nil, nil, "", id, approver.Verdict{Disposition: approver.Approve})
+		id, approver.Verdict{Disposition: approver.Approve})
 	require.Error(t, err) // already approved, not pending
 }


### PR DESCRIPTION
Follow-up from #33/#38 review consensus.

A bounce is the correction-loop notification (ADR 0006), not a side-record. The old code returned a generic error on bounce-delivery failure, implying the **reject** failed — when the reject had committed and only delivery failed.

## Fix
`decideAndApply`'s reject branch now only commits the rejection (source of truth). Bounce generate/sign/deliver moves to a separate `deliverBounce` step the reject command calls afterward. On failure the command prints the rejection (it stuck), then returns a **distinct** `rejected, but bounce delivery FAILED (agent not notified, needs redelivery)` error — never a generic reject-failed error.

## Tests
- `TestRejectCommitsAndBounceDelivers` — happy path (reject commits, signed bounce delivered).
- `TestBounceFailureDistinctFromReject` — a failing inbound store errors distinctly, but the reject still shows committed in the store.

Touches only `cmd/darbaan`. build/vet/gofmt/race/golangci-lint clean.

closes #35
