### PR TITLE
fix(telegram): thread attachment uploads under their decision message

### DIFF
--- a/internal/telegram/body_internal_test.go
+++ b/internal/telegram/body_internal_test.go
@@ -109,6 +109,10 @@ func TestAttachmentsNonTextLeafAndNone(t *testing.T) {
 	assert.Empty(t, attachments(none))
 }
 
+func TestAttachmentCaption(t *testing.T) {
+	assert.Equal(t, "msg 18 - invoice.pdf", attachmentCaption("18", "invoice.pdf"))
+}
+
 func TestHumanSize(t *testing.T) {
 	assert.Equal(t, "512 B", humanSize(512))
 	assert.Equal(t, "1 KB", humanSize(1024))

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -180,17 +180,24 @@ func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
 	// The decision message + keyboard is the anchor and the gating send: it is
 	// marked posted on success, so a later attachment-upload failure never
 	// causes a duplicate re-notify.
-	if _, err = c.bot.SendMessage(ctx, &bot.SendMessageParams{
+	sent, err := c.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:      c.operatorID,
 		Text:        formatNotification(n),
 		ReplyMarkup: decisionKeyboard(m.ID),
-	}); err != nil {
+	})
+	if err != nil {
 		return err
 	}
 	// Then upload each attachment so the operator can open the real file before
 	// approving — best-effort, after the anchor (the metadata line already
 	// describes them, so an upload failure degrades, never blocks the decision).
-	c.sendAttachments(ctx, n.attachments)
+	// Each doc is threaded under the decision message so several held messages'
+	// files don't mix.
+	var anchorID int
+	if sent != nil {
+		anchorID = sent.ID
+	}
+	c.sendAttachments(ctx, m.ID, anchorID, n.attachments)
 	return nil
 }
 
@@ -199,18 +206,32 @@ func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
 // triggers).
 const maxUpload = 50 * 1024 * 1024
 
-func (c *Client) sendAttachments(ctx context.Context, atts []attachment) {
+func (c *Client) sendAttachments(ctx context.Context, queueID string, anchorID int, atts []attachment) {
 	for _, a := range atts {
 		if a.size > maxUpload || len(a.data) == 0 {
 			continue // too large / empty — the metadata line covers it
 		}
-		if _, err := c.bot.SendDocument(ctx, &bot.SendDocumentParams{
+		params := &bot.SendDocumentParams{
 			ChatID:   c.operatorID,
 			Document: &models.InputFileUpload{Filename: a.filename, Data: bytes.NewReader(a.data)},
-		}); err != nil {
+			Caption:  attachmentCaption(queueID, a.filename),
+		}
+		// Thread the file under its decision message so several held messages'
+		// attachments don't mix. Degrade to an unthreaded upload if the anchor
+		// id wasn't captured.
+		if anchorID != 0 {
+			params.ReplyParameters = &models.ReplyParameters{MessageID: anchorID}
+		}
+		if _, err := c.bot.SendDocument(ctx, params); err != nil {
 			log.Printf("darbaan telegram: upload attachment %s: %v", a.filename, err)
 		}
 	}
+}
+
+// attachmentCaption names a file with its held-message id so the operator sees
+// which approval it belongs to (e.g. "msg 18 - invoice.pdf").
+func attachmentCaption(queueID, filename string) string {
+	return fmt.Sprintf("msg %s - %s", queueID, filename)
 }
 
 // prunePosted drops de-dup entries for messages no longer pending, bounding the


### PR DESCRIPTION
With several messages trapped, uploaded attachment files weren't tied to their approval, so the operator couldn't tell which file belonged to which decision.

## Fix
`notify` captures the decision message's id from `SendMessage` and passes it to `sendAttachments`, which:
- sends each document as a **reply** to the decision message (`ReplyParameters.MessageID`), and
- **captions** it with the held-message id + filename — `msg 18 - invoice.pdf`.

So every file both **threads under** and **names** its parent approval. If the id capture fails, it **degrades** to an unthreaded upload (still captioned). Decision-first ordering and the de-dup gate are unchanged — the decision message stays the anchor.

build/vet/gofmt/`go test -race`/golangci-lint clean; `attachmentCaption` unit-tested. Telegram-only; redeploy + re-verify after merge.
