### PR TITLE
fix(imapsync): concrete UIDNEXT bound + streamed fetch (live-test bug)

### DIFF
--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -3,7 +3,6 @@ package imapsync
 import (
 	"context"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/emersion/go-imap/v2"
@@ -74,37 +73,9 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 		last = 0 // new or reset mailbox — full re-sync
 	}
 
-	// UID FETCH (last+1):* — a fresh mailbox (last 0) fetches 1:* (everything).
-	var set imap.UIDSet
-	set.AddRange(imap.UID(last+1), 0) // Stop 0 == "*"
-	msgs, err := c.Fetch(set, &imap.FetchOptions{
-		UID:         true,
-		Envelope:    true,
-		BodySection: []*imap.FetchItemBodySection{{}}, // whole message
-	}).Collect()
+	stored, highest, err := s.pull(c, uint32(sel.UIDNext), last)
 	if err != nil {
-		return 0, fmt.Errorf("imapsync: fetch: %w", err)
-	}
-
-	// Ascending UID so the cursor advances monotonically.
-	sort.Slice(msgs, func(i, j int) bool { return msgs[i].UID < msgs[j].UID })
-
-	highest := last
-	stored := 0
-	for _, m := range msgs {
-		uid := uint32(m.UID)
-		// "N:*" returns the highest existing message even when N is past it;
-		// skip anything not actually newer than the cursor.
-		if uid <= last {
-			continue
-		}
-		if _, err := s.store.Add(deliveryOf(s.owner, m)); err != nil {
-			return stored, fmt.Errorf("imapsync: store uid %d: %w", uid, err)
-		}
-		stored++
-		if uid > highest {
-			highest = uid
-		}
+		return stored, err
 	}
 
 	newState := State{UIDValidity: sel.UIDValidity, LastUID: highest}
@@ -114,6 +85,66 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 		}
 	}
 	return stored, nil
+}
+
+// pull fetches new messages and stores them, returning the count stored and the
+// new cursor (the highest UID stored, or the prior cursor if nothing was new).
+//
+// It uses a CONCRETE upper bound from the mailbox's UIDNEXT — go-imap's dynamic
+// "*" range (Stop 0) is mis-encoded on the wire against strict servers (e.g.
+// Gmail) and silently matches nothing; only when a server reports no UIDNEXT do
+// we fall back to the dynamic range, guarded against the "N:*" past-the-end
+// re-return.
+//
+// The fetch is STREAMED (one message buffered at a time via cmd.Next), so a
+// large mailbox never loads into memory at once. On a mid-stream error the
+// cursor is not advanced, so the next run re-syncs — at-least-once, no gaps.
+func (s *Syncer) pull(c *imapclient.Client, uidNext, last uint32) (int, uint32, error) {
+	var set imap.UIDSet
+	if uidNext > 0 {
+		hi := uidNext - 1 // highest possible existing UID
+		if last+1 > hi {
+			return 0, last, nil // no new messages
+		}
+		set.AddRange(imap.UID(last+1), imap.UID(hi))
+	} else {
+		set.AddRange(imap.UID(last+1), 0) // fallback: dynamic "*"
+	}
+
+	cmd := c.Fetch(set, &imap.FetchOptions{
+		UID:         true,
+		Envelope:    true,
+		BodySection: []*imap.FetchItemBodySection{{}}, // whole message
+	})
+
+	stored, highest := 0, last
+	for {
+		data := cmd.Next()
+		if data == nil {
+			break
+		}
+		m, err := data.Collect()
+		if err != nil {
+			_ = cmd.Close()
+			return stored, highest, fmt.Errorf("imapsync: fetch: %w", err)
+		}
+		uid := uint32(m.UID)
+		if uid <= last {
+			continue // dynamic "N:*" past-the-end guard
+		}
+		if _, err := s.store.Add(deliveryOf(s.owner, m)); err != nil {
+			_ = cmd.Close()
+			return stored, highest, fmt.Errorf("imapsync: store uid %d: %w", uid, err)
+		}
+		stored++
+		if uid > highest {
+			highest = uid
+		}
+	}
+	if err := cmd.Close(); err != nil {
+		return stored, highest, fmt.Errorf("imapsync: fetch: %w", err)
+	}
+	return stored, highest, nil
 }
 
 func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -3,6 +3,7 @@ package imapsync_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -110,6 +111,29 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	assert.Equal(t, 1, n)
 	msgs, _ = store.List("agent")
 	assert.Len(t, msgs, 3)
+}
+
+// Streaming pulls every message (no Collect-all into memory), and the concrete
+// UIDNEXT bound makes a no-new sync return 0 (not via the "N:*" quirk).
+func TestSyncStreamsManyMessages(t *testing.T) {
+	addr, user := startUpstream(t)
+	const n = 25
+	for i := 0; i < n; i++ {
+		appendMsg(t, user, fmt.Sprintf("Subject: m%d\r\n\r\nbody %d", i, i))
+	}
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+
+	got, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, n, got)
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	assert.Len(t, msgs, n)
+
+	got, err = syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, got) // concrete bound: last+1 > UIDNEXT-1, no fetch
 }
 
 // A recorded cursor for a different UIDVALIDITY (mailbox reset) is discarded and


### PR DESCRIPTION
The live Gmail test pulled **0**. Root cause: the fetch used the dynamic `*` range (`UIDSet.AddRange(last+1, 0)`). `UIDSet.String()` renders `"1:*"` correctly, but go-imap/v2 **wire-encodes `Stop:0` differently** and Gmail matches nothing. The in-process `imapmemserver` tolerated it, so the unit tests passed — the strict real server exposed it. **Exactly why the live test earned its keep.**

## Fix (also addresses the first-sync memory cost)
- **Concrete upper bound from UIDNEXT**: fetch `(last+1):(uidNext-1)`, never `*`. No dynamic-range encoding and **no `N:*` past-the-end quirk** to guard. Falls back to the dynamic range only when a server reports no UIDNEXT.
- **Streamed fetch** (`cmd.Next`, one message buffered at a time) instead of `Collect()`-ing the whole mailbox — a 2000+-message first sync stays bounded to **a single message at a time**.

Cursor saved at end (**at-least-once**): a mid-stream error leaves it unmoved → re-sync with no gaps; the crash-mid-sync duplicate stays Inc 3's upstream-UID dedup.

## Verification
memserver reports UIDNEXT, so the **concrete path stays under test**: `TestSyncStreamsManyMessages` exercises the stream loop + the no-new concrete bound; the incremental-pull and UIDVALIDITY-reset tests still pass. build/vet/gofmt/`go test -race`/golangci-lint clean.

Carries the **live Gmail re-verify** on the box after merge.
