### PR TITLE
feat(inbound): idempotent sync via upstream-UID dedup (ADR 0019 Inc 3a)

### DIFF
--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -71,6 +71,9 @@ type failingInbound struct{}
 func (failingInbound) Add(inbound.Delivery) (inbound.Message, error) {
 	return inbound.Message{}, errors.New("inbound store down")
 }
+func (failingInbound) AddSynced(inbound.Delivery) (bool, inbound.Message, error) {
+	return false, inbound.Message{}, errors.New("inbound store down")
+}
 func (failingInbound) List(string) ([]inbound.Message, error) { return nil, nil }
 func (failingInbound) Get(string, string) (inbound.Message, error) {
 	return inbound.Message{}, inbound.ErrNotFound

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -73,7 +73,7 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 		last = 0 // new or reset mailbox — full re-sync
 	}
 
-	stored, highest, err := s.pull(c, uint32(sel.UIDNext), last)
+	stored, highest, err := s.pull(c, sel.UIDValidity, uint32(sel.UIDNext), last)
 	if err != nil {
 		return stored, err
 	}
@@ -99,7 +99,7 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 // The fetch is STREAMED (one message buffered at a time via cmd.Next), so a
 // large mailbox never loads into memory at once. On a mid-stream error the
 // cursor is not advanced, so the next run re-syncs — at-least-once, no gaps.
