### PR TITLE
ci(release): add release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: release-please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: go
+          # No custom release-rules — the action's defaults match the
+          # conventional-commits type→bump table the fleet follows.


### PR DESCRIPTION
Wires **release-please** (#19, parked since MVP) so versions + changelog derive from conventional-commit history.

## What
`.github/workflows/release-please.yml` — `googleapis/release-please-action@v4`, `release-type: go`, on push to `main`, granting the workflow `GITHUB_TOKEN` `contents: write` + `pull-requests: write`. No custom release-rules (the action defaults match the fleet's type→bump table).

## First run
The repo has no tags yet, so the first run after this merges opens a **"Release v0.x.y"** PR aggregating all history + a generated `CHANGELOG.md`. We review + merge that PR to cut the first tag + GitHub Release.

## Actions-permission check (the gotcha)
Verified compatible: the repo has `default_workflow_permissions: read` **but** `can_approve_pull_request_reviews: true` (Actions may create PRs), and this workflow declares explicit `permissions:` — which grant the write scopes at the workflow level regardless of the read default (the default only bites workflows that declare none). So no repo-setting change is needed. If the first run still errors on open-PR or tag-push, the fallback is flipping `default_workflow_permissions` to write or passing a PAT via the action's `token:` input.

YAML validated; `ci.yml` untouched. ci/build PR. **closes #19.**
