### PR TITLE
feat(telegram): show + upload trapped attachments for operator review

### DIFF
--- a/internal/telegram/body.go
+++ b/internal/telegram/body.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"mime"
+	"strconv"
 	"strings"
 
 	gomessage "github.com/emersion/go-message"
@@ -107,6 +109,91 @@ func formatAddr(a *gomail.Address) string {
 		return fmt.Sprintf("%s <%s>", a.Name, a.Address)
 	}
 	return a.Address
+}
+
+// attachment is one attachment part: its metadata plus the transfer-decoded
+// bytes, so the bot can both list it and upload the real file for inspection.
+type attachment struct {
+	filename    string
+	contentType string
+	size        int64
+	data        []byte
+}
+
+// attachments lists the attachment parts of a raw message so the operator sees
+// what they're approving — an attachment is the obvious exfiltration vector. A
+// part is an attachment if it is dispositioned attachment, carries a filename,
+// or is a non-text leaf (anything but the text/plain + text/html body parts).
+func attachments(raw []byte) []attachment {
+	ent, _ := gomessage.Read(bytes.NewReader(raw))
+	if ent == nil {
+		return nil
+	}
+	var out []attachment
+	collectAttachments(ent, &out)
+	return out
+}
+
+func collectAttachments(ent *gomessage.Entity, out *[]attachment) {
+	if mr := ent.MultipartReader(); mr != nil {
+		for {
+			p, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			collectAttachments(p, out)
+		}
+		return
+	}
+	att, ok := asAttachment(ent.Header)
+	if !ok {
+		return
+	}
+	att.data, _ = io.ReadAll(ent.Body) // transfer-decoded by go-message
+	att.size = int64(len(att.data))
+	*out = append(*out, att)
+}
+
+func asAttachment(h gomessage.Header) (attachment, bool) {
+	ct, ctParams, _ := h.ContentType()
+	disp, dispParams, _ := h.ContentDisposition()
+	filename := dispParams["filename"]
+	if filename == "" {
+		filename = ctParams["name"]
+	}
+	// The text/plain + text/html leaves are the body, not attachments — unless
+	// explicitly attached or named (e.g. an attached .txt).
+	bodyPart := ct == "text/plain" || ct == "text/html" || ct == ""
+	if bodyPart && disp != "attachment" && filename == "" {
+		return attachment{}, false
+	}
+	if dec, err := new(mime.WordDecoder).DecodeHeader(filename); err == nil && dec != "" {
+		filename = dec
+	}
+	if filename == "" {
+		filename = "(unnamed)"
+	}
+	if ct == "" {
+		ct = "application/octet-stream"
+	}
+	return attachment{filename: filename, contentType: ct}, true
+}
+
+// humanSize renders a byte count as a short human string (1024-base, e.g.
+// "204 KB", "1.2 MB").
+func humanSize(n int64) string {
+	if n < 1024 {
+		return fmt.Sprintf("%d B", n)
+	}
+	val := float64(n)
+	units := []string{"KB", "MB", "GB", "TB", "PB"}
+	i := -1
+	for val >= 1024 && i < len(units)-1 {
+		val /= 1024
+		i++
+	}
+	s := strings.TrimSuffix(strconv.FormatFloat(val, 'f', 1, 64), ".0")
+	return s + " " + units[i]
 }
 
 // hiddenRcpts returns the envelope recipients not present in the header To/Cc —

--- a/internal/telegram/body_internal_test.go
+++ b/internal/telegram/body_internal_test.go
@@ -77,6 +77,66 @@ func TestHiddenRcpts(t *testing.T) {
 	assert.Empty(t, hiddenRcpts([]string{"b@y.test"}, set))
 }
 
