### PR TITLE
feat: telegram Approve callback (#60 Inc 3)

### DIFF
--- a/internal/telegram/format_internal_test.go
+++ b/internal/telegram/format_internal_test.go
@@ -1,11 +1,15 @@
 package telegram
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/go-telegram/bot/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -35,4 +39,23 @@ func TestDecisionKeyboard(t *testing.T) {
 	assert.Len(t, labels, 3)
 	assert.Equal(t, []string{"approve:42", "reject_perm:42", "reject_retry:42"}, data)
 	assert.Contains(t, strings.Join(labels, "|"), "Approve")
+}
+
+func TestDecisionResult(t *testing.T) {
+	assert.Equal(t, "Approved 7 — approved and sent upstream",
+		decisionResult("Approved", "7", admin.Outcome{Detail: "approved and sent upstream"}, nil))
+	assert.Contains(t,
+		decisionResult("Approved", "7", admin.Outcome{Detail: "approved", Warn: "send failed permanently"}, nil),
+		"[warning: send failed permanently]")
+	assert.Contains(t,
+		decisionResult("Approved", "7", admin.Outcome{}, errors.New("message is rejected, not pending")),
+		"failed (7): message is rejected")
+}
+
+func TestIsOperatorGate(t *testing.T) {
+	c, err := New("123:fake", 999, 0, admin.NewClient("127.0.0.1:1144", "t"))
+	require.NoError(t, err)
+	assert.True(t, c.isOperator(&models.CallbackQuery{From: models.User{ID: 999}}))
+	assert.False(t, c.isOperator(&models.CallbackQuery{From: models.User{ID: 111}})) // not the operator
+	assert.False(t, c.isOperator(nil))
 }

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -64,13 +64,16 @@ func New(token string, operatorID int64, pollInterval time.Duration, adminClient
 	if err != nil {
 		return nil, fmt.Errorf("telegram: init bot: %w", err)
 	}
-	return &Client{
+	c := &Client{
 		bot:          b,
 		admin:        adminClient,
 		operatorID:   operatorID,
 		pollInterval: pollInterval,
 		posted:       make(map[string]bool),
-	}, nil
+	}
+	// [Approve] button. The reject buttons are wired in the next increment.
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbApprove, bot.MatchTypePrefix, c.handleApprove)
+	return c, nil
 }
 
 // Run connects to Telegram, logs readiness, polls the queue for new held
@@ -169,5 +172,62 @@ func decisionKeyboard(id string) models.InlineKeyboardMarkup {
 	}
 }
 
-// ignoreUpdate drops incoming updates until the approve/reject handlers land.
+// handleApprove is the [Approve] button callback: verify the operator, approve
+// via the admin API, and edit the notification to show the outcome.
+func (c *Client) handleApprove(ctx context.Context, b *bot.Bot, update *models.Update) {
+	cq := update.CallbackQuery
+	if !c.isOperator(cq) {
+		c.denyCallback(ctx, b, cq)
+		return
+	}
+	id := strings.TrimPrefix(cq.Data, cbApprove)
+	out, err := c.admin.Approve(ctx, id)
+	c.finishDecision(ctx, b, cq, "Approved", id, out, err)
+}
+
+// isOperator reports whether a callback came from the configured operator — the
+// core security property: only the operator may decide (ADR 0002).
+func (c *Client) isOperator(cq *models.CallbackQuery) bool {
+	return cq != nil && cq.From.ID == c.operatorID
+}
+
+// denyCallback rejects a callback from anyone but the operator.
+func (c *Client) denyCallback(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery) {
+	log.Printf("darbaan telegram: ignored callback from non-operator %d", cq.From.ID)
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: cq.ID, Text: "Not authorized.", ShowAlert: true,
+	})
+}
+
+// finishDecision dismisses the button spinner and rewrites the notification to
+// the outcome, clearing the keyboard so it cannot be tapped again.
+func (c *Client) finishDecision(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery, verb, id string, out admin.Outcome, err error) {
+	result := decisionResult(verb, id, out, err)
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID, Text: verb})
+	if msg := cq.Message.Message; msg != nil {
+		_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
+			ChatID:      msg.Chat.ID,
+			MessageID:   msg.ID,
+			Text:        result,
+			ReplyMarkup: models.InlineKeyboardMarkup{}, // clear the buttons
+		})
+	}
+	log.Printf("darbaan telegram: %s", result)
+}
+
+// decisionResult renders the operator-facing outcome line. A committed verdict
+// with a downstream send/bounce warning is shown as such (distinct from a
+// failed verdict).
+func decisionResult(verb, id string, out admin.Outcome, err error) string {
+	switch {
+	case err != nil:
+		return fmt.Sprintf("%s failed (%s): %v", verb, id, err)
+	case out.Warn != "":
+		return fmt.Sprintf("%s %s — %s [warning: %s]", verb, id, out.Detail, out.Warn)
+	default:
+		return fmt.Sprintf("%s %s — %s", verb, id, out.Detail)
+	}
+}
+
+// ignoreUpdate drops updates that aren't a wired decision callback.
 func ignoreUpdate(context.Context, *bot.Bot, *models.Update) {}


### PR DESCRIPTION
**Increment 3** of the Telegram approval client (#60). The `[Approve]` button now works end to end.

## What
- Register a callback handler on the `approve:` prefix. On tap: **verify the caller is the configured operator** (`isOperator` — only the operator may decide, ADR 0002), `POST /queue/{id}/approve` via the admin client, dismiss the button spinner, and **rewrite the notification to the outcome** with the keyboard cleared so it can't be tapped twice.
- A committed verdict with a downstream send/bounce **warning** is shown as such (`decisionResult`), distinct from a failed verdict.
- A callback from **anyone but the operator** is answered "Not authorized" and ignored.

## Not yet (Inc 4)
The two reject buttons are still unwired — they land in Inc 4 with the force-reply reason prompt — so tapping them does nothing until then. (The whole client is live-tested at Inc 4.)

## Verification
- build/vet/gofmt/`go test -race`/golangci-lint clean.
- Tests: `decisionResult` (sent / warning / error) and the `isOperator` gate (operator / non-operator / nil).

Increment 3 of #60 (does not close the epic). Single-package touch (telegram).
