### PR TITLE
fix: DSN Final-Recipient (intended rcpt) + SEARCH ToLower guard

### DIFF
--- a/internal/bounce/bounce.go
+++ b/internal/bounce/bounce.go
@@ -42,7 +42,15 @@ func Generate(orig sluice.Message, reason string, retryable bool, domain string)
 		status, disposition = "4.7.1", "transient"
 	}
 	from := "MAILER-DAEMON@" + domain
-	to := orig.From
+	to := orig.From // the bounce goes back to the original sender
+
+	// Final-Recipient names the INTENDED recipient(s) — the addresses delivery
+	// failed for (RFC 3464), not the sender. Fall back to the sender only if the
+	// envelope had no recipients, so the DSN is never recipient-less.
+	rcpts := orig.Rcpt
+	if len(rcpts) == 0 {
+		rcpts = []string{to}
+	}
 
 	var buf bytes.Buffer
 
@@ -62,7 +70,7 @@ func Generate(orig sluice.Message, reason string, retryable bool, domain string)
 	if err := writeText(mw, domain, reason, disposition, status, retryable); err != nil {
 		return Bounce{}, err
 	}
-	if err := writeDeliveryStatus(mw, domain, to, status, reason); err != nil {
+	if err := writeDeliveryStatus(mw, domain, rcpts, status, reason); err != nil {
 		return Bounce{}, err
 	}
 	if err := writeOriginal(mw, orig.Raw); err != nil {
@@ -98,22 +106,27 @@ func writeText(mw *message.Writer, domain, reason, disposition, status string, r
 	return pw.Close()
 }
 
-func writeDeliveryStatus(mw *message.Writer, domain, to, status, reason string) error {
+func writeDeliveryStatus(mw *message.Writer, domain string, rcpts []string, status, reason string) error {
 	var h message.Header
 	h.SetContentType("message/delivery-status", nil)
 	pw, err := mw.CreatePart(h)
 	if err != nil {
 		return fmt.Errorf("bounce: delivery-status part: %w", err)
 	}
-	// Per-message fields, blank line, then per-recipient fields (RFC 3464).
-	body := fmt.Sprintf(
-		"Reporting-MTA: dns; %s\r\n\r\n"+
-			"Final-Recipient: rfc822; %s\r\n"+
-			"Action: failed\r\n"+
-			"Status: %s\r\n"+
-			"Diagnostic-Code: X-Darbaan; %s\r\n",
-		domain, to, status, reason)
-	if _, err := pw.Write([]byte(body)); err != nil {
+	// Per-message fields, then one per-recipient group for each INTENDED
+	// recipient — the address delivery failed for, not the bounce recipient
+	// (RFC 3464). Recipients are CR/LF-sanitized against header injection.
+	var b strings.Builder
+	fmt.Fprintf(&b, "Reporting-MTA: dns; %s\r\n", domain)
+	for _, rcpt := range rcpts {
+		fmt.Fprintf(&b,
+			"\r\nFinal-Recipient: rfc822; %s\r\n"+
+				"Action: failed\r\n"+
+				"Status: %s\r\n"+
+				"Diagnostic-Code: X-Darbaan; %s\r\n",
+			sanitize(rcpt), status, reason)
+	}
+	if _, err := pw.Write([]byte(b.String())); err != nil {
 		return fmt.Errorf("bounce: write delivery-status: %w", err)
 	}
 	return pw.Close()

--- a/internal/bounce/bounce_test.go
+++ b/internal/bounce/bounce_test.go
@@ -37,13 +37,13 @@ func parseParts(t *testing.T, raw []byte) map[string]string {
 }
 
 func TestGeneratePermanent(t *testing.T) {
-	orig := sluice.Message{Agent: "agent", From: "sender@local", Raw: []byte("Subject: hi\r\n\r\nbody-marker\r\n")}
+	orig := sluice.Message{Agent: "agent", From: "sender@local", Rcpt: []string{"dest@example.test"}, Raw: []byte("Subject: hi\r\n\r\nbody-marker\r\n")}
 	b, err := bounce.Generate(orig, "refused by policy", false, "darbaan.test")
 	require.NoError(t, err)
 
 	assert.Equal(t, "agent", b.Owner)
 	assert.Equal(t, "MAILER-DAEMON@darbaan.test", b.From)
-	assert.Equal(t, "sender@local", b.To)
+	assert.Equal(t, "sender@local", b.To) // bounce returns to the original sender
 
 	parts := parseParts(t, b.Raw)
 	require.Contains(t, parts, "text/plain")
@@ -53,7 +53,21 @@ func TestGeneratePermanent(t *testing.T) {
 	assert.Contains(t, parts["text/plain"], "refused by policy")
 	assert.Contains(t, parts["message/delivery-status"], "Status: 5.7.1")
 	assert.Contains(t, parts["message/delivery-status"], "Action: failed")
+	// Final-Recipient is the INTENDED recipient, not the sender (#54, RFC 3464).
+	assert.Contains(t, parts["message/delivery-status"], "Final-Recipient: rfc822; dest@example.test")
+	assert.NotContains(t, parts["message/delivery-status"], "Final-Recipient: rfc822; sender@local")
 	assert.Contains(t, parts["message/rfc822"], "body-marker") // original attached intact
+}
+
+func TestGenerateMultiRecipient(t *testing.T) {
+	orig := sluice.Message{Agent: "agent", From: "sender@local", Rcpt: []string{"a@x.test", "b@x.test"}, Raw: []byte("x")}
+	b, err := bounce.Generate(orig, "no", false, "darbaan.test")
+	require.NoError(t, err)
+
+	ds := parseParts(t, b.Raw)["message/delivery-status"]
+	// One Final-Recipient group per intended recipient (RFC 3464).
+	assert.Contains(t, ds, "Final-Recipient: rfc822; a@x.test")
+	assert.Contains(t, ds, "Final-Recipient: rfc822; b@x.test")
 }
 
 func TestGenerateTransient(t *testing.T) {

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -332,21 +332,26 @@ func matchSearch(seqNum uint32, m *inbound.Message, c *imap.SearchCriteria) bool
 	if c.Smaller != 0 && int64(len(m.Raw)) >= c.Smaller {
 		return false
 	}
-	low := bytes.ToLower(m.Raw)
-	for _, h := range c.Header {
-		if !bytes.Contains(low, bytes.ToLower([]byte(h.Key))) ||
-			(h.Value != "" && !bytes.Contains(low, bytes.ToLower([]byte(h.Value)))) {
-			return false
+	// Only lower-case the (potentially large) raw message when a content
+	// criterion actually needs it — the common SEARCH (ALL / flags / seq) skips
+	// this allocation entirely (#56).
+	if len(c.Header) > 0 || len(c.Text) > 0 || len(c.Body) > 0 {
+		low := bytes.ToLower(m.Raw)
+		for _, h := range c.Header {
+			if !bytes.Contains(low, bytes.ToLower([]byte(h.Key))) ||
+				(h.Value != "" && !bytes.Contains(low, bytes.ToLower([]byte(h.Value)))) {
+				return false
+			}
 		}
-	}
-	for _, t := range c.Text {
-		if !bytes.Contains(low, bytes.ToLower([]byte(t))) {
-			return false
+		for _, t := range c.Text {
+			if !bytes.Contains(low, bytes.ToLower([]byte(t))) {
+				return false
+			}
 		}
-	}
-	for _, b := range c.Body {
-		if !bytes.Contains(low, bytes.ToLower([]byte(b))) {
-			return false
+		for _, b := range c.Body {
+			if !bytes.Contains(low, bytes.ToLower([]byte(b))) {
+				return false
+			}
 		}
 	}
 	for i := range c.Not {


### PR DESCRIPTION
Two follow-ups from the live rejection test.

## #54 — DSN Final-Recipient
It named the bounce recipient (the original **sender**) instead of the **intended recipient** the delivery failed for (RFC 3464). Now emits one per-recipient `Final-Recipient` group per original envelope recipient — correct for **multi-rcpt** — CR/LF-sanitized against header injection. The bounce still returns `To:` the original sender.

## #56 — SEARCH ToLower allocation
`matchSearch` lower-cased the (potentially large) raw message on every call; now only when a HEADER/BODY/TEXT criterion needs it. The common SEARCH (ALL / flags / seq) skips the allocation. (Deferred review nit from #55.)

## Tests
`TestGeneratePermanent` asserts Final-Recipient is the intended recipient, not the sender; `TestGenerateMultiRecipient` asserts a group per recipient. Existing SEARCH tests still pass.

Two-file touch (`internal/bounce`, `internal/listener`) — both small live-test follow-ups. build/vet/gofmt/race/golangci-lint clean.

closes #54, closes #56
