### PR TITLE
feat: telegram shows display-name addresses + flags hidden (Bcc) recipients

### DIFF
--- a/internal/telegram/body.go
+++ b/internal/telegram/body.go
@@ -2,11 +2,13 @@ package telegram
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 
 	gomessage "github.com/emersion/go-message"
 	_ "github.com/emersion/go-message/charset" // register charsets so non-UTF-8 bodies decode
+	gomail "github.com/emersion/go-message/mail"
 )
 
 // bodyText extracts the decoded text/plain body from a raw message so the
@@ -54,4 +56,67 @@ func extractText(ent *gomessage.Entity) string {
 		}
 	}
 	return nested
+}
+
+// headerAddrs parses the human display form of the From and To/Cc headers
+// (RFC 2047-decoded "Name <addr>") and the lower-cased set of header recipient
+// addresses (for the hidden-recipient check). parsed is false when the message
+// can't be read — so a fetch/parse failure never false-flags every recipient.
+func headerAddrs(raw []byte) (from, to string, headerSet map[string]bool, parsed bool) {
+	headerSet = map[string]bool{}
+	if len(raw) == 0 {
+		return "", "", headerSet, false
+	}
+	ent, _ := gomessage.Read(bytes.NewReader(raw))
+	if ent == nil {
+		return "", "", headerSet, false
+	}
+	h := gomail.Header{Header: ent.Header}
+	from = addrDisplay(addrList(h, "From"))
+
+	var rcpts []*gomail.Address
+	rcpts = append(rcpts, addrList(h, "To")...)
+	rcpts = append(rcpts, addrList(h, "Cc")...)
+	parts := make([]string, 0, len(rcpts))
+	for _, a := range rcpts {
+		parts = append(parts, formatAddr(a))
+		headerSet[strings.ToLower(a.Address)] = true
+	}
+	return from, strings.Join(parts, ", "), headerSet, true
+}
+
+func addrList(h gomail.Header, key string) []*gomail.Address {
+	as, err := h.AddressList(key)
+	if err != nil {
+		return nil
+	}
+	return as
+}
+
+func addrDisplay(as []*gomail.Address) string {
+	parts := make([]string, 0, len(as))
+	for _, a := range as {
+		parts = append(parts, formatAddr(a))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// formatAddr renders an address as "Name <addr>" (decoded name) or bare address.
+func formatAddr(a *gomail.Address) string {
+	if a.Name != "" {
+		return fmt.Sprintf("%s <%s>", a.Name, a.Address)
+	}
+	return a.Address
+}
+
+// hiddenRcpts returns the envelope recipients not present in the header To/Cc —
+// the Bcc/hidden recipients the operator would otherwise approve unseen.
+func hiddenRcpts(envelope []string, headerSet map[string]bool) []string {
+	var hidden []string
+	for _, r := range envelope {
+		if !headerSet[strings.ToLower(strings.TrimSpace(r))] {
+			hidden = append(hidden, r)
+		}
+	}
+	return hidden
 }

--- a/internal/telegram/body_internal_test.go
+++ b/internal/telegram/body_internal_test.go
@@ -37,22 +37,44 @@ func TestBodyTextNoTextPart(t *testing.T) {
 }
 
 func TestFormatNotificationBody(t *testing.T) {
-	m := sluice.Meta{ID: "7", From: "a@x", Rcpt: []string{"b@y"}, Subject: "s", Size: 10}
-
-	out := formatNotification(m, "the message body")
+	out := formatNotification(notification{id: "7", from: "Alice <a@x>", to: "Bob <b@y>", subject: "s", size: 10, body: "the message body"})
+	assert.Contains(t, out, "from: Alice <a@x>")
+	assert.Contains(t, out, "to: Bob <b@y>")
 	assert.Contains(t, out, "subject: s")
 	assert.Contains(t, out, "--- body ---")
 	assert.Contains(t, out, "the message body")
 
-	assert.Contains(t, formatNotification(m, ""), "(no text body)")
+	assert.Contains(t, formatNotification(notification{id: "7", body: ""}), "(no text body)")
 }
 
 func TestFormatNotificationTruncates(t *testing.T) {
-	m := sluice.Meta{ID: "7", Subject: "s"}
-	big := strings.Repeat("x", 8000)
-	out := formatNotification(m, big)
+	out := formatNotification(notification{id: "7", subject: "s", body: strings.Repeat("x", 8000)})
 	assert.LessOrEqual(t, len([]rune(out)), maxNotificationRunes)
 	assert.Contains(t, out, "...(truncated, 8000 bytes)")
+}
+
+func TestFormatNotificationHidden(t *testing.T) {
+	out := formatNotification(notification{id: "7", to: "Bob <b@y>", hidden: []string{"secret@z"}, body: "x"})
+	assert.Contains(t, out, "(!) also delivering to (not in headers): secret@z")
+}
+
+func TestHeaderAddrs(t *testing.T) {
+	raw := []byte("From: Alice <a@x.test>\r\nTo: Bob <b@y.test>\r\nCc: c@z.test\r\nSubject: s\r\n\r\nbody")
+	from, to, set, parsed := headerAddrs(raw)
+	assert.True(t, parsed)
+	assert.Equal(t, "Alice <a@x.test>", from)
+	assert.Equal(t, "Bob <b@y.test>, c@z.test", to)
+	assert.True(t, set["b@y.test"] && set["c@z.test"])
+
+	_, _, _, parsed = headerAddrs(nil)
+	assert.False(t, parsed) // no false-flagging when unparseable
+}
+
+func TestHiddenRcpts(t *testing.T) {
+	set := map[string]bool{"b@y.test": true}
+	// secret@z is in the envelope but not the headers — a Bcc the operator must see.
+	assert.Equal(t, []string{"secret@z.test"}, hiddenRcpts([]string{"b@y.test", "secret@z.test"}, set))
+	assert.Empty(t, hiddenRcpts([]string{"b@y.test"}, set))
 }
 
 func TestPrunePosted(t *testing.T) {

--- a/internal/telegram/format_internal_test.go
+++ b/internal/telegram/format_internal_test.go
@@ -11,20 +11,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yaad-index/darbaan/internal/admin"
-	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
-func TestFormatPending(t *testing.T) {
-	m := sluice.Meta{ID: "7", From: "a@x.test", Rcpt: []string{"b@y.test", "c@y.test"}, Subject: "deploy keys", Size: 2048}
-	out := formatPending(m)
-	assert.Contains(t, out, "id: 7")
-	assert.Contains(t, out, "from: a@x.test")
-	assert.Contains(t, out, "to: b@y.test, c@y.test")
-	assert.Contains(t, out, "subject: deploy keys")
-	assert.Contains(t, out, "size: 2048 bytes")
-
-	// An empty subject reads as "(no subject)", never blank.
-	assert.Contains(t, formatPending(sluice.Meta{ID: "8", Subject: "  "}), "subject: (no subject)")
+func TestDisplaySubject(t *testing.T) {
+	assert.Equal(t, "deploy keys", displaySubject("deploy keys"))
+	assert.Equal(t, "(no subject)", displaySubject("  "))
+	assert.Equal(t, "(no subject)", displaySubject(""))
 }
 
 func TestDecisionKeyboard(t *testing.T) {

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -148,16 +148,36 @@ func (c *Client) poll(ctx context.Context) {
 }
 
 func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
-	// Fetch the raw message for the body so the operator can review what they're
-	// approving. De-dupe means this is one fetch per message. A fetch failure
-	// still notifies, with headers only.
+	// Fetch the raw message for the body + display addresses so the operator can
+	// review what they're approving. De-dupe means one fetch per message; a
+	// fetch failure still notifies, falling back to the envelope values.
 	raw, err := c.admin.Show(ctx, m.ID)
 	if err != nil {
 		log.Printf("darbaan telegram: fetch body %s: %v", m.ID, err)
 	}
+	from, to, headerSet, parsed := headerAddrs(raw)
+	if from == "" {
+		from = m.From
+	}
+	if to == "" {
+		to = strings.Join(m.Rcpt, ", ")
+	}
+	n := notification{
+		id:      m.ID,
+		from:    from,
+		to:      to,
+		subject: displaySubject(m.Subject),
+		size:    m.Size,
+		body:    bodyText(raw),
+	}
+	// Surface recipients that deliver but aren't visible in the headers (Bcc),
+	// but only when we could actually read the headers.
+	if parsed {
+		n.hidden = hiddenRcpts(m.Rcpt, headerSet)
+	}
 	_, err = c.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:      c.operatorID,
-		Text:        formatNotification(m, bodyText(raw)),
+		Text:        formatNotification(n),
 		ReplyMarkup: decisionKeyboard(m.ID),
 	})
 	return err
@@ -193,28 +213,42 @@ func (c *Client) markPosted(id string) {
 	c.posted[id] = true
 }
 
-// formatPending renders the operator-facing notification (plain text — no parse
-// mode, so addresses and subjects never need markdown escaping). Subject comes
-// from the queue listing (sluice.Meta), already parsed by the store.
-func formatPending(m sluice.Meta) string {
-	subject := m.Subject
-	if strings.TrimSpace(subject) == "" {
-		subject = "(no subject)"
+// notification is the display-ready content of an operator notification.
+type notification struct {
+	id      string
+	from    string // header display form, falling back to the envelope sender
+	to      string // header To/Cc display form, falling back to the envelope rcpts
+	subject string
+	size    int
+	hidden  []string // envelope recipients not in the headers (Bcc)
+	body    string
+}
+
+func displaySubject(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "(no subject)"
 	}
-	return fmt.Sprintf("Held outbound message\nid: %s\nfrom: %s\nto: %s\nsubject: %s\nsize: %d bytes",
-		m.ID, m.From, strings.Join(m.Rcpt, ", "), subject, m.Size)
+	return s
 }
 
 // maxNotificationRunes keeps the notification within Telegram's 4096-char cap
 // with headroom for the keyboard and the truncation marker.
 const maxNotificationRunes = 3900
 
-// formatNotification renders the headers followed by the message body so the
-// operator reviews the content before deciding. The body is truncated
-// (rune-safe) with a marker when the whole notification would exceed the cap.
-func formatNotification(m sluice.Meta, body string) string {
-	header := formatPending(m)
-	if body == "" {
+// formatNotification renders the headers (human address forms, plus a flag for
+// any hidden recipient) followed by the message body so the operator reviews
+// the content before deciding. The body is truncated (rune-safe) with a marker
+// when the whole notification would exceed the cap. Plain text — no parse mode,
+// so addresses and subjects never need markdown escaping.
+func formatNotification(n notification) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Held outbound message\nid: %s\nfrom: %s\nto: %s\nsubject: %s\nsize: %d bytes",
+		n.id, n.from, n.to, n.subject, n.size)
+	if len(n.hidden) > 0 {
+		fmt.Fprintf(&b, "\n(!) also delivering to (not in headers): %s", strings.Join(n.hidden, ", "))
+	}
+	header := b.String()
+	if n.body == "" {
 		return header + "\n\n(no text body)"
 	}
 	prefix := header + "\n\n--- body ---\n"
@@ -222,10 +256,10 @@ func formatNotification(m sluice.Meta, body string) string {
 	if avail < 0 {
 		avail = 0
 	}
-	if br := []rune(body); len(br) > avail {
-		return prefix + string(br[:avail]) + fmt.Sprintf("\n...(truncated, %d bytes)", len(body))
+	if br := []rune(n.body); len(br) > avail {
+		return prefix + string(br[:avail]) + fmt.Sprintf("\n...(truncated, %d bytes)", len(n.body))
 	}
-	return prefix + body
+	return prefix + n.body
 }
 
 // decisionKeyboard lays in all three decision buttons. The callbacks are wired


### PR DESCRIPTION
Live-test finding. The notification showed the **envelope** addresses (`Meta.From` / `Rcpt`), not the header display-name form — and, more importantly, gave the operator no way to see a recipient that delivers but isn't in the visible headers (a **Bcc**).

## What
- `notify` parses From and To/Cc from the raw message (already fetched for the body) via `go-message/mail` and renders the human **"Name <addr>"** form (RFC 2047 decoded), falling back to the envelope value when a header is absent or unparseable.
- **Security (the gate-relevant half):** it computes the envelope recipients (`Meta.Rcpt`) **not** present in the header To/Cc and flags them explicitly — `(!) also delivering to (not in headers): …`. The operator must never approve a send to a recipient they couldn't see. The check runs **only when the message parsed**, so a fetch/parse failure never false-flags every recipient.

Notification rendering moves to a `notification` struct; `formatPending` is retired.

## Verification
- build/vet/gofmt/`go test -race`/golangci-lint clean.
- Tests: `headerAddrs` (display form + unparseable→not-parsed), `hiddenRcpts` (Bcc detected / none), `formatNotification` (hidden line / body / truncation), plus the existing body-decoding tests.

Single-package touch (telegram). After merge: redeploy + re-verify the operator sees display-name from/to and any Bcc flagged.
