### PR TITLE
feat(imapsync): wire inbound sync into serve, config-gated (ADR 0019, Inc 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ DARBAAN_ADMIN_TOKEN=change-me-too
 # in docker-compose.yml. Leave blank while sender-type=stub (nothing sends).
 DARBAAN_SMTP_PASSWORD=
 
+# Upstream IMAP app password for inbound mailbox sync (ADR 0019) — ONLY needed
+# once you enable sync (set DARBAAN_INBOUND_IMAP_HOST in docker-compose.yml).
+# Leave blank while sync is disabled. v1 has NO filter: the agent reads the whole
+# synced mailbox, so point sync at a non-sensitive / test mailbox.
+DARBAAN_INBOUND_IMAP_PASSWORD=
+
 # Telegram approval client (the darbaan-telegram service). Both required to run
 # it; leave the service stopped if you don't use Telegram approvals.
 #   - Bot token from @BotFather (never logged).

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ COPY --from=builder --chown=65532:65532 /data /data
 ENV DARBAAN_SLUICE_DB=/data/sluice.db \
     DARBAAN_AUDIT_DB=/data/audit.db \
     DARBAAN_INBOUND_DB=/data/inbound.db \
+    DARBAAN_INBOUND_SYNC_DB=/data/sync.db \
     DARBAAN_SENDER_TYPE=stub
 
 # SMTP submission face + IMAP read face.

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -16,6 +16,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -29,6 +30,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/imapsync"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/listener"
 	"github.com/yaad-index/darbaan/internal/policy"
@@ -71,6 +73,12 @@ type CLI struct {
 	IMAPAddr string `name:"imap-addr" default:":1143" help:"IMAP read-face listen address (serves the agent's bounces); reuses the agent credential and listener TLS."`
 
 	AdminAddr string `name:"admin-addr" default:"127.0.0.1:1144" help:"Operator admin API address. Loopback-only / container-internal; the queue subcommands connect here. Token from DARBAAN_ADMIN_TOKEN."`
+
+	InboundIMAPHost         string        `name:"inbound-imap-host" help:"Upstream IMAP host:port to sync the agent's mailbox FROM (ADR 0019). Empty disables sync. App password via DARBAAN_INBOUND_IMAP_PASSWORD."`
+	InboundIMAPUsername     string        `name:"inbound-imap-username" help:"Upstream IMAP username for the sync."`
+	InboundIMAPMailbox      string        `name:"inbound-imap-mailbox" default:"INBOX" help:"Upstream mailbox to sync."`
+	InboundIMAPPollInterval time.Duration `name:"inbound-imap-poll-interval" default:"60s" help:"How often to poll the upstream mailbox for new mail."`
+	InboundSyncDB           string        `name:"inbound-sync-db" default:"darbaan-sync.db" help:"Path to the inbound sync-state (UIDVALIDITY + last UID) database." type:"path"`
 
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
@@ -138,6 +146,52 @@ func (c *CLI) openSender() (backend.Sender, error) {
 		Username: c.SMTPUsername,
 		Password: os.Getenv("DARBAAN_SMTP_PASSWORD"),
 	})
+}
+
+// startInboundSync starts the upstream IMAP poll-sync loop (ADR 0019) if an
+// upstream is configured; otherwise it is a no-op, gated off by default like the
+// stub sender. It returns a stop func that closes the sync-state store. Sync
+// errors are logged, never fatal — a flaky or unreachable upstream must not take
+// down serve.
+func (cli *CLI) startInboundSync(ctx context.Context, inbox inbound.InboundStore) (func(), error) {
+	if cli.InboundIMAPHost == "" {
+		fmt.Fprintln(os.Stderr, "darbaan: inbound sync disabled (no inbound-imap-host configured)")
+		return func() {}, nil
+	}
+	state, err := imapsync.NewStateStore(cli.InboundSyncDB)
+	if err != nil {
+		return nil, err
+	}
+	dial := imapsync.Dialer(cli.InboundIMAPHost, cli.InboundIMAPUsername, os.Getenv("DARBAAN_INBOUND_IMAP_PASSWORD"))
+	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbox, state)
+
+	go func() {
+		t := time.NewTicker(cli.InboundIMAPPollInterval)
+		defer t.Stop()
+		runSync(ctx, syncer) // initial pull at startup
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				runSync(ctx, syncer)
+			}
+		}
+	}()
+	fmt.Fprintf(os.Stderr, "darbaan: inbound sync on %s (%s as %s) every %s\n",
+		cli.InboundIMAPHost, cli.InboundIMAPMailbox, cli.InboundIMAPUsername, cli.InboundIMAPPollInterval)
+	return func() { _ = state.Close() }, nil
+}
+
+func runSync(ctx context.Context, s *imapsync.Syncer) {
+	n, err := s.Sync(ctx)
+	if err != nil {
+		log.Printf("darbaan: inbound sync: %v", err)
+		return
+	}
+	if n > 0 {
+		log.Printf("darbaan: inbound sync pulled %d new message(s)", n)
+	}
 }
 
 // adminClient builds a thin client for the running serve's admin API. The token
