### PR TITLE
feat: darbaan telegram subcommand skeleton (#60 Inc 1)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/policy"
 	"github.com/yaad-index/darbaan/internal/signer"
 	"github.com/yaad-index/darbaan/internal/sluice"
+	"github.com/yaad-index/darbaan/internal/telegram"
 )
 
 // version is the build version, overridden at link time via -ldflags.
@@ -73,11 +74,14 @@ type CLI struct {
 
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
+	TelegramOperatorID int64 `name:"telegram-operator-id" help:"Telegram chat/user id permitted to approve/reject (only this id may act). Bot token via DARBAAN_TELEGRAM_TOKEN."`
+
 	ApprovalStrict []string `name:"approval-strict" default:"manual" help:"Approver chain for the strict path."`
 	ApprovalLight  []string `name:"approval-light" default:"manual" help:"Approver chain for the light path."`
 
 	Serve      ServeCmd      `cmd:"" help:"Run the SMTP + IMAP faces and the admin API."`
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
+	Telegram   TelegramCmd   `cmd:"" help:"Run the Telegram approval client (a separate admin-API client process)."`
 	DkimPubkey DkimPubkeyCmd `cmd:"" name:"dkim-pubkey" help:"Print the DKIM public-key record to pin to the agent."`
 	Version    VersionCmd    `cmd:"" help:"Print version and exit."`
 }
@@ -143,6 +147,24 @@ func (c *CLI) adminClient() (*admin.Client, error) {
 		return nil, errors.New("set DARBAAN_ADMIN_TOKEN (the running serve's admin token)")
 	}
 	return admin.NewClient(c.AdminAddr, token), nil
+}
+
+// TelegramCmd runs the Telegram approval client — a separate long-running
+// process that is a client of the admin API (ADR 0017), not part of serve.
+type TelegramCmd struct{}
+
+func (*TelegramCmd) Run(cli *CLI) error {
+	adminClient, err := cli.adminClient() // reuses admin-addr + DARBAAN_ADMIN_TOKEN
+	if err != nil {
+		return err
+	}
+	tc, err := telegram.New(os.Getenv("DARBAAN_TELEGRAM_TOKEN"), cli.TelegramOperatorID, adminClient)
+	if err != nil {
+		return err
+	}
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return tc.Run(ctx)
 }
 
 // DkimPubkeyCmd prints the DKIM public-key record for out-of-band pinning.

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/emersion/go-msgauth v0.7.0
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6
 	github.com/emersion/go-smtp v0.24.0
+	github.com/go-telegram/bot v1.21.0
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/bbolt v1.5.0
 )

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 h1:oP4q0fw+fOSWn3
 github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6/go.mod h1:iL2twTeMvZnrg54ZoPDNfJaJaqy0xIQFuBdrLsmspwQ=
 github.com/emersion/go-smtp v0.24.0 h1:g6AfoF140mvW0vLNPD/LuCBLEAdlxOjIXqbIkJIS6Wk=
 github.com/emersion/go-smtp v0.24.0/go.mod h1:ZtRRkbTyp2XTHCA+BmyTFTrj8xY4I+b4McvHxCU2gsQ=