+func TestAttachments(t *testing.T) {
+	// multipart/mixed: a text body + a base64 PDF attachment ("aGVsbG8=" = "hello").
+	raw := []byte("Content-Type: multipart/mixed; boundary=\"b\"\r\n\r\n" +
+		"--b\r\nContent-Type: text/plain\r\n\r\nthe body\r\n" +
+		"--b\r\nContent-Type: application/pdf; name=\"doc.pdf\"\r\n" +
+		"Content-Disposition: attachment; filename=\"doc.pdf\"\r\n" +
+		"Content-Transfer-Encoding: base64\r\n\r\naGVsbG8=\r\n" +
+		"--b--\r\n")
+	atts := attachments(raw)
+	require.Len(t, atts, 1)
+	assert.Equal(t, "doc.pdf", atts[0].filename)
+	assert.Equal(t, "application/pdf", atts[0].contentType)
+	assert.Equal(t, []byte("hello"), atts[0].data) // transfer-decoded
+	assert.Equal(t, int64(5), atts[0].size)
+}
+
+func TestAttachmentsNonTextLeafAndNone(t *testing.T) {
+	// A non-text leaf with no disposition is still an attachment (unnamed).
+	img := []byte("Content-Type: multipart/mixed; boundary=\"b\"\r\n\r\n" +
+		"--b\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
+		"--b\r\nContent-Type: image/png\r\n\r\nPNGDATA\r\n--b--\r\n")
+	atts := attachments(img)
+	require.Len(t, atts, 1)
+	assert.Equal(t, "(unnamed)", atts[0].filename)
+	assert.Equal(t, "image/png", atts[0].contentType)
+
+	// text/plain + text/html alternative is the body only — no attachments.
+	none := []byte("Content-Type: multipart/alternative; boundary=\"b\"\r\n\r\n" +
+		"--b\r\nContent-Type: text/plain\r\n\r\nx\r\n--b\r\nContent-Type: text/html\r\n\r\n<p>x</p>\r\n--b--\r\n")
+	assert.Empty(t, attachments(none))
+}
+
+func TestHumanSize(t *testing.T) {
+	assert.Equal(t, "512 B", humanSize(512))
+	assert.Equal(t, "1 KB", humanSize(1024))
+	assert.Equal(t, "1.5 KB", humanSize(1536))
+	assert.Equal(t, "2 MB", humanSize(2*1024*1024))
+}
+
+func TestAttachmentsLine(t *testing.T) {
+	assert.Equal(t, "attachments: none", attachmentsLine(nil))
+	assert.Contains(t,
+		attachmentsLine([]attachment{{filename: "a.pdf", contentType: "application/pdf", size: 204 * 1024}}),
+		"a.pdf (application/pdf, 204 KB)")
+	assert.Contains(t,
+		attachmentsLine([]attachment{{filename: "big.zip", contentType: "application/zip", size: 60 * 1024 * 1024}}),
+		"too large to preview")
+}
+
+func TestFormatNotificationAttachmentsSurviveTruncation(t *testing.T) {
+	n := notification{
+		id: "7", subject: "s", body: strings.Repeat("x", 8000),
+		attachments: []attachment{{filename: "secret.pdf", contentType: "application/pdf", size: 1024}},
+	}
+	out := formatNotification(n)
+	assert.LessOrEqual(t, len([]rune(out)), maxNotificationRunes)
+	assert.Contains(t, out, "secret.pdf")    // attachment list survives a long-body truncation
+	assert.Contains(t, out, "...(truncated") // ...because the body truncated instead
+}
+
 func TestPrunePosted(t *testing.T) {
 	c, err := New("123:fake", 999, 0, admin.NewClient("127.0.0.1:1", "t"))
 	require.NoError(t, err)

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -12,6 +12,7 @@
 package telegram
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -163,24 +164,53 @@ func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
 		to = strings.Join(m.Rcpt, ", ")
 	}
 	n := notification{
-		id:      m.ID,
-		from:    from,
-		to:      to,
-		subject: displaySubject(m.Subject),
-		size:    m.Size,
-		body:    bodyText(raw),
+		id:          m.ID,
+		from:        from,
+		to:          to,
+		subject:     displaySubject(m.Subject),
+		size:        m.Size,
+		body:        bodyText(raw),
+		attachments: attachments(raw),
 	}
 	// Surface recipients that deliver but aren't visible in the headers (Bcc),
 	// but only when we could actually read the headers.
 	if parsed {
 		n.hidden = hiddenRcpts(m.Rcpt, headerSet)
 	}
-	_, err = c.bot.SendMessage(ctx, &bot.SendMessageParams{
+	// The decision message + keyboard is the anchor and the gating send: it is
+	// marked posted on success, so a later attachment-upload failure never
+	// causes a duplicate re-notify.
+	if _, err = c.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:      c.operatorID,
 		Text:        formatNotification(n),
 		ReplyMarkup: decisionKeyboard(m.ID),
-	})
-	return err
+	}); err != nil {
+		return err
+	}
+	// Then upload each attachment so the operator can open the real file before
+	// approving — best-effort, after the anchor (the metadata line already
+	// describes them, so an upload failure degrades, never blocks the decision).
+	c.sendAttachments(ctx, n.attachments)
+	return nil
+}
+
+// maxUpload is Telegram's bot sendDocument size cap. Anything over it is shown
+// in the metadata line only (Gmail's ~25 MB outbound cap means this rarely
+// triggers).
+const maxUpload = 50 * 1024 * 1024
+
+func (c *Client) sendAttachments(ctx context.Context, atts []attachment) {
+	for _, a := range atts {
+		if a.size > maxUpload || len(a.data) == 0 {
+			continue // too large / empty — the metadata line covers it
+		}
+		if _, err := c.bot.SendDocument(ctx, &bot.SendDocumentParams{
+			ChatID:   c.operatorID,
+			Document: &models.InputFileUpload{Filename: a.filename, Data: bytes.NewReader(a.data)},
+		}); err != nil {
+			log.Printf("darbaan telegram: upload attachment %s: %v", a.filename, err)
+		}
+	}
 }
 
 // prunePosted drops de-dup entries for messages no longer pending, bounding the
