### PR TITLE
fix: telegram actually removes the keyboard on edit (empty slice, not nil)

### DIFF
--- a/internal/telegram/format_internal_test.go
+++ b/internal/telegram/format_internal_test.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -12,6 +13,19 @@ import (
 
 	"github.com/yaad-index/darbaan/internal/admin"
 )
+
+func TestEmptyKeyboardClearsOnEdit(t *testing.T) {
+	b, err := json.Marshal(emptyKeyboard())
+	require.NoError(t, err)
+	// [] actually removes the keyboard on editMessageText.
+	assert.Equal(t, `{"inline_keyboard":[]}`, string(b))
+
+	// The zero value would serialize to null, which Telegram leaves untouched —
+	// the bug this guards against.
+	z, err := json.Marshal(models.InlineKeyboardMarkup{})
+	require.NoError(t, err)
+	assert.Equal(t, `{"inline_keyboard":null}`, string(z))
+}
 
 func TestDisplaySubject(t *testing.T) {
 	assert.Equal(t, "deploy keys", displaySubject("deploy keys"))

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -312,14 +312,22 @@ func (c *Client) finishDecision(ctx context.Context, b *bot.Bot, cq *models.Call
 	}
 }
 
-// editResult rewrites a notification to a final outcome line, clearing any
-// keyboard so it cannot be acted on again.
+// emptyKeyboard removes an inline keyboard on edit. It must carry a non-nil
+// empty slice: the zero value InlineKeyboardMarkup{} marshals to
+// `{"inline_keyboard":null}`, which Telegram treats as "no change" and leaves
+// the buttons; an empty slice marshals to `[]`, which actually clears them.
+func emptyKeyboard() models.InlineKeyboardMarkup {
+	return models.InlineKeyboardMarkup{InlineKeyboard: [][]models.InlineKeyboardButton{}}
+}
+
+// editResult rewrites a notification to a final outcome line, clearing the
+// keyboard so a decided message cannot be tapped again.
 func (c *Client) editResult(ctx context.Context, b *bot.Bot, chatID int64, msgID int, result string) {
 	_, _ = b.EditMessageText(ctx, &bot.EditMessageTextParams{
 		ChatID:      chatID,
 		MessageID:   msgID,
 		Text:        result,
-		ReplyMarkup: models.InlineKeyboardMarkup{},
+		ReplyMarkup: emptyKeyboard(),
 	})
 	log.Printf("darbaan telegram: %s", result)
 }


### PR DESCRIPTION
Maintainer-found bug. `editResult` passed `models.InlineKeyboardMarkup{}` (zero value, `InlineKeyboard=nil`) to `EditMessageText`, which marshals to `{"inline_keyboard":null}`. **Telegram treats null as "no change" and leaves the buttons** — so after approve/reject the text updated to the outcome but the keyboard stayed, and a decided message could be tapped again. (The server correctly refused the second decision, so no double-commit — purely a UI bug.)

## Fix
Clear via a **non-nil empty slice** — `InlineKeyboard: [][]InlineKeyboardButton{}` — which marshals to `{"inline_keyboard":[]}` and actually removes the keyboard. Routed through one `emptyKeyboard()` helper used by `editResult`, so **all three clear-paths** (approve final, reject final, reject interim strip) are fixed at once.

## Test
Asserts the serialized forms directly: `emptyKeyboard()` → `{"inline_keyboard":[]}` (clears) vs the zero value → `{"inline_keyboard":null}` (the bug being guarded against). Don't trust the zero value — the test pins the distinction.

build/vet/gofmt/`go test -race`/golangci-lint clean. Telegram-only; redeploy + re-verify the buttons disappear on a decided message.