+github.com/go-telegram/bot v1.21.0 h1:Va/PbGc2vBDdv57GCUEEVV6ROlHWiC6SklJY9Hvhzps=
+github.com/go-telegram/bot v1.21.0/go.mod h1:i2TRs7fXWIeaceF3z7KzsMt/he0TwkVC680mvdTFYeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -1,0 +1,64 @@
+// Package telegram is the Telegram approval client (ADR 0017): a separate,
+// long-running process that bridges the operator's Telegram chat to the
+// localhost-only admin API (#52). It is NOT compiled into serve; it holds only
+// a bot token and an admin-API token, never the mail credentials (ADR 0002).
+//
+// Increment 1 connects and logs readiness only — the queue notify / approve /
+// reject flow lands in later increments (#60).
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+// Client is the Telegram approval interface.
+type Client struct {
+	bot        *bot.Bot
+	admin      *admin.Client
+	operatorID int64
+}
+
+// New builds the Telegram client. The bot token is never logged; operatorID is
+// the only chat/user permitted to act (everyone else is ignored); adminClient
+// is the admin-API client through which verdicts are relayed. The bot is
+// constructed without a network call (the connect happens in Run).
+func New(token string, operatorID int64, adminClient *admin.Client) (*Client, error) {
+	if token == "" {
+		return nil, fmt.Errorf("telegram: bot token is required (DARBAAN_TELEGRAM_TOKEN)")
+	}
+	if operatorID == 0 {
+		return nil, fmt.Errorf("telegram: a telegram-operator-id is required (only that chat may approve/reject)")
+	}
+	if adminClient == nil {
+		return nil, fmt.Errorf("telegram: an admin client is required")
+	}
+	b, err := bot.New(token, bot.WithSkipGetMe(), bot.WithDefaultHandler(ignoreUpdate))
+	if err != nil {
+		return nil, fmt.Errorf("telegram: init bot: %w", err)
+	}
+	return &Client{bot: b, admin: adminClient, operatorID: operatorID}, nil
+}
+
+// Run connects to Telegram, logs readiness, and runs the update loop until ctx
+// is cancelled. Increment 1 has no queue logic — it only proves the process
+// comes up as a working admin-API client.
+func (c *Client) Run(ctx context.Context) error {
+	me, err := c.bot.GetMe(ctx)
+	if err != nil {
+		return fmt.Errorf("telegram: connect: %w", err)
+	}
+	log.Printf("darbaan telegram: ready — bot @%s, operator %d, relaying to the admin API", me.Username, c.operatorID)
+	c.bot.Start(ctx) // long-poll loop; returns when ctx is cancelled
+	return nil
+}
+
+// ignoreUpdate drops incoming updates in Increment 1; notify/approve/reject
+// handlers land in later increments.
+func ignoreUpdate(context.Context, *bot.Bot, *models.Update) {}

--- a/internal/telegram/telegram_test.go
+++ b/internal/telegram/telegram_test.go
@@ -1,0 +1,32 @@
+package telegram_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/telegram"
+)
+
+func TestNewValidation(t *testing.T) {
+	ac := admin.NewClient("127.0.0.1:1144", "admintoken")
+
+	_, err := telegram.New("", 12345, ac)
+	require.Error(t, err) // empty bot token
+
+	_, err = telegram.New("123:bot-token", 0, ac)
+	require.Error(t, err) // no operator id
+
+	_, err = telegram.New("123:bot-token", 12345, nil)
+	require.Error(t, err) // no admin client
+}
+
+func TestNewSucceedsWithoutNetwork(t *testing.T) {
+	// WithSkipGetMe means construction does not call the Telegram API; the
+	// connect happens in Run.
+	c, err := telegram.New("123:fake-token", 12345, admin.NewClient("127.0.0.1:1144", "tok"))
+	require.NoError(t, err)
+	assert.NotNil(t, c)
+}


### PR DESCRIPTION
**Increment 1** of the Telegram approval client (#60) — the first interface on the ADR 0017 clients-over-API model.

## What Inc 1 does
A new `darbaan telegram` subcommand: a **separate long-running process, NOT compiled into serve**, that is a client of the admin API.
- **`internal/telegram`** — a `Client` holding the bot token, the operator's Telegram id, and the `internal/admin.Client`. `New` validates (token / operator-id / admin client required) and builds the bot **without a network call** (`WithSkipGetMe`); `Run` connects (`GetMe`), logs readiness, and runs the long-poll loop until signalled. **No queue logic yet** (notify/approve/reject are Inc 2-4).
- **cmd** — bot token from `DARBAAN_TELEGRAM_TOKEN` (never logged); `telegram-operator-id` config (only that chat may act); reuses the existing admin client (`admin-addr` + `DARBAAN_ADMIN_TOKEN`). Holds no mail credentials (ADR 0002).

## Library
`github.com/go-telegram/bot` v1.21.0 — maintained, full Bot API (inline keyboards + callback-query + force-reply, which Inc 2-4 need), minimal deps (ADR 0014).

## Security
Only the configured operator id will act (enforced from Inc 2 when handlers land); tokens are never logged; the core stays loopback-only. Per-client scoped admin tokens tracked separately (#59).

## Verification
- `go build`/`vet`/`gofmt -l` clean; `go test -race ./...` green; `golangci-lint` 0 issues.
- Tests: `New` validation (empty token / no operator / no admin client) + construction-without-network.
- Smoke: `darbaan telegram` fails closed without DARBAAN_TELEGRAM_TOKEN / operator-id / DARBAAN_ADMIN_TOKEN; help lists the command.

**No bot token wired** — the maintainer supplies a real one at test time.

Increment 1 of #60 (does not close the epic).
