### PR TITLE
ci: add Dependabot (gomod + github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      # Batch minor + patch bumps into one PR to cut review noise; majors still
+      # arrive as individual PRs.
+      go-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Add `.github/dependabot.yml` so dependency + Actions updates arrive as CI-gated PRs.

- **gomod** (Go deps) and **github-actions** (workflow pins), both **weekly**.
- **Minor/patch grouped** per ecosystem into one PR (majors arrive individually).
- `open-pull-requests-limit: 5` per ecosystem.

Dependabot PRs are auto-gated by the CI workflow (#12). Config-only.

closes #36
