### PR TITLE
fix: telegram pre-checks message status, explains stale taps

### DIFF
--- a/internal/telegram/format_internal_test.go
+++ b/internal/telegram/format_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
 func TestEmptyKeyboardClearsOnEdit(t *testing.T) {
@@ -65,6 +66,27 @@ func TestIsOperatorGate(t *testing.T) {
 	assert.True(t, c.isOperator(&models.CallbackQuery{From: models.User{ID: 999}}))
 	assert.False(t, c.isOperator(&models.CallbackQuery{From: models.User{ID: 111}})) // not the operator
 	assert.False(t, c.isOperator(nil))
+}
+
+func TestPendingGuardResult(t *testing.T) {
+	// Still pending → proceed, no message.
+	proceed, msg := pendingGuardResult("7", sluice.StatusPending, true, nil)
+	assert.True(t, proceed)
+	assert.Empty(t, msg)
+
+	// Lookup error → proceed (server-side guard backstops).
+	proceed, _ = pendingGuardResult("7", "", false, errors.New("list failed"))
+	assert.True(t, proceed)
+
+	// Already decided → stop with the status.
+	proceed, msg = pendingGuardResult("7", sluice.StatusRejected, true, nil)
+	assert.False(t, proceed)
+	assert.Equal(t, "Message 7: already rejected", msg)
+
+	// Gone from the queue → stop.
+	proceed, msg = pendingGuardResult("7", "", false, nil)
+	assert.False(t, proceed)
+	assert.Equal(t, "Message 7: no longer in the queue", msg)
 }
 
 func TestIsReply(t *testing.T) {

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -285,8 +285,61 @@ func (c *Client) handleApprove(ctx context.Context, b *bot.Bot, update *models.U
 		return
 	}
 	id := strings.TrimPrefix(cq.Data, cbApprove)
+	if !c.guardPending(ctx, b, cq, id) {
+		return
+	}
 	out, err := c.admin.Approve(ctx, id)
 	c.finishDecision(ctx, b, cq, "Approved", id, out, err)
+}
+
+// guardPending pre-checks a tapped message's status so a stale duplicate tap is
+// explained rather than silently re-running. It returns true to proceed (still
+// pending, or the status couldn't be looked up — the server-side not-pending
+// guard is the backstop) and false after telling the operator the message is
+// already decided / gone and stripping its notification.
+func (c *Client) guardPending(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery, id string) bool {
+	status, found, err := c.statusOf(ctx, id)
+	proceed, msg := pendingGuardResult(id, status, found, err)
+	if proceed {
+		return true
+	}
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: cq.ID, Text: msg, ShowAlert: true,
+	})
+	if m := cq.Message.Message; m != nil {
+		c.editResult(ctx, b, m.Chat.ID, m.ID, msg)
+	}
+	return false
+}
+
+// statusOf looks up a message's current status from the queue listing.
+func (c *Client) statusOf(ctx context.Context, id string) (sluice.Status, bool, error) {
+	metas, err := c.admin.List(ctx)
+	if err != nil {
+		return "", false, err
+	}
+	for _, m := range metas {
+		if m.ID == id {
+			return m.Status, true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// pendingGuardResult decides whether to proceed with a decision and, if not,
+// the message to show the operator. A lookup error proceeds (the server-side
+// guard backstops); a still-pending message proceeds; anything else stops.
+func pendingGuardResult(id string, status sluice.Status, found bool, listErr error) (proceed bool, msg string) {
+	switch {
+	case listErr != nil:
+		return true, ""
+	case found && status == sluice.StatusPending:
+		return true, ""
+	case !found:
+		return false, fmt.Sprintf("Message %s: no longer in the queue", id)
+	default:
+		return false, fmt.Sprintf("Message %s: already %s", id, status)
+	}
 }
 
 // isOperator reports whether a callback came from the configured operator — the
@@ -356,6 +409,9 @@ func (c *Client) promptReason(ctx context.Context, b *bot.Bot, cq *models.Callba
 		return
 	}
 	id := strings.TrimPrefix(cq.Data, prefix)
+	if !c.guardPending(ctx, b, cq, id) {
+		return // already decided / gone — don't prompt for a reason
+	}
 	kind := "permanent"
 	if retryable {
 		kind = "retryable"


### PR DESCRIPTION
Follow-on to the keyboard-clear fix (#70). A second decision tap on an already-decided message used to be silent — for reject, it sent **another** reason prompt and only errored after the operator typed a reason.

## Fix
`handleApprove` and `promptReason` now pre-check the message's current status (`guardPending` → `admin.List` lookup). If it's **not pending** — already approved / rejected / sent, or gone from the queue — the operator gets a `ShowAlert` and the notification is rewritten to `Message {id}: already {status}` (clearing the keyboard via the #70 fix), and the handler returns **without** approving or prompting.

A **lookup failure proceeds** and lets the server-side not-pending guard backstop, rather than block on an uncertain lookup. That server-side guard remains the source of truth; this is operator-facing clarity on top of it.

## Test
The decision is a pure helper (`pendingGuardResult`), unit-tested: pending→proceed, lookup-error→proceed, decided→stop (with `already {status}`), gone→stop. The `admin.List` glue is exercised live.

build/vet/gofmt/`go test -race`/golangci-lint clean. Telegram-only. With #70, completes the maintainer's two-part finding — decided messages have no buttons, and a stale-duplicate tap is clearly explained.
