### PR TITLE
feat: Subject in queue Meta (derived at list time)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -321,12 +321,20 @@ func (*QueueLsCmd) Run(cli *CLI) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ID\tSTATUS\tAGENT\tFROM\tRCPT\tSIZE\tRECEIVED")
+	_, _ = fmt.Fprintln(w, "ID\tSTATUS\tAGENT\tFROM\tSUBJECT\tRCPT\tSIZE\tRECEIVED")
 	for _, m := range metas {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
-			m.ID, m.Status, m.Agent, m.From, len(m.Rcpt), m.Size, m.ReceivedAt.Format(time.RFC3339))
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
+			m.ID, m.Status, m.Agent, m.From, truncate(m.Subject, 40), len(m.Rcpt), m.Size, m.ReceivedAt.Format(time.RFC3339))
 	}
 	return w.Flush()
+}
+
+// truncate shortens s to at most n runes for table display.
+func truncate(s string, n int) string {
+	if r := []rune(s); len(r) > n {
+		return string(r[:n-1]) + "…"
+	}
+	return s
 }
 
 // QueueShowCmd dumps a held message's raw RFC 822.

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -103,6 +103,7 @@ func (s *bboltStore) List() ([]Meta, error) {
 				Agent:      m.Agent,
 				From:       m.From,
 				Rcpt:       m.Rcpt,
+				Subject:    subjectFromRaw(m.Raw),
 				Size:       len(m.Raw),
 				ReceivedAt: m.ReceivedAt,
 				Status:     m.Status,

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -7,10 +7,14 @@
 package sluice
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"mime"
 	"sort"
 	"time"
+
+	"github.com/emersion/go-message"
 
 	"github.com/yaad-index/darbaan/internal/audit"
 )
@@ -62,14 +66,33 @@ type Message struct {
 }
 
 // Meta is the listing view of a queued message: everything but the raw body.
+// Subject is derived from the raw message at list time (not separately stored),
+// so admin clients (queue ls, the Telegram bot, a future web UI) get it without
+// fetching and re-parsing the body themselves.
 type Meta struct {
 	ID         string
 	Agent      string
 	From       string
 	Rcpt       []string
+	Subject    string
 	Size       int
 	ReceivedAt time.Time
 	Status     Status
+}
+
+// subjectFromRaw extracts the Subject header from a stored message for display
+// in listings, decoding RFC 2047 encoded-words. Best-effort: a malformed or
+// charset-odd message yields "" rather than failing the whole listing.
+func subjectFromRaw(raw []byte) string {
+	ent, _ := message.Read(bytes.NewReader(raw))
+	if ent == nil {
+		return "" // unparseable (a charset warning still returns a usable entity)
+	}
+	s := ent.Header.Get("Subject")
+	if dec, err := new(mime.WordDecoder).DecodeHeader(s); err == nil {
+		s = dec
+	}
+	return s
 }
 
 // MessageStore is the durable outbound hold/queue. It is the source of truth;

--- a/internal/sluice/sluice_test.go
+++ b/internal/sluice/sluice_test.go
@@ -24,6 +24,28 @@ func newStore(t *testing.T) (sluice.MessageStore, audit.AuditLog) {
 	return q, al
 }
 
+func TestListSubject(t *testing.T) {
+	q, _ := newStore(t)
+
+	// Plain subject, an RFC 2047 encoded-word subject, and no Subject header.
+	_, err := q.Enqueue(sluice.Submission{Agent: "a", Raw: []byte("Subject: Hello there\r\n\r\nbody")})
+	require.NoError(t, err)
+	_, err = q.Enqueue(sluice.Submission{Agent: "a", Raw: []byte("Subject: =?utf-8?q?caf=C3=A9?=\r\n\r\nbody")})
+	require.NoError(t, err)
+	_, err = q.Enqueue(sluice.Submission{Agent: "a", Raw: []byte("From: x\r\n\r\nno subject header")})
+	require.NoError(t, err)
+
+	metas, err := q.List()
+	require.NoError(t, err)
+	got := map[string]bool{}
+	for _, m := range metas {
+		got[m.Subject] = true
+	}
+	assert.True(t, got["Hello there"], "plain subject parsed")
+	assert.True(t, got["café"], "RFC 2047 encoded-word decoded")
+	assert.True(t, got[""], "absent subject yields empty, not an error")
+}
+
 func TestEnqueueListGet(t *testing.T) {
 	q, _ := newStore(t)
 


### PR DESCRIPTION
The queue listing (`sluice.Meta`) carried no Subject, so an admin client wanting to show it would have to fetch the raw message and parse it itself — which the Telegram bot (and a future web UI) would each re-implement. Per ADR 0017, the admin API should carry the fields interfaces need.

## What
- **`Meta.Subject`** — derived from the stored raw message **at List time** (RFC 2047-decoded; best-effort `""` on a malformed/charset-odd message, never failing the listing). **No new stored field, no migration/backfill** — `List` already unmarshals the full message (Size is `len(Raw)`), so this is computed on read.
- It flows through the admin API's `[]sluice.Meta` to **every client for free** (Telegram, web UI later).
- **`queue ls`** gains a `SUBJECT` column (truncated to 40 runes for table fit).

## Why this way
Subject-parsing lives once, in the store/API layer, instead of being re-implemented per client (the alternative was each client doing `GET /queue/{id}` + parse). Chosen because Subject is cleanly derivable at List time with no migration.

## Test
`TestListSubject` — plain subject, an RFC 2047 encoded-word (`=?utf-8?q?caf=C3=A9?=` → `café`), and an absent Subject header (→ empty, not an error).

Prep for #60 Inc 2 (Telegram notify reads `m.Subject`). Two-file touch (sluice + cmd). build/vet/gofmt/race/golangci-lint clean.
