### PR TITLE
feat(imapsync): inbound mailbox sync engine (ADR 0019, Inc 1)

### DIFF
--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -1,0 +1,157 @@
+package imapsync
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// DialFunc opens a logged-in client to the upstream IMAP server. It is injected
+// so the engine can be tested against an in-process server; production builds it
+// from config (TLS dial + login) — see Dialer.
+type DialFunc func() (*imapclient.Client, error)
+
+// Syncer pulls new messages from one upstream mailbox into the inbound store.
+type Syncer struct {
+	dial    DialFunc
+	mailbox string
+	owner   string // the agent whose mailbox this is
+	store   inbound.InboundStore
+	state   StateStore
+}
+
+// New builds a Syncer. owner is the agent the synced mail belongs to.
+func New(dial DialFunc, mailbox, owner string, store inbound.InboundStore, state StateStore) *Syncer {
+	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, store: store, state: state}
+}
+
+// Dialer is the production DialFunc: TLS-connect to addr and log in with the
+// Darbaan-held upstream credentials. The connection is exercised live (Inc 2);
+// the engine is tested with an injected DialFunc.
+func Dialer(addr, username, password string) DialFunc {
+	return func() (*imapclient.Client, error) {
+		c, err := imapclient.DialTLS(addr, nil)
+		if err != nil {
+			return nil, fmt.Errorf("dial %s: %w", addr, err)
+		}
+		if err := c.Login(username, password).Wait(); err != nil {
+			_ = c.Close()
+			return nil, fmt.Errorf("login: %w", err)
+		}
+		return c, nil
+	}
+}
+
+// Sync runs one incremental pull: SELECT the mailbox, UID-FETCH everything newer
+// than the stored cursor, store each via inbound.Add (tiered), and advance the
+// cursor. A UIDVALIDITY change resets the cursor and re-syncs from scratch. The
+// upstream is read-only (no flag/delete write-back, v1). Returns the count
+// stored this run.
+func (s *Syncer) Sync(ctx context.Context) (int, error) {
+	c, err := s.dial()
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: connect: %w", err)
+	}
+	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
+
+	sel, err := c.Select(s.mailbox, nil).Wait()
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: select %q: %w", s.mailbox, err)
+	}
+
+	loaded, err := s.state.Load(s.mailbox)
+	if err != nil {
+		return 0, err
+	}
+	last := loaded.LastUID
+	if loaded.UIDValidity != sel.UIDValidity {
+		last = 0 // new or reset mailbox — full re-sync
+	}
+
+	// UID FETCH (last+1):* — a fresh mailbox (last 0) fetches 1:* (everything).
+	var set imap.UIDSet
+	set.AddRange(imap.UID(last+1), 0) // Stop 0 == "*"
+	msgs, err := c.Fetch(set, &imap.FetchOptions{
+		UID:         true,
+		Envelope:    true,
+		BodySection: []*imap.FetchItemBodySection{{}}, // whole message
+	}).Collect()
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: fetch: %w", err)
+	}
+
+	// Ascending UID so the cursor advances monotonically.
+	sort.Slice(msgs, func(i, j int) bool { return msgs[i].UID < msgs[j].UID })
+
+	highest := last
+	stored := 0
+	for _, m := range msgs {
+		uid := uint32(m.UID)
+		// "N:*" returns the highest existing message even when N is past it;
+		// skip anything not actually newer than the cursor.
+		if uid <= last {
+			continue
+		}
+		if _, err := s.store.Add(deliveryOf(s.owner, m)); err != nil {
+			return stored, fmt.Errorf("imapsync: store uid %d: %w", uid, err)
+		}
+		stored++
+		if uid > highest {
+			highest = uid
+		}
+	}
+
+	newState := State{UIDValidity: sel.UIDValidity, LastUID: highest}
+	if newState != loaded {
+		if err := s.state.Save(s.mailbox, newState); err != nil {
+			return stored, err
+		}
+	}
+	return stored, nil
+}
+
+func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {
+	d := inbound.Delivery{Owner: owner, Raw: rawBody(m)}
+	if m.Envelope != nil {
+		d.Subject = m.Envelope.Subject
+		d.From = firstAddr(m.Envelope.From)
+		d.To = joinAddrs(m.Envelope.To)
+	}
+	return d
+}
+
+func rawBody(m *imapclient.FetchMessageBuffer) []byte {
+	if len(m.BodySection) == 0 {
+		return nil
+	}
+	return m.BodySection[0].Bytes
+}
+
+func formatAddr(a imap.Address) string {
+	addr := a.Mailbox + "@" + a.Host
+	if a.Name != "" {
+		return a.Name + " <" + addr + ">"
+	}
+	return addr
+}
+
+func firstAddr(as []imap.Address) string {
+	if len(as) == 0 {
+		return ""
+	}
+	return formatAddr(as[0])
+}
+
+func joinAddrs(as []imap.Address) string {
+	parts := make([]string, 0, len(as))
+	for _, a := range as {
+		parts = append(parts, formatAddr(a))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -1,0 +1,132 @@
+package imapsync_test
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"path/filepath"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+const upUser, upPass = "agent-up", "pw"
+
+// startUpstream runs an in-process go-imap server with one user + INBOX, and
+// returns its address plus the user so a test can append more messages.
+func startUpstream(t *testing.T) (string, *imapmemserver.User) {
+	t.Helper()
+	user := imapmemserver.NewUser(upUser, upPass)
+	require.NoError(t, user.Create("INBOX", nil))
+	mem := imapmemserver.New()
+	mem.AddUser(user)
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return mem.NewSession(), nil, nil
+		},
+		InsecureAuth: true,
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().String(), user
+}
+
+func appendMsg(t *testing.T, user *imapmemserver.User, raw string) {
+	t.Helper()
+	_, err := user.Append("INBOX", bytes.NewReader([]byte(raw)), &imap.AppendOptions{})
+	require.NoError(t, err)
+}
+
+func dialFor(addr string) imapsync.DialFunc {
+	return func() (*imapclient.Client, error) {
+		c, err := imapclient.DialInsecure(addr, nil)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.Login(upUser, upPass).Wait(); err != nil {
+			_ = c.Close()
+			return nil, err
+		}
+		return c, nil
+	}
+}
+
+func newInbound(t *testing.T) inbound.InboundStore {
+	t.Helper()
+	s, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func newState(t *testing.T) imapsync.StateStore {
+	t.Helper()
+	st, err := imapsync.NewStateStore(filepath.Join(t.TempDir(), "sync.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestSyncPullsIncrementally(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: alice@x.test\r\nTo: agent@d.test\r\nSubject: one\r\n\r\nbody one")
+	appendMsg(t, user, "From: bob@x.test\r\nTo: agent@d.test\r\nSubject: two\r\n\r\nbody two")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+
+	n, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	subjects := map[string]bool{msgs[0].Subject: true, msgs[1].Subject: true}
+	assert.True(t, subjects["one"] && subjects["two"], "subjects from envelope")
+	assert.Equal(t, "agent", msgs[0].Owner) // synced to the agent's mailbox
+	bodies := string(msgs[0].Raw) + string(msgs[1].Raw)
+	assert.Contains(t, bodies, "body one") // full raw round-trips
+
+	// Idempotent: a second sync with no new mail pulls nothing.
+	n, err = syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	// Only genuinely-new mail is pulled on the next cycle.
+	appendMsg(t, user, "From: carol@x.test\r\nSubject: three\r\n\r\nbody three")
+	n, err = syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+	msgs, _ = store.List("agent")
+	assert.Len(t, msgs, 3)
+}
+
+// A recorded cursor for a different UIDVALIDITY (mailbox reset) is discarded and
+// the mailbox re-synced from scratch, despite a high recorded LastUID.
+func TestSyncResetsOnUIDValidityMismatch(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: m1\r\n\r\nb1")
+
+	store := newInbound(t)
+	state := newState(t)
+	require.NoError(t, state.Save("INBOX", imapsync.State{UIDValidity: 424242, LastUID: 99}))
+
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, state)
+	n, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n) // mismatch → cursor reset to 0 → message re-pulled despite LastUID=99
+
+	msgs, _ := store.List("agent")
+	require.Len(t, msgs, 1)
+}

--- a/internal/imapsync/state.go
+++ b/internal/imapsync/state.go
@@ -1,0 +1,83 @@
+// Package imapsync pulls an upstream IMAP mailbox into Darbaan's inbound store
+// (ADR 0019): store-canonical, incremental, read-only on the upstream, no
+// filter (v1). It is the sync engine only — config + the serve poll loop wire it
+// up separately. The agent reads the synced mail through Darbaan's IMAP read
+// face, never the provider directly (ADR 0001/0002).
+package imapsync
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"go.etcd.io/bbolt"
+)
+
+// State is the per-mailbox sync cursor: the upstream UIDVALIDITY this cursor is
+// valid for, and the highest UID synced so far. A UIDVALIDITY change invalidates
+// LastUID and forces a re-sync (ADR 0019).
+type State struct {
+	UIDValidity uint32 `json:"uid_validity"`
+	LastUID     uint32 `json:"last_uid"`
+}
+
+// StateStore persists the sync cursor per mailbox.
+type StateStore interface {
+	Load(mailbox string) (State, error)
+	Save(mailbox string, st State) error
+	Close() error
+}
+
+var bucketSyncState = []byte("syncstate")
+
+type bboltState struct{ db *bbolt.DB }
+
+// NewStateStore opens (or creates) a small bbolt store for sync cursors.
+func NewStateStore(path string) (StateStore, error) {
+	if path == "" {
+		return nil, fmt.Errorf("imapsync: state store requires a path")
+	}
+	db, err := bbolt.Open(path, 0o600, &bbolt.Options{Timeout: time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("imapsync: open state db: %w", err)
+	}
+	if err := db.Update(func(tx *bbolt.Tx) error {
+		_, e := tx.CreateBucketIfNotExists(bucketSyncState)
+		return e
+	}); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("imapsync: init state bucket: %w", err)
+	}
+	return &bboltState{db: db}, nil
+}
+
+func (s *bboltState) Close() error { return s.db.Close() }
+
+// Load returns the cursor for a mailbox, or the zero State if none is recorded.
+func (s *bboltState) Load(mailbox string) (State, error) {
+	var st State
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		v := tx.Bucket(bucketSyncState).Get([]byte(mailbox))
+		if v == nil {
+			return nil // zero State — never synced
+		}
+		return json.Unmarshal(v, &st)
+	})
+	if err != nil {
+		return State{}, fmt.Errorf("imapsync: load state %q: %w", mailbox, err)
+	}
+	return st, nil
+}
+
+func (s *bboltState) Save(mailbox string, st State) error {
+	enc, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	if err := s.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketSyncState).Put([]byte(mailbox), enc)
+	}); err != nil {
+		return fmt.Errorf("imapsync: save state %q: %w", mailbox, err)
+	}
+	return nil
+}


