### PR TITLE
docs: ADR 0019 — inbound mailbox sync (store-canonical, lazy content, no filter v1)

### DIFF
--- a/adr/0019-inbound-sync-store-canonical-lazy-no-filter.md
+++ b/adr/0019-inbound-sync-store-canonical-lazy-no-filter.md
@@ -1,0 +1,78 @@
+# ADR 0019: Inbound mailbox sync — store-canonical incremental pull, lazy content, no filter (v1)
+
+**Status:** Proposed (2026-06-26)
+
+## Context
+
+The MVP IMAP read face serves only Darbaan-generated bounces from the store
+(ADR 0016). The inbound store is now tiered (ADR 0018). The next step is the
+real inbound half of the original design: Darbaan pulls the agent's actual
+mailbox so the agent reads real mail *through Darbaan*, never the provider
+directly (ADR 0001, 0002).
+
+ADR 0001/0016 already settled the shape: **store-canonical, not a live proxy** —
+hiding messages from a live upstream is a UID/sequence-number hazard. So inbound
+is a *sync into the store*, served over the read face.
+
+This ADR scopes the **first increment: sync only, no filter.** The inbound
+filter (hide / allow / hold-for-human, ADR 0008) is deferred to its own later
+increment. The maintainer's explicit premise (2026-06-26): with no filter, the
+agent has **full read access to the entire synced mailbox**. That is accepted
+for the sync mechanism; the filter is the access-control layer that comes after.
+
+## Decision
+
+**Darbaan syncs the upstream mailbox into its inbound store and serves it over
+the existing IMAP read face.** No live proxying.
+
+- **Credential isolation (ADR 0002).** Darbaan connects to the upstream IMAP
+  with the real provider credentials it holds; the agent only ever gets Darbaan
+  credentials. The sync is **read-only on the upstream** in v1 (it pulls; it
+  does not write flags/deletes back — that is a later refinement).
+- **Incremental pull.** Track the upstream mailbox's `UIDVALIDITY` and the
+  highest synced UID; each cycle fetches only messages with a higher UID. A
+  `UIDVALIDITY` change (mailbox reset) triggers a re-sync. Upstream
+  deletion/flag reconciliation is a later refinement; v1 is append-mostly.
+- **Lazy content fetch.** Sync message **headers/metadata eagerly** (small, into
+  bbolt); fetch **bodies + attachments on demand**, storing them as blobs
+  (ADR 0018). The IMAP read face fetches content **per-FETCH** rather than
+  reassembling the whole mailbox at SELECT — this is the read-time half ADR 0018
+  named as future. Combined with tiering, a GB-scale mailbox stays viable:
+  metadata in bbolt, content on the filesystem, loaded only when actually read.
+- **No filter (this increment).** Everything synced is exposed to the agent.
+  The full mailbox is readable by the agent until the filter lands.
+- **Trigger.** Periodic poll on a configured interval for v1; IMAP IDLE (push)
+  is a later optimization (mirrors the outbound's poll-first simplicity).
+- **Store-canonical.** Synced messages live in Darbaan's own UID namespace in
+  the inbound store; the agent's view is the store, decoupled from upstream
+  availability per read.
+
+## Boundaries / non-goals (this increment)
+
+- **No filter** — hide/allow/hold-for-human is deferred (ADR 0008, next
+  increment). Until it lands, point the sync at a non-sensitive / test mailbox.
+- **No write-back** to the upstream (read-only pull; the agent's flag/delete
+  changes in Darbaan do not propagate upstream yet).
+- **Single mailbox** — multi-agent/multi-mailbox stays deferred (ADR 0010).
+- **No pre-screener** on inbound (ADR 0029, later).
+
+## Consequences
+
+- The agent reads real mail through Darbaan — the inbound half of the vision,
+  minus the access control.
+- Lazy fetch + tiering make a large mailbox practical; SELECT no longer
+  reassembles everything.
+- Full mailbox access for the agent until the filter increment — the deliberate,
+  named trade for getting the sync mechanism working first.
+- Per-mailbox sync state (`UIDVALIDITY` + last UID) is persisted.
+
+## Follow-ups
+
+- **Inbound filter** (ADR 0008): hide / allow / hold-for-human — the
+  access-control layer; hold-for-human reuses the admin-API + Telegram approval
+  surface, mirroring the outbound sluice.
+- Upstream deletion/flag reconciliation (bidirectional sync).
+- IMAP IDLE (push) instead of polling.
+- Inbound pre-screener (ADR 0029).
+
+Relates to ADR 0001, 0002, 0008, 0016, 0018.

--- a/adr/0019-inbound-sync-store-canonical-lazy-no-filter.md
+++ b/adr/0019-inbound-sync-store-canonical-lazy-no-filter.md
@@ -54,7 +54,7 @@ the existing IMAP read face.** No live proxying.
 - **No write-back** to the upstream (read-only pull; the agent's flag/delete
   changes in Darbaan do not propagate upstream yet).
 - **Single mailbox** — multi-agent/multi-mailbox stays deferred (ADR 0010).
-- **No pre-screener** on inbound (ADR 0029, later).
+- **No pre-screener** on inbound (#29, later).
 
 ## Consequences
 
@@ -75,4 +75,4 @@ the existing IMAP read face.** No live proxying.
 - IMAP IDLE (push) instead of polling.
 - Inbound pre-screener (ADR 0029).
 
-Relates to ADR 0001, 0002, 0008, 0016, 0018.
+Relates to ADR 0001, 0002, 0008, 0010, 0016, 0018.

--- a/adr/0019-inbound-sync-store-canonical-lazy-no-filter.md
+++ b/adr/0019-inbound-sync-store-canonical-lazy-no-filter.md
@@ -73,6 +73,6 @@ the existing IMAP read face.** No live proxying.
   surface, mirroring the outbound sluice.
 - Upstream deletion/flag reconciliation (bidirectional sync).
 - IMAP IDLE (push) instead of polling.
-- Inbound pre-screener (ADR 0029).
+- Inbound pre-screener (#29).
 
 Relates to ADR 0001, 0002, 0008, 0010, 0016, 0018.

--- a/adr/README.md
+++ b/adr/README.md
@@ -28,3 +28,4 @@ through 2026-06-26 (maintainer review).
 | [0016](0016-store-canonical-translation-faces.md) | Store-canonical architecture; protocol faces are translation adapters |
 | [0017](0017-interfaces-as-clients-over-local-api.md) | Admin and approval interfaces are separate host processes over the local API |
 | [0018](0018-tiered-storage-metadata-kv-content-filesystem.md) | Tiered storage: metadata in the KV store, message content on the filesystem |
+| [0019](0019-inbound-sync-store-canonical-lazy-no-filter.md) | Inbound mailbox sync: store-canonical incremental pull, lazy content, no filter (v1) |


### PR DESCRIPTION
ADR for the inbound half, scoped to the first increment the maintainer asked for: **sync only, no filter.**

- Store-canonical (ADR 0001/0016): Darbaan SYNCS the upstream mailbox into the inbound store and serves it over the IMAP read face — not a live proxy (the UID/state hazard).
- Incremental pull: track UIDVALIDITY + highest synced UID, fetch only new; re-sync on UIDVALIDITY change. Read-only on the upstream in v1.
- Lazy content: headers synced eagerly into bbolt, bodies/attachments fetched on demand into blobs (ADR 0018); the IMAP face fetches per-FETCH so SELECT does not reassemble the whole mailbox — the read-time half ADR 0018 deferred. With tiering, a GB mailbox stays viable.
- No filter (this increment): everything synced is exposed to the agent. Named premise (maintainer, 2026-06-26): full agent read access until the filter lands; point the sync at a non-sensitive/test mailbox meanwhile.
- Credential isolation (ADR 0002): Darbaan holds the upstream creds; the agent gets only Darbaan creds.
- Poll-based trigger (IDLE later).

Non-goals this increment: the filter (ADR 0008, next), write-back to upstream, multi-mailbox (ADR 0010), pre-screener (ADR 0029).

Hard-gate ADR — needs maintainer approval + 2-of-N. Implementation dispatched after it lands. Relates to ADR 0001/0002/0008/0016/0018.