### PR TITLE
fix: imap uidNext=1 (empty mailbox) + same-session Seen sync

### DIFF
--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -94,7 +94,7 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 	}
 	s.selected = msgs
 
-	var firstUnseen, uidNext uint32
+	firstUnseen, uidNext := uint32(0), uint32(1) // UID 0 is invalid (RFC 3501)
 	for i, m := range msgs {
 		uid := uint32(uidOf(m))
 		if uid >= uidNext {
@@ -141,7 +141,7 @@ func (s *imapSession) Status(mailbox string, options *imap.StatusOptions) (*imap
 		}
 		data.NumUnseen = &unseen
 	}
-	var uidNext uint32
+	uidNext := uint32(1) // UID 0 is invalid (RFC 3501)
 	for _, m := range msgs {
 		if u := uint32(uidOf(m)); u >= uidNext {
 			uidNext = u + 1
@@ -176,7 +176,7 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 	}
 
 	var ferr error
-	s.forEach(numSet, func(seqNum uint32, m inbound.Message) {
+	s.forEach(numSet, func(seqNum uint32, m *inbound.Message) {
 		if ferr != nil {
 			return
 		}
@@ -185,9 +185,9 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 				ferr = err
 				return
 			}
-			m.Seen = true
+			m.Seen = true // also updates s.selected via the pointer
 		}
-		ferr = fetchMessage(w.CreateMessage(seqNum), m, options)
+		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options)
 	})
 	return ferr
 }
@@ -196,7 +196,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 	seen, touchesSeen := seenFromStoreFlags(flags)
 
 	var serr error
-	s.forEach(numSet, func(seqNum uint32, m inbound.Message) {
+	s.forEach(numSet, func(seqNum uint32, m *inbound.Message) {
 		if serr != nil {
 			return
 		}
@@ -205,14 +205,14 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 				serr = err
 				return
 			}
-			m.Seen = seen
+			m.Seen = seen // also updates s.selected via the pointer
 		}
 		if flags.Silent {
 			return
 		}
 		rw := w.CreateMessage(seqNum)
-		rw.WriteUID(uidOf(m))
-		rw.WriteFlags(flagList(m))
+		rw.WriteUID(uidOf(*m))
+		rw.WriteFlags(flagList(*m))
 		if err := rw.Close(); err != nil {
 			serr = err
 		}
@@ -221,16 +221,19 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 }
 
 // forEach calls fn for each selected message matching numSet, computing its
-// sequence number (position) and resolving UID vs sequence membership.
-func (s *imapSession) forEach(numSet imap.NumSet, fn func(seqNum uint32, m inbound.Message)) {
-	for i, m := range s.selected {
+// sequence number (position) and resolving UID vs sequence membership. fn
+// receives a pointer into s.selected, so flag updates it makes are reflected in
+// later in-session reads (e.g. a FLAGS query after a body fetch).
+func (s *imapSession) forEach(numSet imap.NumSet, fn func(seqNum uint32, m *inbound.Message)) {
+	for i := range s.selected {
+		m := &s.selected[i]
 		seqNum := uint32(i) + 1
 		var match bool
 		switch set := numSet.(type) {
 		case imap.SeqSet:
 			match = set.Contains(seqNum)
 		case imap.UIDSet:
-			match = set.Contains(uidOf(m))
+			match = set.Contains(uidOf(*m))
 		}
 		if match {
 			fn(seqNum, m)

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -89,6 +89,44 @@ func TestIMAPStoreUnsetSeenPersists(t *testing.T) {
 	assert.False(t, got.Seen) // \Seen cleared and persisted
 }
 
+func TestIMAPSameSessionSeenSync(t *testing.T) {
+	store := seedInbound(t)
+	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	// A non-peek body fetch marks \Seen.
+	_, err = c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+
+	// A later FLAGS-only fetch in the SAME session reflects \Seen (not stale).
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{Flags: true}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].Flags, imap.FlagSeen)
+}
+
+func TestIMAPEmptyMailboxUIDNext(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "empty.db"))
+	require.NoError(t, err)
+	defer func() { _ = store.Close() }()
+
+	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0), sel.NumMessages)
+	assert.Equal(t, imap.UID(1), sel.UIDNext) // UID 0 invalid; empty mailbox → 1
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
The two deferred nits from #38 (sora-rubigd review).

1. **UIDNEXT for an empty mailbox** — was 0; RFC 3501 reserves UID 0 as invalid. Now initialized to 1 in `Select` and `Status`.
2. **Same-session \Seen sync** — `Fetch`/`Store` marked `\Seen` on a local copy only, so a FLAGS read after a body fetch in the same session showed stale state. `forEach` now passes a pointer into `s.selected`, so in-session flag updates are reflected in later reads.

## Tests
- `TestIMAPSameSessionSeenSync` — body fetch marks \Seen, a later FLAGS-only fetch in the same session reflects it.
- `TestIMAPEmptyMailboxUIDNext` — empty mailbox reports UIDNEXT 1.

Touches only `internal/listener/imap.go`. build/vet/gofmt/race/golangci-lint clean.

closes #39