### PR DESCRIPTION
**Inc 1** of the inbound mailbox sync build (ADR 0019): the sync **engine** — store-canonical, incremental, read-only upstream, no filter. Engine only; config + serve poll loop + live test are Inc 2, lazy/per-FETCH is Inc 3.

## What
`internal/imapsync.Syncer.Sync`: SELECT the mailbox, UID-FETCH everything newer than a persisted cursor (**UIDVALIDITY + highest synced UID**), store each via `inbound.Add` (tiered), advance the cursor.
- A **UIDVALIDITY change** resets the cursor and re-syncs from scratch.
- Upstream is **read-only** (no flag/delete write-back, v1).
- The IMAP **`N:*` quirk** (a past-the-end range re-returns the highest message) is guarded by skipping anything not actually newer than the cursor.
- The upstream connection is an **injected `DialFunc`** so the engine is testable without network or credentials; `Dialer` is the production TLS-dial + login (exercised live in Inc 2).
- `StateStore` persists the per-mailbox cursor in a small bbolt store.

## Verification
Tested **end-to-end against an in-process go-imap upstream** (`imapserver` + `imapmemserver`, same pattern as the listener tests) — no network, no live deps:
- `TestSyncPullsIncrementally`: pulls all seeded mail (subject/owner/raw correct), **idempotent** re-sync (0 new), only-new-on-next-cycle.
- `TestSyncResetsOnUIDValidityMismatch`: a stale-UIDVALIDITY cursor is discarded and the mailbox re-synced despite a high recorded LastUID.

build/vet/gofmt/`go test -race`/golangci-lint clean. Ref ADR 0019.
