### PR TITLE
feat: telegram queue notify + decision keyboard (#60 Inc 2)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -74,7 +74,8 @@ type CLI struct {
 
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
-	TelegramOperatorID int64 `name:"telegram-operator-id" help:"Telegram chat/user id permitted to approve/reject (only this id may act). Bot token via DARBAAN_TELEGRAM_TOKEN."`
+	TelegramOperatorID   int64         `name:"telegram-operator-id" help:"Telegram chat/user id permitted to approve/reject (only this id may act). Bot token via DARBAAN_TELEGRAM_TOKEN."`
+	TelegramPollInterval time.Duration `name:"telegram-poll-interval" default:"10s" help:"How often the Telegram client polls the admin queue for new held messages."`
 
 	ApprovalStrict []string `name:"approval-strict" default:"manual" help:"Approver chain for the strict path."`
 	ApprovalLight  []string `name:"approval-light" default:"manual" help:"Approver chain for the light path."`
@@ -158,7 +159,7 @@ func (*TelegramCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	tc, err := telegram.New(os.Getenv("DARBAAN_TELEGRAM_TOKEN"), cli.TelegramOperatorID, adminClient)
+	tc, err := telegram.New(os.Getenv("DARBAAN_TELEGRAM_TOKEN"), cli.TelegramOperatorID, cli.TelegramPollInterval, adminClient)
 	if err != nil {
 		return err
 	}

--- a/internal/telegram/format_internal_test.go
+++ b/internal/telegram/format_internal_test.go
@@ -1,0 +1,38 @@
+package telegram
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+func TestFormatPending(t *testing.T) {
+	m := sluice.Meta{ID: "7", From: "a@x.test", Rcpt: []string{"b@y.test", "c@y.test"}, Subject: "deploy keys", Size: 2048}
+	out := formatPending(m)
+	assert.Contains(t, out, "id: 7")
+	assert.Contains(t, out, "from: a@x.test")
+	assert.Contains(t, out, "to: b@y.test, c@y.test")
+	assert.Contains(t, out, "subject: deploy keys")
+	assert.Contains(t, out, "size: 2048 bytes")
+
+	// An empty subject reads as "(no subject)", never blank.
+	assert.Contains(t, formatPending(sluice.Meta{ID: "8", Subject: "  "}), "subject: (no subject)")
+}
+
+func TestDecisionKeyboard(t *testing.T) {
+	kb := decisionKeyboard("42")
+	var labels, data []string
+	for _, row := range kb.InlineKeyboard {
+		for _, b := range row {
+			labels = append(labels, b.Text)
+			data = append(data, b.CallbackData)
+		}
+	}
+	// All three decision buttons, each carrying its action + the message id.
+	assert.Len(t, labels, 3)
+	assert.Equal(t, []string{"approve:42", "reject_perm:42", "reject_retry:42"}, data)
+	assert.Contains(t, strings.Join(labels, "|"), "Approve")
+}

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -3,33 +3,51 @@
 // localhost-only admin API (#52). It is NOT compiled into serve; it holds only
 // a bot token and an admin-API token, never the mail credentials (ADR 0002).
 //
-// Increment 1 connects and logs readiness only — the queue notify / approve /
-// reject flow lands in later increments (#60).
+// It polls the admin queue and posts each new held message to the operator
+// chat with an [Approve] / [Reject permanent] / [Reject retryable] keyboard.
+// The button callbacks (the actual approve/reject) land in later increments
+// (#60); this increment is notify + de-dupe only.
 package telegram
 
 import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-telegram/bot"
 	"github.com/go-telegram/bot/models"
 
 	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// Callback-data prefixes for the decision buttons. The message id is appended;
+// the handlers that parse these land in later increments.
+const (
+	cbApprove     = "approve:"
+	cbRejectPerm  = "reject_perm:"
+	cbRejectRetry = "reject_retry:"
 )
 
 // Client is the Telegram approval interface.
 type Client struct {
-	bot        *bot.Bot
-	admin      *admin.Client
-	operatorID int64
+	bot          *bot.Bot
+	admin        *admin.Client
+	operatorID   int64
+	pollInterval time.Duration
+
+	mu     sync.Mutex
+	posted map[string]bool // message ids already sent to the operator
 }
 
 // New builds the Telegram client. The bot token is never logged; operatorID is
 // the only chat/user permitted to act (everyone else is ignored); adminClient
-// is the admin-API client through which verdicts are relayed. The bot is
-// constructed without a network call (the connect happens in Run).
-func New(token string, operatorID int64, adminClient *admin.Client) (*Client, error) {
+// is the admin-API client through which the queue is read and verdicts relayed.
+// The bot is constructed without a network call (the connect happens in Run).
+func New(token string, operatorID int64, pollInterval time.Duration, adminClient *admin.Client) (*Client, error) {
 	if token == "" {
 		return nil, fmt.Errorf("telegram: bot token is required (DARBAAN_TELEGRAM_TOKEN)")
 	}
@@ -39,26 +57,117 @@ func New(token string, operatorID int64, adminClient *admin.Client) (*Client, er
 	if adminClient == nil {
 		return nil, fmt.Errorf("telegram: an admin client is required")
 	}
+	if pollInterval <= 0 {
+		pollInterval = 10 * time.Second
+	}
 	b, err := bot.New(token, bot.WithSkipGetMe(), bot.WithDefaultHandler(ignoreUpdate))
 	if err != nil {
 		return nil, fmt.Errorf("telegram: init bot: %w", err)
 	}
-	return &Client{bot: b, admin: adminClient, operatorID: operatorID}, nil
+	return &Client{
+		bot:          b,
+		admin:        adminClient,
+		operatorID:   operatorID,
+		pollInterval: pollInterval,
+		posted:       make(map[string]bool),
+	}, nil
 }
 
-// Run connects to Telegram, logs readiness, and runs the update loop until ctx
-// is cancelled. Increment 1 has no queue logic — it only proves the process
-// comes up as a working admin-API client.
+// Run connects to Telegram, logs readiness, polls the queue for new held
+// messages, and runs the update loop until ctx is cancelled.
 func (c *Client) Run(ctx context.Context) error {
 	me, err := c.bot.GetMe(ctx)
 	if err != nil {
 		return fmt.Errorf("telegram: connect: %w", err)
 	}
-	log.Printf("darbaan telegram: ready — bot @%s, operator %d, relaying to the admin API", me.Username, c.operatorID)
+	log.Printf("darbaan telegram: ready — bot @%s, operator %d, polling the queue every %s", me.Username, c.operatorID, c.pollInterval)
+
+	go c.pollLoop(ctx)
 	c.bot.Start(ctx) // long-poll loop; returns when ctx is cancelled
 	return nil
 }
 
-// ignoreUpdate drops incoming updates in Increment 1; notify/approve/reject
-// handlers land in later increments.
+func (c *Client) pollLoop(ctx context.Context) {
+	t := time.NewTicker(c.pollInterval)
+	defer t.Stop()
+	c.poll(ctx) // post anything already pending at startup
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			c.poll(ctx)
+		}
+	}
+}
+
+// poll lists the queue and notifies the operator of each new pending message.
+// A message is marked posted only after a successful send, so a transient send
+// failure simply retries on the next tick.
+func (c *Client) poll(ctx context.Context) {
+	metas, err := c.admin.List(ctx)
+	if err != nil {
+		log.Printf("darbaan telegram: poll: %v", err)
+		return
+	}
+	for _, m := range metas {
+		if m.Status != sluice.StatusPending || c.seen(m.ID) {
+			continue
+		}
+		if err := c.notify(ctx, m); err != nil {
+			log.Printf("darbaan telegram: notify %s: %v", m.ID, err)
+			continue
+		}
+		c.markPosted(m.ID)
+	}
+}
+
+func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
+	_, err := c.bot.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      c.operatorID,
+		Text:        formatPending(m),
+		ReplyMarkup: decisionKeyboard(m.ID),
+	})
+	return err
+}
+
+func (c *Client) seen(id string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.posted[id]
+}
+
+func (c *Client) markPosted(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.posted[id] = true
+}
+
+// formatPending renders the operator-facing notification (plain text — no parse
+// mode, so addresses and subjects never need markdown escaping). Subject comes
+// from the queue listing (sluice.Meta), already parsed by the store.
+func formatPending(m sluice.Meta) string {
+	subject := m.Subject
+	if strings.TrimSpace(subject) == "" {
+		subject = "(no subject)"
+	}
+	return fmt.Sprintf("Held outbound message\nid: %s\nfrom: %s\nto: %s\nsubject: %s\nsize: %d bytes",
+		m.ID, m.From, strings.Join(m.Rcpt, ", "), subject, m.Size)
+}
+
+// decisionKeyboard lays in all three decision buttons. The callbacks are wired
+// in later increments; the callback data carries the action + message id.
+func decisionKeyboard(id string) models.InlineKeyboardMarkup {
+	return models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{
+			{{Text: "Approve", CallbackData: cbApprove + id}},
+			{
+				{Text: "Reject (permanent)", CallbackData: cbRejectPerm + id},
+				{Text: "Reject (retryable)", CallbackData: cbRejectRetry + id},
+			},
+		},
+	}
+}
+
+// ignoreUpdate drops incoming updates until the approve/reject handlers land.
 func ignoreUpdate(context.Context, *bot.Bot, *models.Update) {}