-func (s *Syncer) pull(c *imapclient.Client, uidNext, last uint32) (int, uint32, error) {
+func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (int, uint32, error) {
 	var set imap.UIDSet
 	if uidNext > 0 {
 		hi := uidNext - 1 // highest possible existing UID
@@ -132,11 +132,20 @@ func (s *Syncer) pull(c *imapclient.Client, uidNext, last uint32) (int, uint32, 
 		if uid <= last {
 			continue // dynamic "N:*" past-the-end guard
 		}
-		if _, err := s.store.Add(deliveryOf(s.owner, m)); err != nil {
+		d := deliveryOf(s.owner, m)
+		d.UpstreamUID = uid
+		d.UIDValidity = uidValidity
+		// AddSynced is idempotent on (owner, UIDVALIDITY, UID): a re-fetched
+		// message (e.g. after a crash) is a no-op (added=false).
+		added, _, err := s.store.AddSynced(d)
+		if err != nil {
 			_ = cmd.Close()
 			return stored, highest, fmt.Errorf("imapsync: store uid %d: %w", uid, err)
 		}
-		stored++
+		if added {
+			stored++
+		}
+		// Advance the cursor past every fetched UID, new or already-stored.
 		if uid > highest {
 			highest = uid
 		}

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -136,6 +136,29 @@ func TestSyncStreamsManyMessages(t *testing.T) {
 	assert.Equal(t, 0, got) // concrete bound: last+1 > UIDNEXT-1, no fetch
 }
 
+// A lost/reset sync cursor re-fetches everything, but the upstream-UID dedup
+// (AddSynced) keeps the store free of duplicates — the crash-mid-sync window.
+func TestSyncDedupsOnCursorReset(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: a\r\n\r\nx")
+	appendMsg(t, user, "Subject: b\r\n\r\ny")
+
+	store := newInbound(t) // shared across both syncers
+
+	n, err := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t)).Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// A second syncer with a FRESH cursor re-fetches both, but dedups: 0 new.
+	n, err = imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t)).Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2) // no duplicates
+}
+
 // A recorded cursor for a different UIDVALIDITY (mailbox reset) is discarded and
 // the mailbox re-synced from scratch, despite a high recorded LastUID.
 func TestSyncResetsOnUIDValidityMismatch(t *testing.T) {

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -1,6 +1,7 @@
 package inbound
 
 import (
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -15,7 +16,12 @@ import (
 	"github.com/yaad-index/darbaan/internal/seqkey"
 )
 
-var bucketInbound = []byte("inbound")
+var (
+	bucketInbound = []byte("inbound")
+	// bucketSynced indexes upstream-pulled messages by (owner, UIDVALIDITY, UID)
+	// for idempotent re-sync (ADR 0019); value is the message's bucketInbound key.
+	bucketSynced = []byte("synced")
+)
 
 func init() {
 	Register("bbolt", newBbolt)
@@ -52,7 +58,10 @@ func newBbolt(path string) (InboundStore, error) {
 		return nil, fmt.Errorf("inbound: open db: %w", err)
 	}
 	if err := db.Update(func(tx *bbolt.Tx) error {
-		_, e := tx.CreateBucketIfNotExists(bucketInbound)
+		if _, e := tx.CreateBucketIfNotExists(bucketInbound); e != nil {
+			return e
+		}
+		_, e := tx.CreateBucketIfNotExists(bucketSynced)
 		return e
 	}); err != nil {
 		_ = db.Close()
@@ -107,32 +116,97 @@ func (s *bboltStore) Close() error { return s.db.Close() }
 func (s *bboltStore) Add(d Delivery) (Message, error) {
 	var msg Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
-		b := tx.Bucket(bucketInbound)
-		seq, err := b.NextSequence()
-		if err != nil {
-			return err
-		}
-		msg = Message{
-			ID:         strconv.FormatUint(seq, 10),
-			Owner:      d.Owner,
-			From:       d.From,
-			To:         d.To,
-			Subject:    d.Subject,
-			Raw:        d.Raw,
-			Seen:       false,
-			ReceivedAt: time.Now().UTC(),
-		}
-		// Content tier first: the durable blob is on disk before the referencing
-		// metadata commits (ADR 0018), so a crash can only orphan a blob.
-		if err := s.blobs.Put(msg.ID, d.Raw); err != nil {
-			return fmt.Errorf("write content: %w", err)
-		}
-		return putStored(tx, seqkey.Encode(seq), storedFrom(msg))
+		var e error
+		msg, _, e = s.put(tx, d)
+		return e
 	})
 	if err != nil {
 		return Message{}, fmt.Errorf("inbound: add: %w", err)
 	}
 	return msg, nil
+}
+
+// AddSynced stores an upstream-pulled message idempotently: if its upstream
+// (owner, UIDValidity, UpstreamUID) is already indexed, it's a no-op returning
+// added=false, so a crash-mid-sync re-fetch never duplicates (#87). Otherwise it
+// stores the message and indexes it.
+func (s *bboltStore) AddSynced(d Delivery) (bool, Message, error) {
+	if d.UpstreamUID == 0 {
+		return false, Message{}, fmt.Errorf("inbound: AddSynced requires a non-zero upstream UID")
+	}
+	idxKey := syncedKey(d.Owner, d.UIDValidity, d.UpstreamUID)
+	var (
+		added bool
+		msg   Message
+	)
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		idx := tx.Bucket(bucketSynced)
+		if ref := idx.Get(idxKey); ref != nil {
+			// Already stored — idempotent no-op; return the existing metadata.
+			if v := tx.Bucket(bucketInbound).Get(ref); v != nil {
+				var rec stored
+				if err := json.Unmarshal(v, &rec); err != nil {
+					return err
+				}
+				msg = rec.Message
+			}
+			return nil
+		}
+		m, key, err := s.put(tx, d)
+		if err != nil {
+			return err
+		}
+		added, msg = true, m
+		return idx.Put(idxKey, key)
+	})
+	if err != nil {
+		return false, Message{}, fmt.Errorf("inbound: add synced: %w", err)
+	}
+	return added, msg, nil
+}
+
+// put builds and persists a new message from a delivery (blob first, then
+// metadata) and returns it with its bbolt key. The caller is inside a write txn.
+func (s *bboltStore) put(tx *bbolt.Tx, d Delivery) (Message, []byte, error) {
+	b := tx.Bucket(bucketInbound)
+	seq, err := b.NextSequence()
+	if err != nil {
+		return Message{}, nil, err
+	}
+	msg := Message{
+		ID:          strconv.FormatUint(seq, 10),
+		Owner:       d.Owner,
+		From:        d.From,
+		To:          d.To,
+		Subject:     d.Subject,
+		Raw:         d.Raw,
+		Seen:        false,
+		ReceivedAt:  time.Now().UTC(),
+		UpstreamUID: d.UpstreamUID,
+		UIDValidity: d.UIDValidity,
+	}
+	key := seqkey.Encode(seq)
+	// Content tier first: the durable blob is on disk before the referencing
+	// metadata commits (ADR 0018), so a crash can only orphan a blob.
+	if err := s.blobs.Put(msg.ID, d.Raw); err != nil {
+		return Message{}, nil, fmt.Errorf("write content: %w", err)
+	}
+	if err := putStored(tx, key, storedFrom(msg)); err != nil {
+		return Message{}, nil, err
+	}
+	return msg, key, nil
+}
+
+// syncedKey is the dedup index key for an upstream message: owner + UIDVALIDITY
+// + UID. UIDVALIDITY is included because UIDs are only unique within it.
+func syncedKey(owner string, uidValidity, uid uint32) []byte {
+	k := make([]byte, 0, len(owner)+1+8)
+	k = append(k, owner...)
+	k = append(k, 0) // separator (an owner name has no NUL)
+	var n [8]byte
+	binary.BigEndian.PutUint32(n[0:4], uidValidity)
+	binary.BigEndian.PutUint32(n[4:8], uid)
+	return append(k, n[:]...)
 }
 
 func (s *bboltStore) List(owner string) ([]Message, error) {

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -23,6 +23,12 @@ type Delivery struct {
 	To      string // the original submitter
 	Subject string
 	Raw     []byte // full message/rfc822 (the DSN bounce)
+
+	// Upstream coordinates for messages pulled by the inbound sync (ADR 0019);
+	// zero for locally-generated deliveries like bounces. AddSynced uses them to
+	// dedup an idempotent re-sync and (later) to fetch content on demand.
+	UpstreamUID uint32
+	UIDValidity uint32
 }
 
 // Message is a stored inbound message.
@@ -35,6 +41,10 @@ type Message struct {
 	Raw        []byte    `json:"raw"`
 	Seen       bool      `json:"seen"` // IMAP \Seen; bounces land unseen
 	ReceivedAt time.Time `json:"received_at"`
+
+	// Upstream coordinates (ADR 0019); zero for locally-generated messages.
+	UpstreamUID uint32 `json:"upstream_uid,omitempty"`
+	UIDValidity uint32 `json:"uid_validity,omitempty"`
 }
 
 // InboundStore is the agent's served mailbox. Implementations are selected by
@@ -42,6 +52,11 @@ type Message struct {
 type InboundStore interface {
 	// Add stores a delivery and returns the stored message.
 	Add(Delivery) (Message, error)
+	// AddSynced stores a message pulled from upstream, keyed for idempotency by
+	// its upstream (UIDValidity, UpstreamUID). If that upstream message is
+	// already stored it is a no-op returning added=false; otherwise it is stored
+	// and added=true. The Delivery must carry non-zero upstream coordinates.
+	AddSynced(Delivery) (added bool, m Message, err error)
 	// List returns the owner's messages in receive order.
 	List(owner string) ([]Message, error)
 	// Get returns one of the owner's messages, or ErrNotFound.

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -18,6 +18,42 @@ func newStore(t *testing.T) inbound.InboundStore {
 	return s
 }
 
+func TestAddSyncedDedup(t *testing.T) {
+	s := newStore(t)
+	d := inbound.Delivery{Owner: "agent", Subject: "hi", Raw: []byte("Subject: hi\r\n\r\nx"), UpstreamUID: 5, UIDValidity: 1}
+
+	added, m1, err := s.AddSynced(d)
+	require.NoError(t, err)
+	assert.True(t, added)
+
+	// Same upstream coordinates → idempotent no-op, returns the existing record.
+	added, m2, err := s.AddSynced(d)
+	require.NoError(t, err)
+	assert.False(t, added)
+	assert.Equal(t, m1.ID, m2.ID)
+	msgs, _ := s.List("agent")
+	assert.Len(t, msgs, 1)
+
+	// A different UID is a new message.
+	d.UpstreamUID = 6
+	added, _, err = s.AddSynced(d)
+	require.NoError(t, err)
+	assert.True(t, added)
+
+	// Same UID under a different UIDVALIDITY is also new (UIDs unique per validity).
+	d.UpstreamUID, d.UIDValidity = 5, 2
+	added, _, err = s.AddSynced(d)
+	require.NoError(t, err)
+	assert.True(t, added)
+
+	msgs, _ = s.List("agent")
+	assert.Len(t, msgs, 3)
+
+	// AddSynced requires upstream coordinates.
+	_, _, err = s.AddSynced(inbound.Delivery{Owner: "agent"})
+	assert.Error(t, err)
+}
+
 func TestAddListGet(t *testing.T) {
 	s := newStore(t)
 	m, err := s.Add(inbound.Delivery{


### PR DESCRIPTION
**Inc 3a** (ADR 0019): the idempotent-sync foundation — independently valuable + lays the upstream-UID the lazy fetch (3b) needs.

## What
- `inbound.Delivery`/`Message` gain **UpstreamUID + UIDValidity** (zero for locally-generated messages like bounces).
- **`InboundStore.AddSynced(Delivery) (added bool, m, err)`**: stores an upstream-pulled message keyed for idempotency by **(owner, UIDValidity, UpstreamUID)** via a `synced` index bucket. Already indexed → **no-op** (added=false, returns the existing record); else store + index, atomic in one bbolt txn. **Bounces keep using `Add`** (no dedup, unchanged).
- **imapsync** stores via `AddSynced` (message UID + mailbox UIDVALIDITY); counts only newly-added, advances the cursor past every fetched UID (new or deduped). The upstream UID is now **persisted per record** — the coordinate 3b's on-demand fetch will use.

## Why
Closes the crash-mid-sync duplicate window (#87): a re-fetch after a crash (cursor not advanced) is now a no-op instead of a duplicate.

## Known gap (deliberate, not backfilled)
Records synced **before** this change have no upstream UID, so they aren't in the dedup index → not dedup-protected if UIDVALIDITY ever resets. Gmail's UIDVALIDITY is stable (=1), so low-risk; a backfill isn't worth it. New syncs are indexed going forward. For live re-verify, a narrow new-arrival → forced-refetch → no-op check exercises dedup without a cursor reset that would re-pull the un-indexed history.

## Verification
build/vet/gofmt/`go test -race`/golangci-lint clean. Tests: `AddSyncedDedup` (same coords no-op; different UID / UIDVALIDITY new; zero UID error); `SyncDedupsOnCursorReset` (fresh cursor re-fetches → 0 new, no duplicates).

Inc 3b next: present/pending tri-state + headers-only sync + on-demand per-FETCH serving.
