### PR TITLE
feat(sluice): tier raw content to filesystem blobs (ADR 0018)

### DIFF
--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -1,0 +1,112 @@
+// Package blobstore is a small filesystem blob store: one file per key under a
+// directory. It backs the content tier of the message stores (ADR 0018) — the
+// raw RFC 822 bytes live here, keyed by message id, while bbolt holds only
+// metadata + a reference.
+//
+// Put writes durably (temp file, fsync, atomic rename, dir fsync) so the blob is
+// on disk before the caller commits the referencing metadata. With that
+// ordering a metadata record never points to missing content; a crash can only
+// leave a reclaimable orphan blob.
+package blobstore
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Store writes and reads blobs under a single directory.
+type Store struct {
+	dir string
+}
+
+// New creates (if needed) and opens the blob directory.
+func New(dir string) (*Store, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("blobstore: empty directory")
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("blobstore: mkdir %s: %w", dir, err)
+	}
+	return &Store{dir: dir}, nil
+}
+
+func (s *Store) path(key string) string { return filepath.Join(s.dir, key) }
+
+// Put writes the blob for key durably. It is the first half of the
+// blob-then-metadata write order: when Put returns, the bytes are on disk.
+func (s *Store) Put(key string, data []byte) error {
+	if err := validKey(key); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(s.dir, key+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("blobstore: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once renamed away
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("blobstore: write: %w", err)
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("blobstore: fsync: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("blobstore: close: %w", err)
+	}
+	if err := os.Rename(tmpName, s.path(key)); err != nil {
+		return fmt.Errorf("blobstore: rename: %w", err)
+	}
+	return syncDir(s.dir)
+}
+
+// Get reads the blob for key.
+func (s *Store) Get(key string) ([]byte, error) {
+	if err := validKey(key); err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(s.path(key))
+	if err != nil {
+		return nil, fmt.Errorf("blobstore: read %s: %w", key, err)
+	}
+	return data, nil
+}
+
+// Delete removes the blob for key. A missing blob is not an error (idempotent).
+func (s *Store) Delete(key string) error {
+	if err := validKey(key); err != nil {
+		return err
+	}
+	if err := os.Remove(s.path(key)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("blobstore: delete %s: %w", key, err)
+	}
+	return nil
+}
+
+// validKey keeps a key to a single path element — it can never contain a
+// separator or traverse out of the directory (defense in depth; ids are
+// store-generated, never operator input).
+func validKey(key string) error {
+	if key == "" || key == "." || key == ".." || strings.ContainsAny(key, `/\`) {
+		return fmt.Errorf("blobstore: invalid key %q", key)
+	}
+	return nil
+}
+
+func syncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return fmt.Errorf("blobstore: open dir for fsync: %w", err)
+	}
+	defer func() { _ = d.Close() }()
+	if err := d.Sync(); err != nil {
+		return fmt.Errorf("blobstore: fsync dir: %w", err)
+	}
+	return nil
+}

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -1,0 +1,43 @@
+package blobstore_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/blobstore"
+)
+
+func TestPutGetDelete(t *testing.T) {
+	s, err := blobstore.New(t.TempDir())
+	require.NoError(t, err)
+
+	require.NoError(t, s.Put("1", []byte("hello")))
+	got, err := s.Get("1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("hello"), got)
+
+	require.NoError(t, s.Delete("1"))
+	require.NoError(t, s.Delete("1")) // missing blob is not an error
+	_, err = s.Get("1")
+	assert.Error(t, err)
+}
+
+func TestPutOverwrites(t *testing.T) {
+	s, err := blobstore.New(t.TempDir())
+	require.NoError(t, err)
+	require.NoError(t, s.Put("1", []byte("old")))
+	require.NoError(t, s.Put("1", []byte("new")))
+	got, err := s.Get("1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("new"), got)
+}
+
+func TestInvalidKeyRejectsTraversal(t *testing.T) {
+	s, err := blobstore.New(t.TempDir())
+	require.NoError(t, err)
+	for _, k := range []string{"", ".", "..", "a/b", `a\b`, "../escape"} {
+		assert.Error(t, s.Put(k, []byte("x")), "key %q must be rejected", k)
+	}
+}

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -1,31 +1,48 @@
 package sluice
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"log"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"go.etcd.io/bbolt"
 
 	"github.com/yaad-index/darbaan/internal/audit"
+	"github.com/yaad-index/darbaan/internal/blobstore"
 	"github.com/yaad-index/darbaan/internal/seqkey"
 )
 
-// bucketMessages holds the held messages, keyed by big-endian sequence so a
-// cursor iterates them in receive order.
+// bucketMessages holds the held messages' metadata, keyed by big-endian sequence
+// so a cursor iterates them in receive order. The raw content lives in the blob
+// store, not here (ADR 0018).
 var bucketMessages = []byte("messages")
 
 func init() {
 	Register("bbolt", newBbolt)
 }
 
-// bboltStore is the bbolt-backed MessageStore. It commits messages to its own
-// database, then writes a best-effort audit entry to the (separate) audit log.
+// stored is the bbolt record: message metadata plus the tiering fields. The raw
+// bytes live in a blob (Blobbed=true; Message.Raw is nil here) — except for
+// legacy records written before ADR 0018, which have Blobbed=false and the raw
+// inline in Message.Raw. Subject and Size are persisted so List never reads a
+// blob; legacy records lack them and derive from the inline raw instead.
+type stored struct {
+	Message
+	Subject string `json:"subject,omitempty"`
+	Size    int    `json:"size,omitempty"`
+	Blobbed bool   `json:"blobbed,omitempty"`
+}
+
+// bboltStore is the bbolt-backed MessageStore. Metadata lives in its database;
+// raw content lives in a per-store blob directory. It writes a best-effort audit
+// entry to the (separate) audit log after each commit.
 type bboltStore struct {
 	db    *bbolt.DB
+	blobs *blobstore.Store
 	audit audit.AuditLog
 }
 
@@ -44,7 +61,15 @@ func newBbolt(path string, al audit.AuditLog) (MessageStore, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("sluice: init bucket: %w", err)
 	}
-	return &bboltStore{db: db, audit: al}, nil
+	// Per-store blob directory (e.g. <data>/blobs/sluice/), namespaced by the db
+	// name so stores never collide on a shared id space.
+	base := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+	blobs, err := blobstore.New(filepath.Join(filepath.Dir(path), "blobs", base))
+	if err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sluice: open blob store: %w", err)
+	}
+	return &bboltStore{db: db, blobs: blobs, audit: al}, nil
 }
 
 func (s *bboltStore) Close() error { return s.db.Close() }
@@ -77,11 +102,13 @@ func (s *bboltStore) Enqueue(sub Submission) (Message, error) {
 			ReceivedAt: time.Now().UTC(),
 			Status:     StatusPending,
 		}
-		enc, err := json.Marshal(msg)
-		if err != nil {
-			return err
+		// Content tier first: the blob is durable before the referencing metadata
+		// commits (ADR 0018), so a crash can only orphan a blob, never dangle a
+		// metadata pointer.
+		if err := s.blobs.Put(msg.ID, sub.Raw); err != nil {
+			return fmt.Errorf("write content: %w", err)
 		}
-		return b.Put(seqkey.Encode(seq), enc)
+		return putStored(tx, seqkey.Encode(seq), storedFrom(msg))
 	})
 	if err != nil {
 		return Message{}, fmt.Errorf("sluice: enqueue: %w", err)
@@ -94,19 +121,24 @@ func (s *bboltStore) List() ([]Meta, error) {
 	var metas []Meta
 	err := s.db.View(func(tx *bbolt.Tx) error {
 		return tx.Bucket(bucketMessages).ForEach(func(_, v []byte) error {
-			var m Message
-			if err := json.Unmarshal(v, &m); err != nil {
+			var rec stored
+			if err := json.Unmarshal(v, &rec); err != nil {
 				return err
 			}
+			subject, size := rec.Subject, rec.Size
+			if !rec.Blobbed { // legacy inline record: derive (no persisted subject/size)
+				subject = subjectFromRaw(rec.Raw)
+				size = len(rec.Raw)
+			}
 			metas = append(metas, Meta{
-				ID:         m.ID,
-				Agent:      m.Agent,
-				From:       m.From,
-				Rcpt:       m.Rcpt,
-				Subject:    subjectFromRaw(m.Raw),
-				Size:       len(m.Raw),
-				ReceivedAt: m.ReceivedAt,
-				Status:     m.Status,
+				ID:         rec.ID,
+				Agent:      rec.Agent,
+				From:       rec.From,
+				Rcpt:       rec.Rcpt,
+				Subject:    subject,
+				Size:       size,
+				ReceivedAt: rec.ReceivedAt,
+				Status:     rec.Status,
 			})
 			return nil
 		})
@@ -118,23 +150,25 @@ func (s *bboltStore) List() ([]Meta, error) {
 }
 
 func (s *bboltStore) Get(id string) (Message, error) {
-	var msg Message
+	var rec stored
 	err := s.db.View(func(tx *bbolt.Tx) error {
 		var e error
-		msg, _, e = loadMessage(tx, id)
+		rec, _, e = loadStored(tx, id)
 		return e
 	})
 	if err != nil {
 		return Message{}, err
 	}
-	return msg, nil
+	return s.withRaw(rec)
 }
 
 func (s *bboltStore) Approve(id, decidedBy string, released []byte) (Message, error) {
 	return s.transitionFromPending(id, "approve", decidedBy, func(m *Message) {
 		m.Status = StatusApproved
 		m.DecidedBy = decidedBy
-		if released != nil && !bytes.Equal(released, m.Raw) {
+		// An amended body (ADR 0004) is recorded inline; it is nil in v1 (no
+		// amendment flow) — tiering Released pairs with that feature (follow-up).
+		if len(released) > 0 {
 			m.Released = released
 		}
 	})
@@ -153,18 +187,20 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 	detail := "sent"
 	var out Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
-		m, key, err := loadMessage(tx, id)
+		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
 		if sendErr != nil {
-			m.SendErr = sendErr.Error() // stays approved for a manual re-send
+			rec.SendErr = sendErr.Error() // stays approved for a manual re-send
 		} else {
-			m.Status = StatusSent // delivered upstream
-			m.SendErr = ""
+			rec.Status = StatusSent // delivered upstream
+			rec.SendErr = ""
 		}
-		out = m
-		return putMessage(tx, key, m)
+		// The caller uses only the updated status; the raw body is not
+		// reassembled here, so a send never re-reads a (possibly large) blob.
+		out = rec.Message
+		return putStored(tx, key, rec)
 	})
 	if err != nil {
 		return Message{}, fmt.Errorf("sluice: record send attempt: %w", err)
@@ -178,47 +214,77 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 
 // transitionFromPending commits a status change to a pending message, then
 // writes a best-effort audit entry. It errors if the message is not pending, so
-// a verdict can never be applied twice.
+// a verdict can never be applied twice. The returned message includes the raw
+// body (the approve/reject callers send it / attach it to a bounce).
 func (s *bboltStore) transitionFromPending(id, event, detail string, mutate func(*Message)) (Message, error) {
-	var out Message
+	var rec stored
 	err := s.db.Update(func(tx *bbolt.Tx) error {
-		m, key, err := loadMessage(tx, id)
+		r, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
-		if m.Status != StatusPending {
-			return fmt.Errorf("%w: %s is %s", ErrNotPending, id, m.Status)
+		if r.Status != StatusPending {
+			return fmt.Errorf("%w: %s is %s", ErrNotPending, id, r.Status)
 		}
-		mutate(&m)
-		out = m
-		return putMessage(tx, key, m)
+		mutate(&r.Message)
+		rec = r
+		return putStored(tx, key, r)
 	})
 	if err != nil {
 		return Message{}, fmt.Errorf("sluice: %s: %w", event, err)
+	}
+	out, err := s.withRaw(rec)
+	if err != nil {
+		return Message{}, err
 	}
 	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, MessageID: id, Detail: detail})
 	return out, nil
 }
 
-func loadMessage(tx *bbolt.Tx, id string) (Message, []byte, error) {
+// withRaw reassembles the full message: metadata from the record plus the raw
+// content from the blob (or, for a legacy record, the inline raw it already
+// carries).
+func (s *bboltStore) withRaw(rec stored) (Message, error) {
+	msg := rec.Message
+	if rec.Blobbed {
+		raw, err := s.blobs.Get(msg.ID)
+		if err != nil {
+			return Message{}, fmt.Errorf("sluice: load content %s: %w", msg.ID, err)
+		}
+		msg.Raw = raw
+	}
+	return msg, nil
+}
+
+// storedFrom builds a blobbed metadata record from a full message: the raw bytes
+// are dropped (they live in the blob) and subject/size are persisted so List
+// never needs the blob.
+func storedFrom(m Message) stored {
+	subject := subjectFromRaw(m.Raw)
+	size := len(m.Raw)
+	m.Raw = nil
+	return stored{Message: m, Subject: subject, Size: size, Blobbed: true}
+}
+
+func loadStored(tx *bbolt.Tx, id string) (stored, []byte, error) {
 	seq, err := strconv.ParseUint(id, 10, 64)
 	if err != nil {
-		return Message{}, nil, fmt.Errorf("%w: invalid id %q", ErrNotFound, id)
+		return stored{}, nil, fmt.Errorf("%w: invalid id %q", ErrNotFound, id)
 	}
 	key := seqkey.Encode(seq)
 	v := tx.Bucket(bucketMessages).Get(key)
 	if v == nil {
-		return Message{}, nil, ErrNotFound
+		return stored{}, nil, ErrNotFound
 	}
-	var m Message
-	if err := json.Unmarshal(v, &m); err != nil {
-		return Message{}, nil, err
+	var rec stored
+	if err := json.Unmarshal(v, &rec); err != nil {
+		return stored{}, nil, err
 	}
-	return m, key, nil
+	return rec, key, nil
 }
 
-func putMessage(tx *bbolt.Tx, key []byte, m Message) error {
-	enc, err := json.Marshal(m)
+func putStored(tx *bbolt.Tx, key []byte, rec stored) error {
+	enc, err := json.Marshal(rec)
 	if err != nil {
 		return err
 	}

--- a/internal/sluice/tiering_internal_test.go
+++ b/internal/sluice/tiering_internal_test.go
@@ -1,0 +1,82 @@
+package sluice
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/bbolt"
+
+	"github.com/yaad-index/darbaan/internal/audit"
+	"github.com/yaad-index/darbaan/internal/seqkey"
+)
+
+func newTieredStore(t *testing.T) *bboltStore {
+	t.Helper()
+	al, err := audit.New("null", "")
+	require.NoError(t, err)
+	ms, err := newBbolt(filepath.Join(t.TempDir(), "sluice.db"), al)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ms.Close(); _ = al.Close() })
+	return ms.(*bboltStore)
+}
+
+// A new message keeps its raw bytes OUT of bbolt (in the blob), and persists
+// subject + size so List never needs the blob — the crux of the tiering.
+func TestEnqueueTiersContent(t *testing.T) {
+	q := newTieredStore(t)
+	m, err := q.Enqueue(Submission{Agent: "a", Raw: []byte("Subject: hi there\r\n\r\nthe body")})
+	require.NoError(t, err)
+
+	seq, err := strconv.ParseUint(m.ID, 10, 64)
+	require.NoError(t, err)
+	var rec stored
+	require.NoError(t, q.db.View(func(tx *bbolt.Tx) error {
+		return json.Unmarshal(tx.Bucket(bucketMessages).Get(seqkey.Encode(seq)), &rec)
+	}))
+	assert.True(t, rec.Blobbed)
+	assert.Nil(t, rec.Raw, "raw must not be stored in bbolt")
+	assert.Equal(t, "hi there", rec.Subject) // persisted, not derived at list time
+	assert.Equal(t, len(m.Raw), rec.Size)
+
+	got, err := q.Get(m.ID) // reassembles metadata + blob
+	require.NoError(t, err)
+	assert.Equal(t, m.Raw, got.Raw)
+}
+
+// A legacy record (pre-ADR-0018: a bare Message with inline raw, no Blobbed /
+// subject / size) is read back from the inline bytes — Get returns the raw and
+// List derives subject + size. No migrate-on-open.
+func TestLegacyInlineRecordFallback(t *testing.T) {
+	q := newTieredStore(t)
+	legacy := Message{
+		ID: "1", Agent: "a", From: "f", Rcpt: []string{"r"},
+		Raw: []byte("Subject: old format\r\n\r\nbody"), Status: StatusPending,
+		ReceivedAt: time.Now().UTC(),
+	}
+	enc, err := json.Marshal(legacy) // old on-disk shape = the Message itself
+	require.NoError(t, err)
+	require.NoError(t, q.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketMessages).Put(seqkey.Encode(1), enc)
+	}))
+
+	got, err := q.Get("1")
+	require.NoError(t, err)
+	assert.Equal(t, legacy.Raw, got.Raw) // inline raw, no blob read
+
+	metas, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, "old format", metas[0].Subject) // derived from inline raw
+	assert.Equal(t, len(legacy.Raw), metas[0].Size)
+
+	// A legacy message still transitions, and the verdict reads back its raw.
+	approved, err := q.Approve("1", "op", nil)
+	require.NoError(t, err)
+	assert.Equal(t, StatusApproved, approved.Status)
+	assert.Equal(t, legacy.Raw, approved.Raw)
+}


### PR DESCRIPTION
Tiered storage for the **sluice** store (ADR 0018) — the first of the two stores. bbolt holds metadata; the raw RFC 822 (headers + body + attachments) moves to a filesystem blob keyed by message id, so bbolt stays small regardless of attachment / mailbox size. `MessageStore` is unchanged (ADR 0015) — the split is internal.

## What
- **`internal/blobstore`** — a small filesystem blob store. `Put` writes durably (temp + fsync + atomic rename + dir fsync) so the blob is on disk **before** the referencing metadata commits; keys are path-traversal-guarded.
- **`Enqueue`** writes the **blob first, then the metadata** (crash-safe: a crash can only orphan a blob, never dangle a pointer). **Subject + size are derived once and persisted** in metadata, so **`List` never reads a blob** — the whole point of the tiering.
- **`Get` / `Approve` / `Reject`** reassemble raw from the blob; **`RecordSendAttempt`** returns metadata only (no blob re-read — caller uses just the status).
- **Per-store blob dir** `<data>/blobs/<db-name>/` — namespaced so sluice and inbound never collide on their per-store sequential ids.

## Migration (flagged) — read-inline-if-present, no migrate-on-open
Low-risk on the **live** store: legacy records (pre-tiering bare inline-raw Messages, no flag/subject/size) are detected by the absent `blobbed` flag — `Get` returns their inline raw, `List` derives subject/size from it. New writes are blobbed with persisted subject/size. A deployed inline DB keeps working and **tiers forward** as new messages arrive.

## Scope notes
- The amend-on-approve **Released** body stays inline (nil in v1 — no amendment flow); tiering it pairs with that feature.
- **Audit stays untiered** (ADR 0011). **Orphan-blob sweep** is a separate follow-up.
- Trade-off: the blob fsync happens inside the enqueue write-txn (holds the bbolt write-lock briefly); fine at v1 volume, a two-phase split is a future optimization if write throughput matters.

## Verification
- build/vet/gofmt/`go test -race`/golangci-lint clean. Existing sluice tests pass unchanged (behavior-compatible).
- New tests: blobstore (put/get/delete idempotent, overwrite, traversal-rejected); sluice `TestEnqueueTiersContent` (raw NOT in bbolt, subject/size persisted, Get reassembles) and `TestLegacyInlineRecordFallback` (legacy inline Get/List/Approve all work).

closes part of #78 (sluice). Inbound store reuses this pattern next. Ref ADR 0018/0015/0011.
