### PR TITLE
fix: telegram strips reject keyboard immediately (interim state)

### DIFF
--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -372,6 +372,11 @@ func (c *Client) promptReason(ctx context.Context, b *bot.Bot, cq *models.Callba
 	c.pending[prompt.ID] = rejectState{id: id, retryable: retryable, origChatID: msg.Chat.ID, origMsgID: msg.ID, at: time.Now()}
 	c.mu.Unlock()
 	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID, Text: "Reason?"})
+	// Strip the keyboard on the original notification and show an interim state,
+	// so a tapped-but-unfinished reject is visibly distinct from untouched
+	// messages when several are open. handleReasonReply overwrites this with the
+	// final outcome once the reason arrives.
+	c.editResult(ctx, b, msg.Chat.ID, msg.ID, fmt.Sprintf("⏳ Rejecting %s — awaiting your reason", id))
 }
 
 // prunePendingLocked drops reason prompts older than pendingTTL — those the


### PR DESCRIPTION
Live-test UX finding: tapping **Reject** opens a force-reply for the reason but leaves the original notification's buttons in place, so with several messages open the operator can't tell which they've already acted on. (Approve already clears immediately.)

## Fix
`promptReason`, after the prompt is sent and `pending` is stored, edits the original notification to **strip the keyboard** and show `⏳ Rejecting {id} — awaiting your reason`. `handleReasonReply` overwrites that with the final outcome once the reason arrives.

On a prompt-send failure the keyboard is **left intact** (the existing retry path), so only a successful prompt removes the buttons.

build/vet/gofmt/`go test -race`/golangci-lint clean. Single-line behavior change; the reject/reason gate tests are unchanged. Telegram-only; redeploy + re-verify after merge.
