### PR TITLE
feat(storage): reclaim orphan blobs at store-open (#83)

### DIFF
--- a/internal/blobstore/blobstore.go
+++ b/internal/blobstore/blobstore.go
@@ -89,6 +89,33 @@ func (s *Store) Delete(key string) error {
 	return nil
 }
 
+// SweepOrphans deletes blobs whose id is not in live — content left behind when
+// a crash interrupted the blob-then-metadata write, so no metadata references
+// it. In-progress temp files (from Put) are skipped; only final, id-named blobs
+// are considered. It returns the number reclaimed. Safe to run only when there
+// are no concurrent writers (e.g. at store-open).
+func (s *Store) SweepOrphans(live map[string]bool) (int, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return 0, fmt.Errorf("blobstore: read dir: %w", err)
+	}
+	reclaimed := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || strings.Contains(name, ".tmp-") {
+			continue // skip subdirs and in-progress temp files
+		}
+		if live[name] {
+			continue // a metadata record references it — keep
+		}
+		if err := s.Delete(name); err != nil {
+			return reclaimed, err
+		}
+		reclaimed++
+	}
+	return reclaimed, nil
+}
+
 // validKey keeps a key to a single path element — it can never contain a
 // separator or traverse out of the directory (defense in depth; ids are
 // store-generated, never operator input).

--- a/internal/blobstore/blobstore_test.go
+++ b/internal/blobstore/blobstore_test.go
@@ -1,6 +1,8 @@
 package blobstore_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,6 +34,29 @@ func TestPutOverwrites(t *testing.T) {
 	got, err := s.Get("1")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("new"), got)
+}
+
+func TestSweepOrphans(t *testing.T) {
+	dir := t.TempDir()
+	s, err := blobstore.New(dir)
+	require.NoError(t, err)
+	require.NoError(t, s.Put("1", []byte("live")))
+	require.NoError(t, s.Put("2", []byte("orphan")))
+	require.NoError(t, s.Put("3", []byte("live")))
+	// An interrupted Put leaves a temp file; the sweep must skip it.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "9.tmp-abc123"), []byte("partial"), 0o600))
+
+	n, err := s.SweepOrphans(map[string]bool{"1": true, "3": true})
+	require.NoError(t, err)
+	assert.Equal(t, 1, n) // only "2" had no referencing metadata
+
+	_, err = s.Get("2")
+	assert.Error(t, err) // reclaimed
+	got, err := s.Get("1")
+	require.NoError(t, err)
+	assert.Equal(t, []byte("live"), got) // referenced blob kept
+	_, err = os.Stat(filepath.Join(dir, "9.tmp-abc123"))
+	assert.NoError(t, err) // temp file untouched
 }
 
 func TestInvalidKeyRejectsTraversal(t *testing.T) {

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -3,6 +3,7 @@ package inbound
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -65,7 +66,40 @@ func newBbolt(path string) (InboundStore, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("inbound: open blob store: %w", err)
 	}
-	return &bboltStore{db: db, blobs: blobs}, nil
+	store := &bboltStore{db: db, blobs: blobs}
+	// Reclaim blobs orphaned by a crash between blob and metadata writes. Safe at
+	// open: no concurrent writers yet (#83).
+	if err := store.sweepOrphans(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("inbound: sweep orphan blobs: %w", err)
+	}
+	return store, nil
+}
+
+// sweepOrphans deletes blobs with no referencing metadata record (#83). It is
+// run at open, before serving.
+func (s *bboltStore) sweepOrphans() error {
+	live := map[string]bool{}
+	if err := s.db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketInbound).ForEach(func(_, v []byte) error {
+			var rec stored
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return err
+			}
+			live[rec.ID] = true
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+	n, err := s.blobs.SweepOrphans(live)
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		log.Printf("darbaan: inbound reclaimed %d orphan blob(s) at startup", n)
+	}
+	return nil
 }
 
 func (s *bboltStore) Close() error { return s.db.Close() }

--- a/internal/inbound/tiering_internal_test.go
+++ b/internal/inbound/tiering_internal_test.go
@@ -49,6 +49,22 @@ func TestAddTiersContent(t *testing.T) {
 	assert.Equal(t, m.Raw, list[0].Raw) // List reassembles (IMAP snapshot needs it)
 }
 
