### PR TITLE
build(compose): run the telegram bot as a permanent service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,10 @@ DARBAAN_ADMIN_TOKEN=change-me-too
 # Upstream Gmail app password — ONLY needed once you flip DARBAAN_SENDER_TYPE=smtp
 # in docker-compose.yml. Leave blank while sender-type=stub (nothing sends).
 DARBAAN_SMTP_PASSWORD=
+
+# Telegram approval client (the darbaan-telegram service). Both required to run
+# it; leave the service stopped if you don't use Telegram approvals.
+#   - Bot token from @BotFather (never logged).
+DARBAAN_TELEGRAM_TOKEN=
+#   - The operator's Telegram chat/user id — ONLY this id may approve/reject.
+DARBAAN_TELEGRAM_OPERATOR_ID=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,5 +54,25 @@ services:
       - ./secrets/dkim:/run/secrets/dkim:ro # you provide dkim.pem (ed25519)
       # - ./config.yaml:/etc/darbaan/config.yaml:ro   # optional mounted config
 
+  # Telegram approval client — a separate process (ADR 0017), a client of the
+  # admin API, NOT part of serve. It shares darbaan's network namespace
+  # (network_mode: service:darbaan) so it reaches the admin API on loopback
+  # (127.0.0.1:1144) and has outbound egress to Telegram; it never touches the
+  # stores directly and holds no mail credentials (ADR 0002). It is stateless —
+  # the posted/pending sets are in-memory by design — so it has no volume.
+  darbaan-telegram:
+    build: .
+    # image: ghcr.io/yaad-index/darbaan:latest   # once a published image exists
+    command: telegram
+    restart: unless-stopped
+    depends_on:
+      - darbaan
+    network_mode: "service:darbaan"
+    environment:
+      DARBAAN_TELEGRAM_TOKEN: "${DARBAAN_TELEGRAM_TOKEN:?set DARBAAN_TELEGRAM_TOKEN in .env}"
+      DARBAAN_TELEGRAM_OPERATOR_ID: "${DARBAAN_TELEGRAM_OPERATOR_ID:?set DARBAAN_TELEGRAM_OPERATOR_ID in .env}"
+      # Same admin token as darbaan — this is the client side of the admin API.
+      DARBAAN_ADMIN_TOKEN: "${DARBAAN_ADMIN_TOKEN:?set DARBAAN_ADMIN_TOKEN in .env}"
+
 volumes:
   darbaan-data:


### PR DESCRIPTION
Makes the Telegram approval client a permanent compose service so it survives restarts, and audits state-on-volumes (maintainer wants nothing ephemeral).

## 1. `darbaan-telegram` service
- Same image, `command: telegram`, `restart: unless-stopped`, `depends_on: darbaan`.
- **`network_mode: "service:darbaan"`** — shares serve's network namespace, so the client reaches the admin API on **loopback (127.0.0.1:1144)** and has **Telegram egress** without publishing any port. The admin API stays container-internal (never host-exposed), consistent with the existing posture.
- Env: `DARBAAN_TELEGRAM_TOKEN` + `DARBAAN_TELEGRAM_OPERATOR_ID` (from `.env`, **not** hardcoded) + `DARBAAN_ADMIN_TOKEN` (the client side of the admin API). No mail credentials (ADR 0002).
- **Stateless** — `posted`/`pending` are in-memory by design — so **no volume**.

## 2. State-on-volumes audit — clean
- The three bbolt DBs are pinned to `/data` via the image ENV (`DARBAAN_SLUICE_DB`/`AUDIT_DB`/`INBOUND_DB` → `/data/*.db`), and `/data` is the `darbaan-data` named volume.
- TLS + DKIM are read-only mounts from `./secrets`.
- **No component writes outside `/data`** — the DBs are the only writable state; the container is distroless non-root. Nothing ephemeral.

## 3. `.env.example`
Added `DARBAAN_TELEGRAM_TOKEN` + `DARBAAN_TELEGRAM_OPERATOR_ID` with comments. Confirmed the `telegram-operator-id` flag binds from `DARBAAN_TELEGRAM_OPERATOR_ID` via the kong env resolver.

## Verification
- `docker compose config` valid; telegram service renders with command/network_mode/restart/env.
- In-image smoke: `darbaan telegram` with all env set reaches the Telegram connect (past config, proving the env wiring incl. operator-id); fails closed without the operator id.

build/ci PR. Redeploy the full stack from compose after merge to verify the bot self-restarts.
