### PR TITLE
feat: Docker support (distroless image + compose)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# VCS + CI
+.git
+.github
+
+# Secrets and local state — must never enter the build context or image layers
+*.pem
+*.key
+*.env
+.env
+*.db
+*.db-lock
+secrets/
+
+# Local build output
+/darbaan
+/dist
+
+# Compose + docs not needed to build the binary
+docker-compose.yml
+*_test.go

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy to .env and fill in. NEVER commit .env (it holds secrets).
+# docker compose reads these for variable substitution.
+
+# The agent's Darbaan SMTP/IMAP password (required).
+DARBAAN_AGENT_PASS=change-me
+
+# Upstream Gmail app password — ONLY needed once you flip DARBAAN_SENDER_TYPE=smtp
+# in docker-compose.yml. Leave blank while sender-type=stub (nothing sends).
+DARBAAN_SMTP_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+# --- builder: compile a static binary -------------------------------------
+FROM golang:1.26 AS builder
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG VERSION=docker
+# CGO_ENABLED=0 ⇒ a fully static binary that runs on distroless/static.
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
+    -ldflags "-s -w -X main.version=${VERSION}" \
+    -o /out/darbaan ./cmd/darbaan
+
+# Pre-create the data dir owned by the nonroot uid (65532) so a fresh named
+# volume mounted at /data inherits writable ownership — distroless has no shell
+# to chown at runtime.
+RUN mkdir -p /data && chown 65532:65532 /data
+
+# --- runtime: minimal, non-root -------------------------------------------
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /out/darbaan /usr/local/bin/darbaan
+COPY --from=builder --chown=65532:65532 /data /data
+
+# Env-driven config (file < env < flags). Point the three bbolt DBs at the
+# /data volume and keep the safe default sender-type=stub: a fresh container
+# sends NOTHING until the operator sets sender-type=smtp + the app password.
+# Secrets (DARBAAN_AGENT_PASS, DARBAAN_SMTP_PASSWORD) and files (DKIM key, TLS
+# certs, optional config) come from env / mounts — never baked into the image.
+ENV DARBAAN_SLUICE_DB=/data/sluice.db \
+    DARBAAN_AUDIT_DB=/data/audit.db \
+    DARBAAN_INBOUND_DB=/data/inbound.db \
+    DARBAAN_SENDER_TYPE=stub
+
+# SMTP submission face + IMAP read face.
+EXPOSE 1465 1143
+
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/darbaan"]
+CMD ["serve"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,51 @@
+# Ready-to-run Darbaan.
+#
+#   1. cp .env.example .env   and fill DARBAAN_AGENT_PASS
+#   2. put TLS cert+key in ./secrets/tls/ and an ed25519 DKIM key in ./secrets/dkim/
+#   3. docker compose up -d
+#
+# Safe by default: sender-type=stub, so the container sends NOTHING until you set
+# DARBAAN_SENDER_TYPE=smtp + DARBAAN_SMTP_PASSWORD (a Gmail app password). Ports
+# bind to 127.0.0.1 only — Darbaan is a local-trusted-host service, not
+# internet-facing (ADR 0012). Secrets come from .env / mounts, never the image.
+
+services:
+  darbaan:
+    build: .
+    # image: ghcr.io/yaad-index/darbaan:latest   # once a published image exists
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:1465:1465"   # SMTP submission (agent -> Darbaan)
+      - "127.0.0.1:1143:1143"   # IMAP read (agent reads its bounces)
+    environment:
+      # Agent credential. Username here, password from .env.
+      DARBAAN_AGENT_USERNAME: "agent"
+      DARBAAN_AGENT_PASS: "${DARBAAN_AGENT_PASS:?set DARBAAN_AGENT_PASS in .env}"
+
+      # TLS — secure by default. Mount your cert + key (see volumes) and the
+      # agent connects over TLS (ADR 0002).
+      DARBAAN_LISTENER_TLS_CERT: /run/secrets/tls/cert.pem
+      DARBAAN_LISTENER_TLS_KEY: /run/secrets/tls/key.pem
+      # For a localhost-only first run WITHOUT certs, comment the two lines above
+      # and uncomment this (plaintext AUTH — localhost only, never in production):
+      # DARBAAN_LISTENER_ALLOW_INSECURE: "true"
+
+      # Bounce signing (ADR 0007): mount the ed25519 key, set selector + domain.
+      DARBAAN_DKIM_KEY_FILE: /run/secrets/dkim/dkim.pem
+      DARBAAN_DKIM_SELECTOR: "darbaan"
+      DARBAAN_DKIM_DOMAIN: "darbaan.example"
+
+      # Upstream Sender — DEFAULT stub (sends nothing). The deliberate flip:
+      # set sender-type=smtp + the username, and DARBAAN_SMTP_PASSWORD in .env.
+      DARBAAN_SENDER_TYPE: "stub" # change to "smtp" to actually deliver
+      DARBAAN_SMTP_HOST: "smtp.gmail.com:587"
+      DARBAAN_SMTP_USERNAME: "" # e.g. you@gmail.com (when sender-type=smtp)
+      DARBAAN_SMTP_PASSWORD: "${DARBAAN_SMTP_PASSWORD:-}"
+    volumes:
+      - darbaan-data:/data # the three bbolt DBs (sluice / audit / inbound)
+      - ./secrets/tls:/run/secrets/tls:ro # you provide cert.pem + key.pem
+      - ./secrets/dkim:/run/secrets/dkim:ro # you provide dkim.pem (ed25519)
+      # - ./config.yaml:/etc/darbaan/config.yaml:ro   # optional mounted config
+
+volumes:
+  darbaan-data:


### PR DESCRIPTION
One-command install (#46): a container image + ready-to-run compose.

## Base image: `gcr.io/distroless/static-debian12:nonroot`
Darbaan is a fully static `CGO_ENABLED=0` binary, so distroless/static fits — the smallest surface, no shell or package manager (a feature for a trust-boundary daemon), non-root (uid 65532) by default. (Alpine would add a shell + apk for little gain.)

## Dockerfile
- Multi-stage: golang builder → distroless runtime; version injected via `-ldflags`.
- Runs as **nonroot (65532)**; `/data` pre-created with that ownership so a fresh named volume inherits writable perms (distroless has no shell to chown at runtime).
- Env defaults point the three bbolt DBs at `/data` and keep **`sender-type=stub`**. `EXPOSE 1465 1143`. **No secrets baked in.**

## docker-compose.yml (the easy-install deliverable)
- **Secure by default**: TLS cert/key + DKIM key mounted from `./secrets`, creds from `.env`; the `--listener-allow-insecure` toggle is **commented-and-off** (documented localhost-only first-run).
- **Ports bind to `127.0.0.1` only** — Darbaan is a local-trusted-host service, not internet-facing (ADR 0012); I bind `:PORT` (all interfaces) inside the container and narrow exposure host-side.
- **Default `sender-type=stub`** — a fresh container sends nothing until the operator sets `sender-type=smtp` + `DARBAAN_SMTP_PASSWORD`.
- Named volume for `/data`; bind-mounts for TLS + DKIM; optional config mount.

## Also
`.env.example` (secret inputs); `.dockerignore` keeps git, local DBs, keys, and `.env` out of the build context/layers.

## Verification (built + ran locally, Docker 29.5.2)
- `docker build` succeeds; `darbaan version` prints the injected version.
- Image runs as `nonroot:nonroot`, exposes 1143/1465.
- `serve` binds both faces and **writes the `/data` volume as non-root** (creates the bbolt DBs — the named-volume ownership works).
- `docker compose config` / YAML valid; secrets only via env/mounts.

## Out of scope (noted in the issue)
A docker-build CI job can be a follow-up.

closes #46