+// sweepOrphans reclaims a blob with no metadata record but keeps a referenced one.
+func TestSweepOrphans(t *testing.T) {
+	s := newTieredStore(t)
+	m, err := s.Add(Delivery{Owner: "agent", Raw: []byte("Subject: x\r\n\r\nbody")})
+	require.NoError(t, err)
+	require.NoError(t, s.blobs.Put("9999", []byte("orphan"))) // no metadata record
+
+	require.NoError(t, s.sweepOrphans())
+
+	got, err := s.Get("agent", m.ID) // referenced blob survived
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.Raw)
+	_, err = s.blobs.Get("9999") // orphan reclaimed
+	assert.Error(t, err)
+}
+
 // A legacy record (pre-ADR-0018: a bare inline-raw Message) is read back from
 // the inline bytes by Get and List, mutates via SetSeen, and stays owner-scoped.
 func TestLegacyInlineFallback(t *testing.T) {

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -69,7 +69,40 @@ func newBbolt(path string, al audit.AuditLog) (MessageStore, error) {
 		_ = db.Close()
 		return nil, fmt.Errorf("sluice: open blob store: %w", err)
 	}
-	return &bboltStore{db: db, blobs: blobs, audit: al}, nil
+	store := &bboltStore{db: db, blobs: blobs, audit: al}
+	// Reclaim blobs orphaned by a crash between blob and metadata writes. Safe at
+	// open: no concurrent writers yet (#83).
+	if err := store.sweepOrphans(); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("sluice: sweep orphan blobs: %w", err)
+	}
+	return store, nil
+}
+
+// sweepOrphans deletes blobs with no referencing metadata record (#83). It is
+// run at open, before serving.
+func (s *bboltStore) sweepOrphans() error {
+	live := map[string]bool{}
+	if err := s.db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketMessages).ForEach(func(_, v []byte) error {
+			var rec stored
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return err
+			}
+			live[rec.ID] = true
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+	n, err := s.blobs.SweepOrphans(live)
+	if err != nil {
+		return err
+	}
+	if n > 0 {
+		log.Printf("darbaan: sluice reclaimed %d orphan blob(s) at startup", n)
+	}
+	return nil
 }
 
 func (s *bboltStore) Close() error { return s.db.Close() }

--- a/internal/sluice/tiering_internal_test.go
+++ b/internal/sluice/tiering_internal_test.go
@@ -48,6 +48,51 @@ func TestEnqueueTiersContent(t *testing.T) {
 	assert.Equal(t, m.Raw, got.Raw)
 }
 
+// The sweep fires at store-open: an orphan blob present when a store is reopened
+// is reclaimed by newBbolt before serving.
+func TestSweepRunsAtOpen(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "sluice.db")
+
+	al, err := audit.New("null", "")
+	require.NoError(t, err)
+	ms, err := newBbolt(dbPath, al)
+	require.NoError(t, err)
+	q := ms.(*bboltStore)
+	_, err = q.Enqueue(Submission{Raw: []byte("x")})
+	require.NoError(t, err)
+	require.NoError(t, q.blobs.Put("9999", []byte("orphan"))) // no metadata record
+	require.NoError(t, q.Close())
+	require.NoError(t, al.Close())
+
+	// Reopen — newBbolt sweeps before returning.
+	al2, err := audit.New("null", "")
+	require.NoError(t, err)
+	ms2, err := newBbolt(dbPath, al2)
+	require.NoError(t, err)
+	q2 := ms2.(*bboltStore)
+	t.Cleanup(func() { _ = q2.Close(); _ = al2.Close() })
+	_, err = q2.blobs.Get("9999")
+	assert.Error(t, err) // reclaimed at open
+}
+
+// sweepOrphans reclaims a blob with no metadata record but keeps a referenced one.
+func TestSweepOrphans(t *testing.T) {
+	q := newTieredStore(t)
+	m, err := q.Enqueue(Submission{Raw: []byte("Subject: x\r\n\r\nbody")})
+	require.NoError(t, err)
+	// A blob whose id has no metadata record (a crash-orphan).
+	require.NoError(t, q.blobs.Put("9999", []byte("orphan")))
+
+	require.NoError(t, q.sweepOrphans())
+
+	got, err := q.Get(m.ID) // referenced blob survived
+	require.NoError(t, err)
+	assert.NotEmpty(t, got.Raw)
+	_, err = q.blobs.Get("9999") // orphan reclaimed
+	assert.Error(t, err)
+}
+
 // A legacy record (pre-ADR-0018: a bare Message with inline raw, no Blobbed /
 // subject / size) is read back from the inline bytes — Get returns the raw and
 // List derives subject + size. No migrate-on-open.


### PR DESCRIPTION
The blob-then-metadata write order (ADR 0018) can leave an **orphan blob** if a crash lands between the two writes — content on disk that no metadata references. Reclaim those at startup (#83).

## What
- **`blobstore.SweepOrphans(live)`** reads the blob dir, **skips in-progress temp files** (the `CreateTemp` `.tmp-` names — only final id-named blobs are swept), deletes any blob whose id is **not in the live set**, and returns the reclaimed count.
- Each tiered store (**sluice + inbound**) builds its live-id set from **ALL** bbolt metadata records and **sweeps at open**, in `newBbolt` before serving — no concurrent writers then, so it is **safe and idempotent**. A blob is an orphan only when **no** record references it, so a referenced blob is never touched. The reclaimed count is logged.

Startup sweep is enough for v1; a periodic sweep is a later option.

## Verification
- build/vet/gofmt/`go test -race`/golangci-lint clean.
- Tests: `blobstore.TestSweepOrphans` (orphan reclaimed, referenced kept, temp file skipped); per-store `TestSweepOrphans` (real blob kept, crash-orphan reclaimed); `TestSweepRunsAtOpen` (an orphan present at reopen is swept by `newBbolt` before serving).

closes #83. Ref ADR 0018.
