### PR TITLE
feat: real Gmail SMTP Sender (the opt-in default-deny flip)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -53,6 +53,10 @@ type CLI struct {
 	DKIMSelector string `name:"dkim-selector" default:"darbaan" help:"DKIM selector for bounce signatures."`
 	DKIMDomain   string `name:"dkim-domain" help:"DKIM signing domain (d=) for bounce signatures."`
 
+	SenderType   string `name:"sender-type" default:"stub" help:"Upstream sender: stub (default — nothing sends, default-deny holds) or smtp (real delivery; the deliberate flip)." enum:"stub,smtp"`
+	SMTPHost     string `name:"smtp-host" default:"smtp.gmail.com:587" help:"Upstream SMTP submission host:port (sender-type=smtp)."`
+	SMTPUsername string `name:"smtp-username" help:"Upstream SMTP username (sender-type=smtp). The app password is supplied via DARBAAN_SMTP_PASSWORD, never inlined."`
+
 	ListenerAddr          string `name:"listener-addr" default:":1465" help:"SMTP submission listen address."`
 	ListenerDomain        string `name:"listener-domain" default:"localhost" help:"SMTP greeting domain."`
 	ListenerTLSCert       string `name:"listener-tls-cert" help:"Path to the TLS certificate (PEM)." type:"path"`
@@ -112,6 +116,17 @@ func (c *CLI) openInbound() (inbound.InboundStore, error) {
 // silently-unsigned bounce.
 func (c *CLI) openSigner() (*signer.Signer, error) {
 	return signer.New(c.DKIMKeyFile, c.DKIMSelector, c.DKIMDomain)
+}
+
+// openSender constructs the configured upstream Sender. The default (stub)
+// sends nothing, so default-deny holds until an operator sets sender-type=smtp
+// with credentials — the flip is a deliberate operator act, not a merge effect.
+func (c *CLI) openSender() (backend.Sender, error) {
+	return backend.New(c.SenderType, backend.Config{
+		Host:     c.SMTPHost,
+		Username: c.SMTPUsername,
+		Password: os.Getenv("DARBAAN_SMTP_PASSWORD"),
+	})
 }
 
 // bounceSigner signs a bounce before it is stored. *signer.Signer implements it.
@@ -293,21 +308,73 @@ func (c *QueueApproveCmd) Run(cli *CLI) error {
 	}
 	defer closeStore()
 
-	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, cli.router(),
+	sender, err := cli.openSender()
+	if err != nil {
+		return err
+	}
+
+	m, err := decideAndApply(context.Background(), q, cli.router(),
 		c.ID, approver.Verdict{Disposition: approver.Approve})
 	if err != nil {
 		return err
 	}
-	switch m.Status {
-	case sluice.StatusApproved:
-		fmt.Printf("message %s approved by %s\n", m.ID, m.DecidedBy)
-		if m.SendErr != "" {
-			fmt.Printf("  send: %s — nothing left Darbaan\n", m.SendErr)
-		}
-	default:
+	if m.Status != sluice.StatusApproved {
 		fmt.Printf("message %s: still %s, no verdict applied\n", m.ID, m.Status)
+		return nil
 	}
-	return nil
+	fmt.Printf("message %s approved by %s\n", m.ID, m.DecidedBy)
+
+	// Bounce deps are only needed if a real Sender can permanently fail; the
+	// stub never does, so don't require DKIM config in stub mode.
+	var inbox inbound.InboundStore
+	var sgn bounceSigner
+	if cli.SenderType != "stub" {
+		inbox, err = cli.openInbound()
+		if err != nil {
+			return err
+		}
+		defer func() { _ = inbox.Close() }()
+		if sgn, err = cli.openSigner(); err != nil {
+			return err
+		}
+	}
+	return sendApproved(context.Background(), q, sender, inbox, sgn, m, cli.ListenerDomain)
+}
+
+// sendApproved delivers an already-approved message to the upstream Sender and
+// applies the result — downstream of the approval commit, never inside the
+// decision (ADR 0003). On success the message is marked sent. On a permanent
+// (5xx) failure the agent is bounced (ADR 0006); on a transient failure the
+// message stays approved for a manual re-send and is NOT bounced. The stub
+// Sender's ErrSendPending is neither: default-deny simply holds.
+func sendApproved(ctx context.Context, q sluice.MessageStore, sender backend.Sender, inbox inbound.InboundStore, sgn bounceSigner, m sluice.Message, domain string) error {
+	sendErr := sender.Send(ctx, m)
+	if _, err := q.RecordSendAttempt(m.ID, sendErr); err != nil {
+		return err
+	}
+
+	switch {
+	case sendErr == nil:
+		fmt.Printf("  sent upstream\n")
+		return nil
+	case errors.Is(sendErr, backend.ErrSendPending):
+		fmt.Printf("  send pending: no real Sender configured — nothing left Darbaan\n")
+		return nil
+	case backend.IsPermanent(sendErr):
+		// Permanent failure: bounce the agent with a generic reason that never
+		// echoes the upstream response body.
+		if inbox == nil || sgn == nil {
+			return fmt.Errorf("message %s approved but upstream send FAILED permanently (no bounce path configured): %w", m.ID, sendErr)
+		}
+		if bErr := deliverBounce(inbox, sgn, m, "upstream delivery failed permanently", false, domain); bErr != nil {
+			return fmt.Errorf("message %s send FAILED permanently AND bounce delivery failed: %v (send: %w)", m.ID, bErr, sendErr)
+		}
+		fmt.Printf("  send FAILED permanently — bounced to %s\n", m.Agent)
+		return fmt.Errorf("message %s approved but upstream send FAILED permanently (bounced): %w", m.ID, sendErr)
+	default:
+		// Transient: stays approved for a manual re-send; no bounce, no retry loop.
+		return fmt.Errorf("message %s approved but upstream send failed (transient; stays approved for re-send): %w", m.ID, sendErr)
+	}
 }
 
 // QueueRejectCmd rejects a held message.
@@ -338,7 +405,7 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 		return err
 	}
 
-	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, cli.router(),
+	m, err := decideAndApply(context.Background(), q, cli.router(),
 		c.ID, approver.Verdict{Disposition: approver.Reject, Reason: c.Reason, Retryable: c.Retryable})
 	if err != nil {
 		return err
@@ -356,7 +423,7 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 	}
 	fmt.Printf("message %s rejected by %s (%s): %s\n", m.ID, m.DecidedBy, kind, m.Reason)
 
-	if err := deliverBounce(inbox, sgn, m, cli.ListenerDomain); err != nil {
+	if err := deliverBounce(inbox, sgn, m, m.Reason, m.Retryable, cli.ListenerDomain); err != nil {
 		// The reject stuck; only the bounce failed. Surface it as its own signal
 		// — the agent was NOT notified and the bounce needs redelivery — never as
 		// a reject failure (ADR 0006).
@@ -370,8 +437,8 @@ func (c *QueueRejectCmd) Run(cli *CLI) error {
 // already-rejected message. It is a distinct step from the rejection: a failure
 // here means "rejected, but the agent was not notified," not a reject failure
 // (ADR 0006). Signing is required (ADR 0007).
-func deliverBounce(inbox inbound.InboundStore, sgn bounceSigner, m sluice.Message, domain string) error {
-	b, err := bounce.Generate(m, m.Reason, m.Retryable, domain)
+func deliverBounce(inbox inbound.InboundStore, sgn bounceSigner, m sluice.Message, reason string, retryable bool, domain string) error {
+	b, err := bounce.Generate(m, reason, retryable, domain)
 	if err != nil {
 		return fmt.Errorf("generate: %w", err)
 	}
@@ -387,13 +454,14 @@ func deliverBounce(inbox inbound.InboundStore, sgn bounceSigner, m sluice.Messag
 	return nil
 }
 
-// decideAndApply runs the approval chain for one message and applies the
-// outcome. The human verdict is injected into the human stage of the chain — it
-// is one stage, never an override of the others (ADR 0004). On approval the
-// message is marked approved and handed to the (stubbed) Sender; the send result
-// is recorded and audited, never silently dropped (ADR 0003). On rejection the
-// reason is recorded. A Hold leaves the message pending.
-func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.Sender, router *policy.Router, id string, human approver.Verdict) (sluice.Message, error) {
+// decideAndApply runs the approval chain for one message and commits the
+// outcome — nothing more. The human verdict is injected into the human stage of
+// the chain — it is one stage, never an override of the others (ADR 0004).
+// Approve commits status=approved, Reject commits status=rejected, Hold leaves
+// it pending. Everything downstream of the commit (sending an approved message,
+// recording the send, bouncing on failure) lives in the caller, so this stays
+// pure and the send/bounce paths never re-entangle the decision.
+func decideAndApply(ctx context.Context, q sluice.MessageStore, router *policy.Router, id string, human approver.Verdict) (sluice.Message, error) {
 	msg, err := q.Get(id)
 	if err != nil {
 		return sluice.Message{}, err
@@ -424,15 +492,9 @@ func decideAndApply(ctx context.Context, q sluice.MessageStore, sender backend.S
 
 	switch outcome.Disposition {
 	case approver.Approve:
-		if _, err := q.Approve(id, outcome.DecidedBy, outcome.Released); err != nil {
-			return sluice.Message{}, err
-		}
-		approved, err := q.Get(id)
-		if err != nil {
-			return sluice.Message{}, err
-		}
-		sendErr := sender.Send(ctx, approved)
-		return q.RecordSendAttempt(id, sendErr)
+		// Commit only. The send is a distinct, downstream step (sendApproved)
+		// so a send failure is never mistaken for an approval failure.
+		return q.Approve(id, outcome.DecidedBy, outcome.Released)
 	case approver.Reject:
 		// Commit the rejection. The DSN bounce is a distinct, downstream step
 		// (deliverBounce) so a delivery failure is never mistaken for a reject

--- a/cmd/darbaan/main_test.go
+++ b/cmd/darbaan/main_test.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/emersion/go-smtp"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -42,17 +44,91 @@ func router() *policy.Router {
 	return policy.NewRouter([]string{"manual"}, []string{"manual"})
 }
 
-func TestApproveReachesStubSenderAndNothingLeaves(t *testing.T) {
+func TestApproveCommitsOnly(t *testing.T) {
 	q, id := newSeededSluice(t)
 
-	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+	out, err := decideAndApply(context.Background(), q, router(),
 		id, approver.Verdict{Disposition: approver.Approve})
 	require.NoError(t, err)
-
-	assert.Equal(t, sluice.StatusApproved, out.Status)
+	assert.Equal(t, sluice.StatusApproved, out.Status) // commit only; no send here
 	assert.Equal(t, "manual", out.DecidedBy)
-	// The stub Sender ran but nothing left: the send error is recorded, not dropped.
-	assert.Equal(t, backend.ErrSendPending.Error(), out.SendErr)
+}
+
+type fakeSender struct{ err error }
+
+func (f fakeSender) Send(context.Context, sluice.Message) error { return f.err }
+
+func approvedMessage(t *testing.T, q sluice.MessageStore, id string) sluice.Message {
+	t.Helper()
+	m, err := decideAndApply(context.Background(), q, router(),
+		id, approver.Verdict{Disposition: approver.Approve})
+	require.NoError(t, err)
+	require.Equal(t, sluice.StatusApproved, m.Status)
+	return m
+}
+
+func TestSendApprovedStubHoldsDefaultDeny(t *testing.T) {
+	q, id := newSeededSluice(t)
+	m := approvedMessage(t, q, id)
+
+	// Stub: ErrSendPending is not a failure — default-deny holds, nothing left.
+	require.NoError(t, sendApproved(context.Background(), q, backend.StubSender{}, nil, nil, m, "darbaan.test"))
+	got, err := q.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, got.Status) // not sent
+}
+
+func TestSendApprovedSuccessMarksSent(t *testing.T) {
+	q, id := newSeededSluice(t)
+	m := approvedMessage(t, q, id)
+
+	require.NoError(t, sendApproved(context.Background(), q, fakeSender{nil}, nil, nil, m, "darbaan.test"))
+	got, err := q.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusSent, got.Status) // delivered upstream
+}
+
+func TestSendApprovedPermanentFailureBounces(t *testing.T) {
+	q, id := newSeededSluice(t)
+	inbox, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	defer func() { _ = inbox.Close() }()
+	m := approvedMessage(t, q, id)
+
+	perm := fakeSender{&smtp.SMTPError{Code: 550, Message: "mailbox unavailable"}}
+	err = sendApproved(context.Background(), q, perm, inbox, testSigner(t), m, "darbaan.test")
+	require.Error(t, err) // permanent send failure is surfaced...
+
+	msgs, err := inbox.List("agent")
+	require.NoError(t, err)
+	require.Len(t, msgs, 1) // ...and the agent was bounced
+	assert.Contains(t, string(msgs[0].Raw), "upstream delivery failed permanently")
+	assert.NotContains(t, string(msgs[0].Raw), "mailbox unavailable") // never echo the upstream body
+	assert.Contains(t, string(msgs[0].Raw), "DKIM-Signature:")
+
+	got, err := q.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, got.Status) // not sent (still approved + SendErr)
+	assert.NotEmpty(t, got.SendErr)
+}
+
+func TestSendApprovedTransientFailureStaysApproved(t *testing.T) {
+	q, id := newSeededSluice(t)
+	inbox, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	defer func() { _ = inbox.Close() }()
+	m := approvedMessage(t, q, id)
+
+	tr := fakeSender{&smtp.SMTPError{Code: 451, Message: "try again later"}}
+	require.Error(t, sendApproved(context.Background(), q, tr, inbox, testSigner(t), m, "darbaan.test"))
+
+	msgs, err := inbox.List("agent")
+	require.NoError(t, err)
+	assert.Empty(t, msgs) // transient → NO bounce
+
+	got, err := q.Get(id)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, got.Status) // stays approved for re-send
 }
 
 func TestRejectCommitsAndBounceDelivers(t *testing.T) {
@@ -61,12 +137,12 @@ func TestRejectCommitsAndBounceDelivers(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = inbox.Close() }()
 
-	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+	m, err := decideAndApply(context.Background(), q, router(),
 		id, approver.Verdict{Disposition: approver.Reject, Reason: "smells like exfiltration", Retryable: false})
 	require.NoError(t, err)
 	require.Equal(t, sluice.StatusRejected, m.Status)
 
-	require.NoError(t, deliverBounce(inbox, testSigner(t), m, "darbaan.test"))
+	require.NoError(t, deliverBounce(inbox, testSigner(t), m, m.Reason, m.Retryable, "darbaan.test"))
 
 	// A DSN bounce was delivered to the agent's inbound mailbox (ADR 0006),
 	// already DKIM-signed (ADR 0007).
@@ -87,13 +163,13 @@ func TestRejectCommitsAndBounceDelivers(t *testing.T) {
 func TestBounceFailureDistinctFromReject(t *testing.T) {
 	q, id := newSeededSluice(t)
 
-	m, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+	m, err := decideAndApply(context.Background(), q, router(),
 		id, approver.Verdict{Disposition: approver.Reject, Reason: "no", Retryable: false})
 	require.NoError(t, err)
 	require.Equal(t, sluice.StatusRejected, m.Status)
 
 	// Bounce delivery to a failing store errors distinctly...
-	require.Error(t, deliverBounce(failingInbound{}, testSigner(t), m, "darbaan.test"))
+	require.Error(t, deliverBounce(failingInbound{}, testSigner(t), m, m.Reason, m.Retryable, "darbaan.test"))
 
 	// ...but the reject already stuck (the store still shows it rejected).
 	got, err := q.Get(id)
@@ -134,7 +210,7 @@ func TestNoDecisionLeavesPending(t *testing.T) {
 
 	// A Hold verdict (the human took no action) must leave the message pending —
 	// fail-closed.
-	out, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+	out, err := decideAndApply(context.Background(), q, router(),
 		id, approver.Verdict{Disposition: approver.Hold})
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusPending, out.Status)
@@ -147,11 +223,11 @@ func TestNoDecisionLeavesPending(t *testing.T) {
 func TestApproveTwiceIsRefused(t *testing.T) {
 	q, id := newSeededSluice(t)
 
-	_, err := decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+	_, err := decideAndApply(context.Background(), q, router(),
 		id, approver.Verdict{Disposition: approver.Approve})
 	require.NoError(t, err)
 
-	_, err = decideAndApply(context.Background(), q, backend.StubSender{}, router(),
+	_, err = decideAndApply(context.Background(), q, router(),
 		id, approver.Verdict{Disposition: approver.Approve})
 	require.Error(t, err) // already approved, not pending
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -33,6 +33,17 @@ dkim-key-file: ""            # path to the ed25519 private key (PEM)
 dkim-selector: darbaan
 dkim-domain: ""              # signing domain (d=); typically the listener domain
 
+# Upstream Sender — the only component that delivers approved mail off the box.
+# DEFAULT is "stub": nothing sends, default-deny stays structural (ADR 0003).
+# Setting sender-type=smtp is the DELIBERATE flip — it makes a fully-approved
+# message actually deliver. Only ever reached after the approval pipeline; no
+# path sends without approval. The app password is supplied via
+# DARBAAN_SMTP_PASSWORD (a Gmail app password, account 2FA), never inlined here
+# and never logged (ADR 0012). Real credentials live only in Darbaan (ADR 0002).
+sender-type: stub                  # stub | smtp
+smtp-host: "smtp.gmail.com:587"    # host:port (STARTTLS, cert verified)
+smtp-username: ""                  # e.g. you@gmail.com
+
 # SMTP submission face.
 listener-addr: ":1465"
 listener-domain: localhost

--- a/internal/backend/sender.go
+++ b/internal/backend/sender.go
@@ -1,28 +1,97 @@
+// Package backend is the upstream connectivity layer: the Sender that delivers
+// a fully-approved message to the real upstream SMTP (ADR 0009). It is the only
+// component that can cause mail to leave Darbaan, and it is selected by config
+// (sender-type), defaulting to the stub — so enabling real delivery is a
+// deliberate operator act, never a merge side-effect (ADR 0003).
 package backend
 
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/emersion/go-smtp"
 
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
-// Sender releases an approved message to the real upstream. It is the only
-// component that can cause mail to leave Darbaan, which is why it is a distinct
-// seam: until a real Sender is wired (a later issue), default-deny is structural
-// — an approved message reaches this seam and goes no further (ADR 0003).
+// Sender releases an approved message to the real upstream. Only fully-approved
+// messages ever reach it (ADR 0003); it is invoked downstream of the approval
+// commit, in the caller, never inside the decision path.
 type Sender interface {
 	Send(ctx context.Context, msg sluice.Message) error
 }
 
 // ErrSendPending is returned by the stub Sender: approval reaches the send seam,
-// but no upstream backend exists yet, so nothing is delivered.
+// but no upstream backend is configured, so nothing is delivered. Default-deny
+// stays structural until an operator sets sender-type=smtp.
 var ErrSendPending = errors.New("upstream send pending")
 
-// StubSender is the v1 placeholder Sender. It always returns ErrSendPending, so
-// nothing is ever actually sent. The approval still records and audits the
-// attempt; the message is never quietly dropped.
+// StubSender is the default Sender. It always returns ErrSendPending, so nothing
+// is ever actually sent; the approval still records and audits the attempt.
 type StubSender struct{}
 
 // Send always fails with ErrSendPending.
 func (StubSender) Send(context.Context, sluice.Message) error { return ErrSendPending }
+
+func init() {
+	Register("stub", func(Config) (Sender, error) { return StubSender{}, nil })
+}
+
+// Config configures a Sender backend. Password is the SMTP secret (a Gmail app
+// password for v1): supplied via the environment, never inlined in config or
+// logged (ADR 0012).
+type Config struct {
+	Host     string // host:port, e.g. smtp.gmail.com:587
+	Username string
+	Password string
+}
+
+// Factory constructs a Sender of a given type.
+type Factory func(Config) (Sender, error)
+
+var registry = map[string]Factory{}
+
+// Register adds a named sender backend. It panics on a duplicate name.
+func Register(name string, f Factory) {
+	if _, dup := registry[name]; dup {
+		panic(fmt.Sprintf("backend: duplicate registration %q", name))
+	}
+	registry[name] = f
+}
+
+// New constructs the configured sender backend, or an error if senderType is not
+// registered.
+func New(senderType string, cfg Config) (Sender, error) {
+	f, ok := registry[senderType]
+	if !ok {
+		return nil, fmt.Errorf("backend: unknown sender type %q (have %v)", senderType, Registered())
+	}
+	return f(cfg)
+}
+
+// Registered returns the names of all registered sender backends, sorted.
+func Registered() []string {
+	names := make([]string, 0, len(registry))
+	for n := range registry {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsPermanent reports whether a send error is a permanent (5xx) SMTP failure —
+// which should bounce the agent (ADR 0006) — as opposed to a transient (4xx) or
+// network failure, which leaves the message approved for a manual re-send and
+// does NOT bounce. ErrSendPending (the stub) is neither.
+func IsPermanent(err error) bool {
+	if err == nil || errors.Is(err, ErrSendPending) {
+		return false
+	}
+	var se *smtp.SMTPError
+	if errors.As(err, &se) {
+		return se.Code >= 500
+	}
+	return false // network / unknown → transient
+}

--- a/internal/backend/sender_test.go
+++ b/internal/backend/sender_test.go
@@ -2,9 +2,12 @@ package backend_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/emersion/go-smtp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/sluice"
@@ -13,4 +16,36 @@ import (
 func TestStubSenderNeverSends(t *testing.T) {
 	err := backend.StubSender{}.Send(context.Background(), sluice.Message{ID: "1"})
 	assert.ErrorIs(t, err, backend.ErrSendPending)
+}
+
+func TestNewDefaultsToStub(t *testing.T) {
+	s, err := backend.New("stub", backend.Config{})
+	require.NoError(t, err)
+	assert.ErrorIs(t, s.Send(context.Background(), sluice.Message{}), backend.ErrSendPending)
+	assert.Contains(t, backend.Registered(), "stub")
+	assert.Contains(t, backend.Registered(), "smtp")
+}
+
+func TestNewUnknownType(t *testing.T) {
+	_, err := backend.New("carrier-pigeon", backend.Config{})
+	require.Error(t, err)
+}
+
+func TestSMTPRequiresHostAndCreds(t *testing.T) {
+	// Fail closed: smtp without host/username/password is not constructible.
+	_, err := backend.New("smtp", backend.Config{})
+	require.Error(t, err)
+	_, err = backend.New("smtp", backend.Config{Host: "smtp.gmail.com:587", Username: "u"})
+	require.Error(t, err) // missing password
+	_, err = backend.New("smtp", backend.Config{Host: "no-port", Username: "u", Password: "p"})
+	require.Error(t, err) // host must be host:port
+}
+
+func TestIsPermanent(t *testing.T) {
+	assert.True(t, backend.IsPermanent(&smtp.SMTPError{Code: 550}))
+	assert.True(t, backend.IsPermanent(&smtp.SMTPError{Code: 500}))
+	assert.False(t, backend.IsPermanent(&smtp.SMTPError{Code: 451})) // transient
+	assert.False(t, backend.IsPermanent(errors.New("dial tcp: connection refused")))
+	assert.False(t, backend.IsPermanent(backend.ErrSendPending))
+	assert.False(t, backend.IsPermanent(nil))
 }

--- a/internal/backend/smtp.go
+++ b/internal/backend/smtp.go
@@ -1,0 +1,67 @@
+package backend
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+
+	"github.com/emersion/go-sasl"
+	"github.com/emersion/go-smtp"
+
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+func init() {
+	Register("smtp", newSMTP)
+}
+
+// smtpSender delivers messages to an upstream SMTP submission server (Gmail =
+// smtp.gmail.com) over STARTTLS with AUTH PLAIN, verifying the server
+// certificate. A vetted client (emersion/go-smtp), no hand-rolled SMTP
+// (ADR 0014).
+type smtpSender struct {
+	cfg Config
+}
+
+func newSMTP(cfg Config) (Sender, error) {
+	// Fail closed: an smtp sender with missing host or credentials must not be
+	// constructed (it would silently never deliver).
+	if cfg.Host == "" || cfg.Username == "" || cfg.Password == "" {
+		return nil, fmt.Errorf("backend: smtp sender requires smtp-host, smtp-username, and DARBAAN_SMTP_PASSWORD")
+	}
+	if _, _, err := net.SplitHostPort(cfg.Host); err != nil {
+		return nil, fmt.Errorf("backend: smtp-host must be host:port, got %q: %w", cfg.Host, err)
+	}
+	return &smtpSender{cfg: cfg}, nil
+}
+
+func (s *smtpSender) Send(_ context.Context, msg sluice.Message) error {
+	host, _, _ := net.SplitHostPort(s.cfg.Host)
+
+	// ServerName set + no InsecureSkipVerify ⇒ the server certificate is
+	// verified against the host (ADR 0009: verify TLS).
+	c, err := smtp.DialStartTLS(s.cfg.Host, &tls.Config{ServerName: host})
+	if err != nil {
+		return fmt.Errorf("backend: dial %s: %w", s.cfg.Host, err)
+	}
+	defer func() { _ = c.Close() }()
+
+	if err := c.Auth(sasl.NewPlainClient("", s.cfg.Username, s.cfg.Password)); err != nil {
+		return fmt.Errorf("backend: auth: %w", err)
+	}
+
+	// Release the edited body if a human approver amended it (ADR 0004),
+	// otherwise the original.
+	body := msg.Raw
+	if msg.Released != nil {
+		body = msg.Released
+	}
+	// Return the SendMail error wrapped: errors.As still recovers the
+	// *smtp.SMTPError so IsPermanent can classify the 5xx/4xx code.
+	if err := c.SendMail(msg.From, msg.Rcpt, bytes.NewReader(body)); err != nil {
+		return fmt.Errorf("backend: send: %w", err)
+	}
+	return nil
+}

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -157,7 +157,10 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 			return err
 		}
 		if sendErr != nil {
-			m.SendErr = sendErr.Error()
+			m.SendErr = sendErr.Error() // stays approved for a manual re-send
+		} else {
+			m.Status = StatusSent // delivered upstream
+			m.SendErr = ""
 		}
 		out = m
 		return putMessage(tx, key, m)

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -32,6 +32,7 @@ const (
 	StatusPending  Status = "pending"
 	StatusApproved Status = "approved"
 	StatusRejected Status = "rejected"
+	StatusSent     Status = "sent" // approved AND delivered upstream
 )
 
 // Submission is a new outbound message to trap, as captured from the SMTP face.


### PR DESCRIPTION
The upstream Sender (ADR 0009) — the first component where an approved message can actually leave Darbaan. The highest-stakes component, with the safety property built in up front.

## The safety property: the flip is opt-in by config
`sender-type` **defaults to `stub`** (nothing sends, default-deny stays structural, ADR 0003). **Merging this PR does NOT enable sending.** An operator must deliberately set `sender-type=smtp` + credentials to flip it. `sender-type=smtp` **fails closed** without host/username/`DARBAAN_SMTP_PASSWORD`.

## Architecture (caller-side, symmetric to #40)
`decideAndApply` is now **pure** — it commits the decision and nothing else (its `sender` param is gone). Everything downstream of the commit lives in the caller (`sendApproved`), so the send/bounce paths never re-entangle the decision:
- reject → commit → `deliverBounce`
- approve → commit → send → on **permanent (5xx)** failure `deliverBounce`; on **transient (4xx/network)** failure stay approved for a manual re-send, **no bounce**, no retry loop.

## Components
- **`internal/backend`** — config-selected Sender (registry, like store/audit): `stub` (default) + `smtp`. The smtp sender delivers via **`emersion/go-smtp`** over **STARTTLS with AUTH PLAIN, verifying the server cert** (no hand-rolled SMTP, ADR 0014). App password from `DARBAAN_SMTP_PASSWORD`, **never inlined or logged** (ADR 0012); creds live only in Darbaan (ADR 0002). `IsPermanent` classifies 5xx vs 4xx/network.
- **`internal/sluice`** — `StatusSent`; `RecordSendAttempt` marks sent on success, leaves approved + `SendErr` on failure.
- **cmd** — `sendApproved` (testable); `sender-type`/`smtp-host`/`smtp-username` config.

## Invariants
- Only fully-approved messages reach the Sender; no path sends without approval (the Sender is invoked only in `sendApproved`, after the full chain commits `approved`).
- App-password auth for v1; **OAuth2/XOAUTH2 is post-v1**.
- The bounce reason on send failure is **generic** ("upstream delivery failed permanently") — it never echoes the upstream response body.
- The carried q.Get explicit-error check stays handled.

## Cross-package touch (one cohesive component)
`internal/backend` (Sender impl), `internal/sluice` (StatusSent + RecordSendAttempt), `cmd/darbaan` (pure decideAndApply + sendApproved + config). `config.example.yaml` updated with the safety note.

## Verification
- `go build`/`vet`/`gofmt -l` clean; `go test -race ./...` green; `golangci-lint` (v2.11.4) 0 issues.
- Tests: stub holds default-deny; success → StatusSent; **permanent failure → agent bounced** (generic reason, body not echoed, signed) + message stays approved; **transient failure → no bounce, stays approved**; backend registry + `IsPermanent` (5xx/4xx/network/stub/nil) + smtp fail-closed.
- Smoke: default stub needs no creds; `sender-type=smtp` errors without creds; help shows the flags.

closes #30
