### PR TITLE
feat(inbound): pending content state + on-demand FetchContent (ADR 0019 Inc 3b-i)

### DIFF
--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -74,6 +74,12 @@ func (failingInbound) Add(inbound.Delivery) (inbound.Message, error) {
 func (failingInbound) AddSynced(inbound.Delivery) (bool, inbound.Message, error) {
 	return false, inbound.Message{}, errors.New("inbound store down")
 }
+func (failingInbound) AddSyncedPending(inbound.Delivery) (bool, inbound.Message, error) {
+	return false, inbound.Message{}, errors.New("inbound store down")
+}
+func (failingInbound) SetContent(string, string, []byte) (inbound.Message, error) {
+	return inbound.Message{}, errors.New("inbound store down")
+}
 func (failingInbound) List(string) ([]inbound.Message, error) { return nil, nil }
 func (failingInbound) Get(string, string) (inbound.Message, error) {
 	return inbound.Message{}, inbound.ErrNotFound

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -156,6 +156,66 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 	return stored, highest, nil
 }
 
+// FetchContent fills a pending message's body on demand (ADR 0019, the read-time
+// half): it dials upstream, fetches that message's body by its stored UID, and
+// SetContents it (marking the record present). A present message is returned
+// as-is without contacting upstream — content is fetched once, then cached. It
+// errors cleanly when the mailbox UIDVALIDITY has changed (the stored UID is
+// stale) or the message is gone upstream, so the read face can surface a
+// transient error rather than empty content.
+func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
+	m, err := s.store.Get(owner, id)
+	if err != nil {
+		return inbound.Message{}, err
+	}
+	if !m.Pending {
+		return m, nil // already present — no upstream contact
+	}
+
+	c, err := s.dial()
+	if err != nil {
+		return inbound.Message{}, fmt.Errorf("imapsync: connect: %w", err)
+	}
+	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
+
+	sel, err := c.Select(s.mailbox, nil).Wait()
+	if err != nil {
+		return inbound.Message{}, fmt.Errorf("imapsync: select %q: %w", s.mailbox, err)
+	}
+	if sel.UIDValidity != m.UIDValidity {
+		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: mailbox reset (uidvalidity %d != %d)", id, sel.UIDValidity, m.UIDValidity)
+	}
+
+	var set imap.UIDSet
+	set.AddNum(imap.UID(m.UpstreamUID))
+	cmd := c.Fetch(set, &imap.FetchOptions{
+		UID:         true,
+		BodySection: []*imap.FetchItemBodySection{{}},
+	})
+	var raw []byte
+	for {
+		data := cmd.Next()
+		if data == nil {
+			break
+		}
+		fm, err := data.Collect()
+		if err != nil {
+			_ = cmd.Close()
+			return inbound.Message{}, fmt.Errorf("imapsync: fetch content %s: %w", id, err)
+		}
+		if uint32(fm.UID) == m.UpstreamUID {
+			raw = rawBody(fm)
+		}
+	}
+	if err := cmd.Close(); err != nil {
+		return inbound.Message{}, fmt.Errorf("imapsync: fetch content %s: %w", id, err)
+	}
+	if raw == nil {
+		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found", id, m.UpstreamUID)
+	}
+	return s.store.SetContent(owner, id, raw)
+}
+
 func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {
 	d := inbound.Delivery{Owner: owner, Raw: rawBody(m)}
 	if m.Envelope != nil {

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -136,6 +136,50 @@ func TestSyncStreamsManyMessages(t *testing.T) {
 	assert.Equal(t, 0, got) // concrete bound: last+1 > UIDNEXT-1, no fetch
 }
 
+// FetchContent fills a pending (headers-only) record's body from upstream on
+// demand, marks it present, and is a no-op on an already-present message.
+func TestFetchContentFillsPending(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: real\r\n\r\nreal body") // upstream UID 1, UIDVALIDITY 1
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "real", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+	require.True(t, m.Pending)
+
+	filled, err := syncer.FetchContent("agent", m.ID)
+	require.NoError(t, err)
+	assert.False(t, filled.Pending)
+	assert.Contains(t, string(filled.Raw), "real body")
+
+	got, err := store.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Pending)
+	assert.Contains(t, string(got.Raw), "real body")
+
+	// Present message → no upstream contact, returned as-is.
+	again, err := syncer.FetchContent("agent", m.ID)
+	require.NoError(t, err)
+	assert.False(t, again.Pending)
+}
+
+// A pending record whose UIDVALIDITY no longer matches upstream errors cleanly
+// (stale UID) rather than serving wrong/empty content.
+func TestFetchContentStaleUIDValidity(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: x\r\n\r\ny")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 999})
+	require.NoError(t, err)
+
+	_, err = syncer.FetchContent("agent", m.ID)
+	require.Error(t, err)
+}
+
 // A lost/reset sync cursor re-fetches everything, but the upstream-UID dedup
 // (AddSynced) keeps the store free of duplicates — the crash-mid-sync window.
 func TestSyncDedupsOnCursorReset(t *testing.T) {

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -117,7 +117,7 @@ func (s *bboltStore) Add(d Delivery) (Message, error) {
 	var msg Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		var e error
-		msg, _, e = s.put(tx, d)
+		msg, _, e = s.put(tx, d, false)
 		return e
 	})
 	if err != nil {
@@ -126,11 +126,22 @@ func (s *bboltStore) Add(d Delivery) (Message, error) {
 	return msg, nil
 }
 
-// AddSynced stores an upstream-pulled message idempotently: if its upstream
-// (owner, UIDValidity, UpstreamUID) is already indexed, it's a no-op returning
-// added=false, so a crash-mid-sync re-fetch never duplicates (#87). Otherwise it
-// stores the message and indexes it.
+// AddSynced stores an upstream-pulled message (with content) idempotently.
 func (s *bboltStore) AddSynced(d Delivery) (bool, Message, error) {
+	return s.addSynced(d, false)
+}
+
+// AddSyncedPending stores a headers-only (pending) record idempotently — no
+// content blob; SetContent fills it later (lazy sync, ADR 0019).
+func (s *bboltStore) AddSyncedPending(d Delivery) (bool, Message, error) {
+	return s.addSynced(d, true)
+}
+
+// addSynced is the shared dedup path: if the upstream (owner, UIDValidity,
+// UpstreamUID) is already indexed it's a no-op (added=false, returns the
+// existing record), so a crash-mid-sync re-fetch never duplicates (#87);
+// otherwise it stores the message (pending or present) and indexes it.
+func (s *bboltStore) addSynced(d Delivery, pending bool) (bool, Message, error) {
 	if d.UpstreamUID == 0 {
 		return false, Message{}, fmt.Errorf("inbound: AddSynced requires a non-zero upstream UID")
 	}
@@ -142,7 +153,6 @@ func (s *bboltStore) AddSynced(d Delivery) (bool, Message, error) {
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		idx := tx.Bucket(bucketSynced)
 		if ref := idx.Get(idxKey); ref != nil {
-			// Already stored — idempotent no-op; return the existing metadata.
 			if v := tx.Bucket(bucketInbound).Get(ref); v != nil {
 				var rec stored
 				if err := json.Unmarshal(v, &rec); err != nil {
@@ -152,7 +162,7 @@ func (s *bboltStore) AddSynced(d Delivery) (bool, Message, error) {
 			}
 			return nil
 		}
-		m, key, err := s.put(tx, d)
+		m, key, err := s.put(tx, d, pending)
 		if err != nil {
 			return err
 		}
@@ -165,9 +175,38 @@ func (s *bboltStore) AddSynced(d Delivery) (bool, Message, error) {
 	return added, msg, nil
 }
 
-// put builds and persists a new message from a delivery (blob first, then
-// metadata) and returns it with its bbolt key. The caller is inside a write txn.
-func (s *bboltStore) put(tx *bbolt.Tx, d Delivery) (Message, []byte, error) {
+// SetContent fills a pending message's body: write the content blob and mark the
+// record present. Owner-scoped; returns the now-complete message.
+func (s *bboltStore) SetContent(owner, id string, raw []byte) (Message, error) {
+	var msg Message
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		rec, key, err := loadStored(tx, id)
+		if err != nil {
+			return err
+		}
+		if rec.Owner != owner {
+			return ErrNotFound
+		}
+		// Content blob first, then the metadata flip (same ordering as Add).
+		if err := s.blobs.Put(id, raw); err != nil {
+			return fmt.Errorf("write content: %w", err)
+		}
+		rec.Pending = false
+		rec.Blobbed = true
+		msg = rec.Message
+		msg.Raw = raw
+		return putStored(tx, key, rec)
+	})
+	if err != nil {
+		return Message{}, fmt.Errorf("inbound: set content %s: %w", id, err)
+	}
+	return msg, nil
+}
+
+// put builds and persists a new message. For a present message it writes the
+// content blob first (ADR 0018 ordering); a pending message has no blob yet.
+// Returns the message and its bbolt key. The caller is inside a write txn.
+func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byte, error) {
 	b := tx.Bucket(bucketInbound)
 	seq, err := b.NextSequence()
 	if err != nil {
@@ -179,19 +218,22 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery) (Message, []byte, error) {
 		From:        d.From,
 		To:          d.To,
 		Subject:     d.Subject,
-		Raw:         d.Raw,
 		Seen:        false,
 		ReceivedAt:  time.Now().UTC(),
 		UpstreamUID: d.UpstreamUID,
 		UIDValidity: d.UIDValidity,
+		Pending:     pending,
 	}
 	key := seqkey.Encode(seq)
-	// Content tier first: the durable blob is on disk before the referencing
-	// metadata commits (ADR 0018), so a crash can only orphan a blob.
-	if err := s.blobs.Put(msg.ID, d.Raw); err != nil {
-		return Message{}, nil, fmt.Errorf("write content: %w", err)
+	blobbed := false
+	if !pending {
+		msg.Raw = d.Raw // present (return carries it; storedRec drops it for storage)
+		if err := s.blobs.Put(msg.ID, d.Raw); err != nil {
+			return Message{}, nil, fmt.Errorf("write content: %w", err)
+		}
+		blobbed = true
 	}
-	if err := putStored(tx, key, storedFrom(msg)); err != nil {
+	if err := putStored(tx, key, storedRec(msg, blobbed)); err != nil {
 		return Message{}, nil, err
 	}
 	return msg, key, nil
@@ -279,21 +321,26 @@ func (s *bboltStore) Get(owner, id string) (Message, error) {
 // blob (or, for a legacy record, the inline raw it already carries).
 func (s *bboltStore) withRaw(rec stored) (Message, error) {
 	msg := rec.Message
-	if rec.Blobbed {
+	switch {
+	case msg.Pending:
+		// Content not fetched yet — Raw stays nil; the caller fetches on demand.
+	case rec.Blobbed:
 		raw, err := s.blobs.Get(msg.ID)
 		if err != nil {
 			return Message{}, fmt.Errorf("inbound: load content %s: %w", msg.ID, err)
 		}
 		msg.Raw = raw
+	default:
+		// Legacy inline record — Raw is already inline on rec.Message.
 	}
 	return msg, nil
 }
 
-// storedFrom builds a blobbed metadata record from a full message: the raw bytes
-// are dropped (they live in the blob).
-func storedFrom(m Message) stored {
+// storedRec builds the on-disk record from a message: the raw bytes are dropped
+// (they live in a blob when blobbed; a pending record has none yet).
+func storedRec(m Message, blobbed bool) stored {
 	m.Raw = nil
-	return stored{Message: m, Blobbed: true}
+	return stored{Message: m, Blobbed: blobbed}
 }
 
 func loadStored(tx *bbolt.Tx, id string) (stored, []byte, error) {

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -45,6 +45,12 @@ type Message struct {
 	// Upstream coordinates (ADR 0019); zero for locally-generated messages.
 	UpstreamUID uint32 `json:"upstream_uid,omitempty"`
 	UIDValidity uint32 `json:"uid_validity,omitempty"`
+
+	// Pending means the headers are synced but the body/content has not been
+	// fetched yet (lazy sync, ADR 0019). Raw is empty until it is fetched on
+	// demand (Syncer.FetchContent → SetContent); callers must not treat a pending
+	// message's empty Raw as "no body".
+	Pending bool `json:"pending,omitempty"`
 }
 
 // InboundStore is the agent's served mailbox. Implementations are selected by
@@ -57,6 +63,13 @@ type InboundStore interface {
 	// already stored it is a no-op returning added=false; otherwise it is stored
 	// and added=true. The Delivery must carry non-zero upstream coordinates.
 	AddSynced(Delivery) (added bool, m Message, err error)
+	// AddSyncedPending stores a headers-only (Pending) record — metadata without
+	// content — for lazy sync (ADR 0019). Same idempotency as AddSynced; the
+	// Delivery's Raw is ignored. SetContent fills the body later.
+	AddSyncedPending(Delivery) (added bool, m Message, err error)
+	// SetContent fills a pending message's body (write the content blob, mark it
+	// present) and returns the now-complete message. Owner-scoped.
+	SetContent(owner, id string, raw []byte) (Message, error)
 	// List returns the owner's messages in receive order.
 	List(owner string) ([]Message, error)
 	// Get returns one of the owner's messages, or ErrNotFound.

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -54,6 +54,38 @@ func TestAddSyncedDedup(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPendingThenSetContent(t *testing.T) {
+	s := newStore(t)
+	added, m, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "hi", UpstreamUID: 7, UIDValidity: 1})
+	require.NoError(t, err)
+	assert.True(t, added)
+	assert.True(t, m.Pending)
+
+	// A pending record exposes its metadata but no content yet.
+	got, err := s.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.True(t, got.Pending)
+	assert.Empty(t, got.Raw)
+	assert.Equal(t, "hi", got.Subject)
+	list, err := s.List("agent")
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.True(t, list[0].Pending)
+	assert.Empty(t, list[0].Raw)
+
+	// SetContent fills the body and marks it present.
+	raw := []byte("Subject: hi\r\n\r\nbody")
+	filled, err := s.SetContent("agent", m.ID, raw)
+	require.NoError(t, err)
+	assert.False(t, filled.Pending)
+	assert.Equal(t, raw, filled.Raw)
+
+	got, err = s.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Pending)
+	assert.Equal(t, raw, got.Raw)
+}
+
 func TestAddListGet(t *testing.T) {
 	s := newStore(t)
 	m, err := s.Add(inbound.Delivery{


### PR DESCRIPTION
**Inc 3b-i** (ADR 0019): the additive foundation for lazy serving — the inbound store can hold a headers-only record and fill its body on demand. **ADDITIVE / zero behavior change**: sync still full-fetches (stores present records); the atomic flip to headers-only sync + per-FETCH read face is **3b-ii**.

## What
- `inbound.Message` gains **`Pending`**: a record is **present** (content in a blob), **pending** (headers synced, no content yet), or **legacy-inline**. `withRaw` returns `Raw=nil` for pending — the caller fetches on demand, it is **not** "no body".
- **`AddSyncedPending`** stores a headers-only pending record (same upstream-UID idempotency as `AddSynced`; no blob). **`SetContent`** fills a pending body (blob-first, then mark present) and returns the complete message.
- **`imapsync.Syncer.FetchContent(owner, id)`**: for a pending record, dial upstream, UID-FETCH its body by the stored `UpstreamUID`, `SetContent` it (present). A present message returns **as-is without contacting upstream** (fetch-once, then cached). Checks UIDVALIDITY and **errors cleanly** on a mailbox reset (stale UID) or a vanished message — never empty/wrong content.

## 3b-ii notes (named now, addressed there)
- Read-time upstream dependency: after the flip, a FETCH of a pending body dials upstream → can fail if upstream is down. `FetchContent` already returns a clean error for that (the read face will surface it as a transient IMAP error); present records + the existing 2019 never touch upstream.
- Concurrent FETCH of the same pending record → a per-record fetch-once guard in 3b-ii avoids the double upstream round-trip (the SetContent itself is idempotent/benign).

## Verification
build/vet/gofmt/`go test -race`/golangci-lint clean. Tests: pending → Get/List expose metadata with empty Raw → SetContent → present; `FetchContent` fills a pending body from an in-process upstream + is a no-op when present; stale UIDVALIDITY errors.

Inc 3b-ii next (the atomic flip): headers-only sync + per-FETCH read face.