@@ -263,15 +317,24 @@ func (*ServeCmd) Run(cli *CLI) error {
 		return err
 	}
 
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Inbound mailbox sync (ADR 0019) — a no-op unless an upstream is configured.
+	// It shares the shutdown ctx; sync errors are logged, never fatal.
+	stopSync, err := cli.startInboundSync(ctx, inbox)
+	if err != nil {
+		return err
+	}
+	defer stopSync()
+
 	closeAll := func() {
 		_ = smtpSrv.Close()
 		_ = imapSrv.Close()
 		_ = adminSrv.Close()
 	}
 	go func() {
-		sig := make(chan os.Signal, 1)
-		signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
-		<-sig
+		<-ctx.Done()
 		closeAll()
 	}()
 

--- a/cmd/darbaan/sync_test.go
+++ b/cmd/darbaan/sync_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Inbound sync is off by default: with no upstream host, startInboundSync is a
+// no-op (no state store opened, no goroutine) and never errors.
+func TestInboundSyncDisabledByDefault(t *testing.T) {
+	cli := &CLI{} // InboundIMAPHost == ""
+	stop, err := cli.startInboundSync(context.Background(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, stop)
+	stop() // no-op, must not panic
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,15 @@ services:
       DARBAAN_SMTP_HOST: "smtp.gmail.com:587"
       DARBAAN_SMTP_USERNAME: "" # e.g. you@gmail.com (when sender-type=smtp)
       DARBAAN_SMTP_PASSWORD: "${DARBAAN_SMTP_PASSWORD:-}"
+
+      # Inbound mailbox sync (ADR 0019) — OFF by default (no host = disabled).
+      # WARNING (v1, no filter): everything synced is fully readable by the agent
+      # — point it at a non-sensitive / test mailbox until the filter lands.
+      # Uncomment + set the host/username to enable; password from .env.
+      # DARBAAN_INBOUND_IMAP_HOST: "imap.gmail.com:993"
+      # DARBAAN_INBOUND_IMAP_USERNAME: "" # e.g. you@gmail.com
+      # DARBAAN_INBOUND_IMAP_MAILBOX: "INBOX"
+      DARBAAN_INBOUND_IMAP_PASSWORD: "${DARBAAN_INBOUND_IMAP_PASSWORD:-}"
     volumes:
       - darbaan-data:/data # the three bbolt DBs (sluice / audit / inbound)
       - ./secrets/tls:/run/secrets/tls:ro # you provide cert.pem + key.pem


### PR DESCRIPTION
**Inc 2** of the inbound sync build (ADR 0019): run the Inc 1 engine from `serve`, config-driven — the bare end-to-end sync. **Off by default.**

## What
- **Config** (env, ADR 0012): `inbound-imap-host` / `-username` / `-mailbox` (INBOX) / `-poll-interval` (60s) + `inbound-sync-db`; the app password via `DARBAAN_INBOUND_IMAP_PASSWORD` (never inlined). **Empty host = disabled** — same gate-off posture as `sender-type=stub`.
- **serve** starts the poll-sync loop when configured, sharing the shutdown context. **Best-effort**: a connect/fetch error is logged, **never fatal** — a flaky/unreachable upstream must not take down serve. `owner = agent-username`; synced mail is served over the **existing IMAP read face** (no read-face change).
- **Docker**: sync-state DB defaults to `/data` (on the volume); compose + `.env.example` document the inbound-imap env, **commented off**, with the v1 **no-filter warning** (the agent reads the whole synced mailbox — point sync at a non-sensitive / test mailbox until the filter lands).

## Verification
- `serve --help` lists the flags; with no host → `inbound sync disabled`; with an unreachable host → serve **stays up** and the sync error is logged (best-effort, confirmed in a smoke run).
- `TestInboundSyncDisabledByDefault` pins the off-by-default no-op. `docker compose config` valid.
- build/vet/gofmt/`go test -race`/golangci-lint clean.

Carries the **live Gmail sync test** on the box after merge (upstream env set there). Ref ADR 0019; Inc 3 = lazy/per-FETCH refinement.