@@ -215,13 +245,14 @@ func (c *Client) markPosted(id string) {
 
 // notification is the display-ready content of an operator notification.
 type notification struct {
-	id      string
-	from    string // header display form, falling back to the envelope sender
-	to      string // header To/Cc display form, falling back to the envelope rcpts
-	subject string
-	size    int
-	hidden  []string // envelope recipients not in the headers (Bcc)
-	body    string
+	id          string
+	from        string // header display form, falling back to the envelope sender
+	to          string // header To/Cc display form, falling back to the envelope rcpts
+	subject     string
+	size        int
+	hidden      []string // envelope recipients not in the headers (Bcc)
+	body        string
+	attachments []attachment // attachment parts (filename/type/size — the exfil vector)
 }
 
 func displaySubject(s string) string {
@@ -248,18 +279,40 @@ func formatNotification(n notification) string {
 		fmt.Fprintf(&b, "\n(!) also delivering to (not in headers): %s", strings.Join(n.hidden, ", "))
 	}
 	header := b.String()
+	// The attachment line is security-critical (the exfil vector), so it is
+	// reserved in the cap budget and rendered after the body: the BODY truncates
+	// first, the attachment list always survives.
+	suffix := "\n\n" + attachmentsLine(n.attachments)
 	if n.body == "" {
-		return header + "\n\n(no text body)"
+		return header + "\n\n(no text body)" + suffix
 	}
 	prefix := header + "\n\n--- body ---\n"
-	avail := maxNotificationRunes - len([]rune(prefix)) - 40 // room for the marker
+	avail := maxNotificationRunes - len([]rune(prefix)) - len([]rune(suffix)) - 40 // room for the marker
 	if avail < 0 {
 		avail = 0
 	}
 	if br := []rune(n.body); len(br) > avail {
-		return prefix + string(br[:avail]) + fmt.Sprintf("\n...(truncated, %d bytes)", len(n.body))
+		return prefix + string(br[:avail]) + fmt.Sprintf("\n...(truncated, %d bytes)", len(n.body)) + suffix
 	}
-	return prefix + n.body
+	return prefix + n.body + suffix
+}
+
+// attachmentsLine lists the attachments (filename, content-type, human size) —
+// the bytes are uploaded separately. An over-cap attachment is flagged as not
+// previewable.
+func attachmentsLine(atts []attachment) string {
+	if len(atts) == 0 {
+		return "attachments: none"
+	}
+	parts := make([]string, len(atts))
+	for i, a := range atts {
+		if a.size > maxUpload {
+			parts[i] = fmt.Sprintf("%s (%s, %s, too large to preview)", a.filename, a.contentType, humanSize(a.size))
+		} else {
+			parts[i] = fmt.Sprintf("%s (%s, %s)", a.filename, a.contentType, humanSize(a.size))
+		}
+	}
+	return "attachments: " + strings.Join(parts, ", ")
 }
 
 // decisionKeyboard lays in all three decision buttons. The callbacks are wired


### PR DESCRIPTION
An attachment is most of what the operator is approving and the obvious **exfiltration vector**, so they must see it before tapping Approve — both a summary and the real file.

## What
- **Parse** the trapped message MIME (already fetched for the body) for attachment parts: `Content-Disposition: attachment`, a filename param, or any **non-text leaf** (everything but the text/plain + text/html body). Transfer-encoding decoded.
- **List** them on the notification — `filename (content-type, human size)`, or `attachments: none`. The line is **reserved in the 4096-char budget and rendered after the body**, so the body truncates first and the attachment list **always survives** (it would be useless if truncated away).
- **Upload** each attachment via `sendDocument` so the operator can open the real file. The decision message + keyboard is the **anchor and gating send** (marked posted on success); uploads follow **best-effort** — a failure degrades to the metadata line and never blocks the decision.
- **50 MB cap**: over it (Gmail caps outbound ~25 MB, so this rarely fires) the upload is skipped and the line notes `too large to preview`.

## Security / privacy
This **egresses the attachment bytes to Telegram** (the operator chat, gated to `operatorID`) — the same trust boundary as the subject/body already going there. **No send-behavior change**: attachments pass through the store-canonical trap untouched regardless (ADR 0016). Visibility only.

## Verification
- build/vet/gofmt/`go test -race`/golangci-lint clean.
- Tests: `attachments` (base64 PDF decoded, non-text leaf as unnamed, text/html-alternative = none), `humanSize`, `attachmentsLine` (none / listed / over-cap note), and `formatNotification` proving the **attachment line survives a long-body truncation**.

Telegram-only. Ref ADR 0016; relates to #67/#68 (body, hidden-recipient).