--- a/internal/telegram/telegram_test.go
+++ b/internal/telegram/telegram_test.go
@@ -2,6 +2,7 @@ package telegram_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,20 +14,20 @@ import (
 func TestNewValidation(t *testing.T) {
 	ac := admin.NewClient("127.0.0.1:1144", "admintoken")
 
-	_, err := telegram.New("", 12345, ac)
+	_, err := telegram.New("", 12345, time.Second, ac)
 	require.Error(t, err) // empty bot token
 
-	_, err = telegram.New("123:bot-token", 0, ac)
+	_, err = telegram.New("123:bot-token", 0, time.Second, ac)
 	require.Error(t, err) // no operator id
 
-	_, err = telegram.New("123:bot-token", 12345, nil)
+	_, err = telegram.New("123:bot-token", 12345, time.Second, nil)
 	require.Error(t, err) // no admin client
 }
 
 func TestNewSucceedsWithoutNetwork(t *testing.T) {
 	// WithSkipGetMe means construction does not call the Telegram API; the
 	// connect happens in Run.
-	c, err := telegram.New("123:fake-token", 12345, admin.NewClient("127.0.0.1:1144", "tok"))
+	c, err := telegram.New("123:fake-token", 12345, 0, admin.NewClient("127.0.0.1:1144", "tok"))
 	require.NoError(t, err)
 	assert.NotNil(t, c)
 }


### PR DESCRIPTION
**Increment 2** of the Telegram approval client (#60). The client now polls the admin queue and notifies the operator of each new held message.

## What
- **Poll** `GET /queue` on `telegram-poll-interval` (default 10s). For each **PENDING** message not already posted, send the operator chat a notification — id, from, to, **subject**, size — with an inline keyboard.
- **Subject** comes from the queue listing (`sluice.Meta`, #62) — no per-message fetch/parse in the client.
- **De-dupe** by message id (mutex-guarded; the Inc 3/4 callback handlers share it). A message is marked posted only **after a successful send**, so a transient send failure retries next tick.
- **Keyboard**: all three decision buttons laid in now — `[Approve]` `[Reject (permanent)]` `[Reject (retryable)]` — callback data carries the action + id. The callbacks are wired in Inc 3 (approve) / Inc 4 (reject + force-reply reason); updates are still ignored this increment.

Plain-text notifications (no parse mode) so addresses/subjects never need markdown escaping.

## Verification
- `go build`/`vet`/`gofmt -l` clean; `go test -race ./...` green; `golangci-lint` 0 issues.
- Tests: `formatPending` (fields + empty-subject → `(no subject)`); `decisionKeyboard` (three buttons, callback data `approve:/reject_perm:/reject_retry:` + id); `New` validation; flags present (`telegram-poll-interval` default 10s).
- The live poll→send path is exercised end-to-end once Inc 4 lands, with the real bot token.

Increment 2 of #60 (does not close the epic). Two-file touch (telegram + cmd).
