### PR TITLE
feat(inbound): headers-only sync + per-FETCH lazy read face (ADR 0019 Inc 3b-ii)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -148,39 +148,50 @@ func (c *CLI) openSender() (backend.Sender, error) {
 	})
 }
 
-// startInboundSync starts the upstream IMAP poll-sync loop (ADR 0019) if an
-// upstream is configured; otherwise it is a no-op, gated off by default like the
-// stub sender. It returns a stop func that closes the sync-state store. Sync
-// errors are logged, never fatal — a flaky or unreachable upstream must not take
-// down serve.
-func (cli *CLI) startInboundSync(ctx context.Context, inbox inbound.InboundStore) (func(), error) {
+// newSyncer builds the inbound sync engine (ADR 0019) if an upstream is
+// configured; otherwise returns nil (gated off by default like the stub sender).
+// The returned stop func closes the sync-state store.
+func (cli *CLI) newSyncer(inbox inbound.InboundStore) (*imapsync.Syncer, func(), error) {
 	if cli.InboundIMAPHost == "" {
-		fmt.Fprintln(os.Stderr, "darbaan: inbound sync disabled (no inbound-imap-host configured)")
-		return func() {}, nil
+		return nil, func() {}, nil
 	}
 	state, err := imapsync.NewStateStore(cli.InboundSyncDB)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	dial := imapsync.Dialer(cli.InboundIMAPHost, cli.InboundIMAPUsername, os.Getenv("DARBAAN_INBOUND_IMAP_PASSWORD"))
 	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbox, state)
+	return syncer, func() { _ = state.Close() }, nil
+}
 
-	go func() {
-		t := time.NewTicker(cli.InboundIMAPPollInterval)
-		defer t.Stop()
-		runSync(ctx, syncer) // initial pull at startup
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				runSync(ctx, syncer)
-			}
-		}
-	}()
+// imapContentFetch is the read face's on-demand content resolver: the syncer's
+// FetchContent when sync is on (serves a pending body by fetching upstream),
+// else nil — the read face then reads content from the store (no pending records
+// exist without sync).
+func imapContentFetch(syncer *imapsync.Syncer) listener.ContentFetch {
+	if syncer == nil {
+		return nil
+	}
+	return syncer.FetchContent
+}
+
+// runSyncLoop polls the upstream mailbox on the configured interval until ctx is
+// cancelled. Sync errors are logged, never fatal — a flaky or unreachable
+// upstream must not take down serve.
+func (cli *CLI) runSyncLoop(ctx context.Context, syncer *imapsync.Syncer) {
 	fmt.Fprintf(os.Stderr, "darbaan: inbound sync on %s (%s as %s) every %s\n",
 		cli.InboundIMAPHost, cli.InboundIMAPMailbox, cli.InboundIMAPUsername, cli.InboundIMAPPollInterval)
-	return func() { _ = state.Close() }, nil
+	t := time.NewTicker(cli.InboundIMAPPollInterval)
+	defer t.Stop()
+	runSync(ctx, syncer) // initial pull at startup
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			runSync(ctx, syncer)
+		}
+	}
 }
 
 func runSync(ctx context.Context, s *imapsync.Syncer) {
@@ -308,11 +319,20 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
+	// Inbound mailbox sync (ADR 0019) — built before the read face so its
+	// FetchContent serves pending bodies on demand. nil when no upstream is
+	// configured (the read face then reads content straight from the store).
+	syncer, stopSync, err := cli.newSyncer(inbox)
+	if err != nil {
+		return err
+	}
+	defer stopSync()
+
 	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, inbox)
+	}, cred, inbox, imapContentFetch(syncer))
 	if err != nil {
 		return err
 	}
@@ -320,13 +340,12 @@ func (*ServeCmd) Run(cli *CLI) error {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// Inbound mailbox sync (ADR 0019) — a no-op unless an upstream is configured.
-	// It shares the shutdown ctx; sync errors are logged, never fatal.
-	stopSync, err := cli.startInboundSync(ctx, inbox)
-	if err != nil {
-		return err
+	// Run the sync poll loop (shares the shutdown ctx; errors logged, never fatal).
+	if syncer != nil {
+		go cli.runSyncLoop(ctx, syncer)
+	} else {
+		fmt.Fprintln(os.Stderr, "darbaan: inbound sync disabled (no inbound-imap-host configured)")
 	}
-	defer stopSync()
 
 	closeAll := func() {
 		_ = smtpSrv.Close()

--- a/cmd/darbaan/sync_test.go
+++ b/cmd/darbaan/sync_test.go
@@ -1,18 +1,21 @@
 package main
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
-// Inbound sync is off by default: with no upstream host, startInboundSync is a
-// no-op (no state store opened, no goroutine) and never errors.
+// Inbound sync is off by default: with no upstream host, newSyncer returns a nil
+// syncer (no state store opened) and a no-op stop, and never errors. A nil
+// syncer makes imapContentFetch nil too (the read face reads straight from the
+// store).
 func TestInboundSyncDisabledByDefault(t *testing.T) {
 	cli := &CLI{} // InboundIMAPHost == ""
-	stop, err := cli.startInboundSync(context.Background(), nil)
+	syncer, stop, err := cli.newSyncer(nil)
 	require.NoError(t, err)
+	require.Nil(t, syncer)
 	require.NotNil(t, stop)
+	require.Nil(t, imapContentFetch(syncer))
 	stop() // no-op, must not panic
 }

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -121,9 +121,11 @@ func TestApprovePermanentFailureBounces(t *testing.T) {
 	msgs, err := inbox.List("agent")
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
-	assert.Contains(t, string(msgs[0].Raw), "upstream delivery failed permanently")
-	assert.NotContains(t, string(msgs[0].Raw), "mailbox unavailable") // never echo upstream body
-	assert.Contains(t, string(msgs[0].Raw), "DKIM-Signature:")
+	bounce, err := inbox.Get("agent", msgs[0].ID) // List is metadata-only; content via Get
+	require.NoError(t, err)
+	assert.Contains(t, string(bounce.Raw), "upstream delivery failed permanently")
+	assert.NotContains(t, string(bounce.Raw), "mailbox unavailable") // never echo upstream body
+	assert.Contains(t, string(bounce.Raw), "DKIM-Signature:")
 
 	got, _ := q.Get(id)
 	assert.Equal(t, sluice.StatusApproved, got.Status) // not sent
@@ -158,9 +160,11 @@ func TestRejectDeliversSignedBounce(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "MAILER-DAEMON@darbaan.test", msgs[0].From)
-	assert.Contains(t, string(msgs[0].Raw), "smells like exfiltration")
-	assert.Contains(t, string(msgs[0].Raw), "5.7.1")
-	assert.Contains(t, string(msgs[0].Raw), "DKIM-Signature:")
+	bounce, err := inbox.Get("agent", msgs[0].ID) // List is metadata-only; content via Get
+	require.NoError(t, err)
+	assert.Contains(t, string(bounce.Raw), "smells like exfiltration")
+	assert.Contains(t, string(bounce.Raw), "5.7.1")
+	assert.Contains(t, string(bounce.Raw), "DKIM-Signature:")
 }
 
 func TestRejectBounceFailureDistinct(t *testing.T) {

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -47,11 +47,12 @@ func Dialer(addr, username, password string) DialFunc {
 	}
 }
 
-// Sync runs one incremental pull: SELECT the mailbox, UID-FETCH everything newer
-// than the stored cursor, store each via inbound.Add (tiered), and advance the
-// cursor. A UIDVALIDITY change resets the cursor and re-syncs from scratch. The
-// upstream is read-only (no flag/delete write-back, v1). Returns the count
-// stored this run.
+// Sync runs one incremental pull: SELECT the mailbox, UID-FETCH the ENVELOPE of
+// everything newer than the stored cursor, store each headers-only (pending) via
+// inbound.AddSyncedPending, and advance the cursor. Bodies are fetched on demand
+// (FetchContent) when first read. A UIDVALIDITY change resets the cursor and
+// re-syncs from scratch. The upstream is read-only (no flag/delete write-back,
+// v1). Returns the count stored this run.
 func (s *Syncer) Sync(ctx context.Context) (int, error) {
 	c, err := s.dial()
 	if err != nil {
@@ -111,10 +112,11 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 		set.AddRange(imap.UID(last+1), 0) // fallback: dynamic "*"
 	}
 
+	// Headers-only: ENVELOPE (for the metadata) but no BODY[] — the body is
+	// fetched on demand when first read (lazy, ADR 0019).
 	cmd := c.Fetch(set, &imap.FetchOptions{
-		UID:         true,
-		Envelope:    true,
-		BodySection: []*imap.FetchItemBodySection{{}}, // whole message
+		UID:      true,
+		Envelope: true,
 	})
 
 	stored, highest := 0, last
@@ -135,9 +137,9 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 		d := deliveryOf(s.owner, m)
 		d.UpstreamUID = uid
 		d.UIDValidity = uidValidity
-		// AddSynced is idempotent on (owner, UIDVALIDITY, UID): a re-fetched
-		// message (e.g. after a crash) is a no-op (added=false).
-		added, _, err := s.store.AddSynced(d)
+		// Store headers-only (pending); the body is fetched on demand. Idempotent
+		// on (owner, UIDVALIDITY, UID): a re-fetched message is a no-op.
+		added, _, err := s.store.AddSyncedPending(d)
 		if err != nil {
 			_ = cmd.Close()
 			return stored, highest, fmt.Errorf("imapsync: store uid %d: %w", uid, err)

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -93,16 +93,23 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	msgs, err := store.List("agent")
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
+	// Headers-only sync: metadata from the envelope, bodies pending (lazy).
 	subjects := map[string]bool{msgs[0].Subject: true, msgs[1].Subject: true}
 	assert.True(t, subjects["one"] && subjects["two"], "subjects from envelope")
 	assert.Equal(t, "agent", msgs[0].Owner) // synced to the agent's mailbox
-	bodies := string(msgs[0].Raw) + string(msgs[1].Raw)
-	assert.Contains(t, bodies, "body one") // full raw round-trips
+	assert.True(t, msgs[0].Pending)
+	assert.Empty(t, msgs[0].Raw)
 
 	// Idempotent: a second sync with no new mail pulls nothing.
 	n, err = syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
+
+	// The body is fetched on demand.
+	filled, err := syncer.FetchContent("agent", msgs[0].ID)
+	require.NoError(t, err)
+	assert.False(t, filled.Pending)
+	assert.Contains(t, string(filled.Raw), "body")
 
 	// Only genuinely-new mail is pulled on the next cycle.
 	appendMsg(t, user, "From: carol@x.test\r\nSubject: three\r\n\r\nbody three")
@@ -130,6 +137,9 @@ func TestSyncStreamsManyMessages(t *testing.T) {
 	msgs, err := store.List("agent")
 	require.NoError(t, err)
 	assert.Len(t, msgs, n)
+	for _, m := range msgs {
+		assert.True(t, m.Pending) // headers-only
+	}
 
 	got, err = syncer.Sync(context.Background())
 	require.NoError(t, err)

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -28,15 +28,14 @@ func init() {
 }
 
 // stored is the bbolt record: message metadata plus the tiering flag. The raw
-// bytes live in a blob (Blobbed=true; Message.Raw is nil here), except for
-// legacy records written before ADR 0018, which have Blobbed=false and the raw
-// inline. Subject is already a stored field, so only the raw is reassembled.
+// bytes live in a blob (Blobbed=true; Message.Raw is nil here), except for legacy
+// records written before ADR 0018 (Blobbed=false, raw inline) and pending records
+// (Message.Pending=true, no content yet — ADR 0019). Subject is metadata.
 //
-// Unlike the sluice (whose List returns blob-free Meta), inbound's List returns
-// full Messages and reassembles Raw from blobs — the IMAP face snapshots the raw
-// at SELECT for FETCH/SEARCH. That eager read-time load is removed by the future
-// lazy-inbound-sync work (ADR 0018 names it as future); this change is the
-// storage tier only, keeping bbolt small regardless of mailbox size.
+// List returns metadata only (no blob reads): the IMAP read face snapshots
+// metadata at SELECT and fetches a message's content per-FETCH via Get / the
+// content fetcher (ADR 0019), so bbolt stays small and SELECT never reassembles
+// the whole mailbox.
 type stored struct {
 	Message
 	Blobbed bool `json:"blobbed,omitempty"`
@@ -268,15 +267,14 @@ func (s *bboltStore) List(owner string) ([]Message, error) {
 	if err != nil {
 		return nil, fmt.Errorf("inbound: list: %w", err)
 	}
-	// Reassemble each message's raw from its blob outside the txn, so file IO
-	// never holds the read transaction.
+	// Metadata only: List never loads content (no blob reads, no eager mailbox
+	// reassembly at SELECT). Callers fetch a message's body on demand via Get /
+	// the content fetcher (ADR 0019).
 	out := make([]Message, 0, len(recs))
 	for _, rec := range recs {
-		msg, err := s.withRaw(rec)
-		if err != nil {
-			return nil, fmt.Errorf("inbound: list: %w", err)
-		}
-		out = append(out, msg)
+		m := rec.Message
+		m.Raw = nil
+		out = append(out, m)
 	}
 	return out, nil
 }

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -70,9 +70,10 @@ type InboundStore interface {
 	// SetContent fills a pending message's body (write the content blob, mark it
 	// present) and returns the now-complete message. Owner-scoped.
 	SetContent(owner, id string, raw []byte) (Message, error)
-	// List returns the owner's messages in receive order.
+	// List returns the owner's messages' metadata (no content/Raw) in receive
+	// order; a body is fetched per-message via Get / the content fetcher.
 	List(owner string) ([]Message, error)
-	// Get returns one of the owner's messages, or ErrNotFound.
+	// Get returns one of the owner's messages with content, or ErrNotFound.
 	Get(owner, id string) (Message, error)
 	// SetSeen sets or clears the \Seen flag on the owner's message — the only
 	// mutable flag the v1 IMAP face persists. Owner-scoped like Get.

--- a/internal/inbound/tiering_internal_test.go
+++ b/internal/inbound/tiering_internal_test.go
@@ -43,10 +43,12 @@ func TestAddTiersContent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, m.Raw, got.Raw) // reassembled from the blob
 
+	// List is metadata-only (no blob reads): content comes per-FETCH via Get.
 	list, err := s.List("agent")
 	require.NoError(t, err)
 	require.Len(t, list, 1)
-	assert.Equal(t, m.Raw, list[0].Raw) // List reassembles (IMAP snapshot needs it)
+	assert.Equal(t, "bounce", list[0].Subject)
+	assert.Empty(t, list[0].Raw)
 }
 
 // sweepOrphans reclaims a blob with no metadata record but keeps a referenced one.
@@ -83,10 +85,13 @@ func TestLegacyInlineFallback(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, legacy.Raw, got.Raw) // inline raw, no blob read
 
+	// List is metadata-only now (content fetched per-FETCH): metadata present,
+	// Raw empty even for a legacy inline record.
 	list, err := s.List("agent")
 	require.NoError(t, err)
 	require.Len(t, list, 1)
-	assert.Equal(t, legacy.Raw, list[0].Raw)
+	assert.Equal(t, "old", list[0].Subject)
+	assert.Empty(t, list[0].Raw)
 
 	// SetSeen mutates metadata and keeps the inline raw readable.
 	require.NoError(t, s.SetSeen("agent", "1", true))

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -31,22 +31,33 @@ type IMAPServerConfig struct {
 	AllowInsecure bool        // permit AUTH over plaintext — local/testing only
 }
 
+// ContentFetch resolves a message's full content (Raw) on demand: for a present
+// record from its blob, for a pending record by fetching the body from upstream
+// (lazy, ADR 0019). It is called per-FETCH, never at SELECT.
+type ContentFetch func(owner, id string) (inbound.Message, error)
+
 // IMAPServer serves the agent's mailbox (the InboundStore) over IMAP as a
-// translation adapter (ADR 0016): the store is canonical, there is no upstream
-// IMAP proxy and no upstream fetch in v1.
+// translation adapter (ADR 0016): the store is canonical. SELECT snapshots
+// metadata only; a body FETCH resolves content per-message via a ContentFetch.
 type IMAPServer struct {
 	imap *imapserver.Server
 }
 
 // NewIMAPServer wires the IMAP read face. TLS is required unless AllowInsecure
-// is set (local/testing), mirroring the SMTP face.
-func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore) (*IMAPServer, error) {
+// is set (local/testing), mirroring the SMTP face. fetch resolves message
+// content on demand; if nil it defaults to reading straight from the store
+// (no upstream — bounce-only / sync-disabled deployments have no pending
+// records).
+func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
+	if fetch == nil {
+		fetch = func(owner, id string) (inbound.Message, error) { return store.Get(owner, id) }
+	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{cred: cred, store: store}, nil, nil
+			return &imapSession{cred: cred, store: store, fetch: fetch}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -69,9 +80,10 @@ func (s *IMAPServer) Close() error { return s.imap.Close() }
 type imapSession struct {
 	cred     Credential
 	store    inbound.InboundStore
+	fetch    ContentFetch // resolves message content on demand (per-FETCH)
 	owner    string
 	authed   bool
-	selected []inbound.Message // snapshot taken at Select
+	selected []inbound.Message // metadata snapshot taken at Select (no content)
 }
 
 func (s *imapSession) Close() error { return nil }
@@ -176,6 +188,7 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 		}
 	}
 
+	needRaw := fetchNeedsRaw(options)
 	var ferr error
 	s.forEach(numSet, func(seqNum uint32, m *inbound.Message) {
 		if ferr != nil {
@@ -188,9 +201,28 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 			}
 			m.Seen = true // also updates s.selected via the pointer
 		}
-		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options)
+		msg := *m
+		if needRaw {
+			// Resolve content on demand (blob, or upstream for a pending record).
+			// A failure surfaces as an IMAP error, never empty/wrong content.
+			full, err := s.fetch(s.owner, m.ID)
+			if err != nil {
+				ferr = err
+				return
+			}
+			full.Seen = m.Seen // keep the in-session flag state
+			msg = full
+		}
+		ferr = fetchMessage(w.CreateMessage(seqNum), msg, options)
 	})
 	return ferr
+}
+
+// fetchNeedsRaw reports whether any requested item requires the message body;
+// flags/UID/internal-date alone do not, so a metadata-only FETCH never triggers
+// an on-demand content fetch.
+func fetchNeedsRaw(o *imap.FetchOptions) bool {
+	return o.RFC822Size || o.Envelope || o.BodyStructure != nil || len(o.BodySection) > 0
 }
 
 func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, _ *imap.StoreOptions) error {
@@ -263,6 +295,7 @@ func (s *imapSession) Append(string, imap.LiteralReader, *imap.AppendOptions) (*
 // matching for HEADER/BODY/TEXT. (Returning an error here surfaces as a
 // NO [SERVERBUG] and breaks real clients — #53.)
 func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCriteria, _ *imap.SearchOptions) (*imap.SearchData, error) {
+	needRaw := searchNeedsRaw(criteria)
 	var (
 		data   imap.SearchData
 		seqSet imap.SeqSet
@@ -271,7 +304,18 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 	for i := range s.selected {
 		m := &s.selected[i]
 		seqNum := uint32(i) + 1
-		if !matchSearch(seqNum, m, criteria) {
+		cand := *m
+		if needRaw {
+			// Content-bearing criteria (size / header / body / text) need the
+			// body — resolve it on demand for this candidate.
+			full, err := s.fetch(s.owner, m.ID)
+			if err != nil {
+				return nil, err
+			}
+			full.Seen = m.Seen
+			cand = full
+		}
+		if !matchSearch(seqNum, &cand, criteria) {
 			continue
 		}
 		uid := uidOf(*m)
@@ -300,6 +344,26 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 		data.All = uidSet
 	}
 	return &data, nil
+}
+
+// searchNeedsRaw reports whether any criterion needs the message body (size /
+// header / body / text), recursing into NOT/OR — so a metadata-only search
+// (seq/uid/flags/date) never triggers an on-demand content fetch.
+func searchNeedsRaw(c *imap.SearchCriteria) bool {
+	if c.Larger != 0 || c.Smaller != 0 || len(c.Header) > 0 || len(c.Body) > 0 || len(c.Text) > 0 {
+		return true
+	}
+	for i := range c.Not {
+		if searchNeedsRaw(&c.Not[i]) {
+			return true
+		}
+	}
+	for _, or := range c.Or {
+		if searchNeedsRaw(&or[0]) || searchNeedsRaw(&or[1]) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchSearch(seqNum uint32, m *inbound.Message, c *imap.SearchCriteria) bool {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -31,15 +31,64 @@ func seedInbound(t *testing.T) inbound.InboundStore {
 }
 
 func startIMAP(t *testing.T, store inbound.InboundStore) string {
+	return startIMAPWithFetch(t, store, nil)
+}
+
+func startIMAPWithFetch(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store)
+		listener.Credential{Username: "agent", Password: "pw"}, store, fetch)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
 	return l.Addr().String()
+}
+
+// A body FETCH of a pending (headers-only) record resolves its content on demand
+// via the ContentFetch; a flags-only FETCH does not touch the fetcher.
+func TestIMAPFetchResolvesPendingOnDemand(t *testing.T) {
+	store := seedInbound(t) // present bounce at seq 1
+	_, m, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "lazy", UpstreamUID: 5, UIDValidity: 1,
+	})
+	require.NoError(t, err) // pending record at seq 2
+
+	var fetchCalls int
+	fetch := func(owner, id string) (inbound.Message, error) {
+		fetchCalls++
+		if id == m.ID { // simulate the on-demand upstream fill
+			return store.SetContent(owner, id, []byte("Subject: lazy\r\n\r\nlazy-body"))
+		}
+		return store.Get(owner, id)
+	}
+
+	c, err := imapclient.DialInsecure(startIMAPWithFetch(t, store, fetch), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	// Flags-only FETCH: no content needed → fetcher untouched.
+	_, err = c.Fetch(imap.SeqSetNum(1, 2), &imap.FetchOptions{UID: true, Flags: true}).Collect()
+	require.NoError(t, err)
+	assert.Equal(t, 0, fetchCalls, "flags-only fetch must not resolve content")
+
+	// BODY[] FETCH of the pending record resolves it on demand.
+	msgs, err := c.Fetch(imap.SeqSetNum(2), &imap.FetchOptions{
+		UID:         true,
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, string(msgs[0].FindBodySection(&imap.FetchItemBodySection{})), "lazy-body")
+	assert.GreaterOrEqual(t, fetchCalls, 1)
+
+	got, err := store.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Pending) // cached present after the on-demand fetch
 }
 
 func TestIMAPFetchMarksSeenAndPersists(t *testing.T) {
@@ -165,6 +214,6 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t))
+		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil)
 	require.Error(t, err)
 }


### PR DESCRIPTION
**Inc 3b-ii** (ADR 0019): the atomic flip to lazy — sync stores headers only, and the IMAP read face fetches a body on demand instead of reassembling the mailbox at SELECT. Built on 3b-i's present/pending + `FetchContent`. **One PR** so there is never a window where a pending record has no body and nothing to fetch it.

## What
- **Sync** UID-FETCHes the **ENVELOPE only** (no `BODY[]`) → `AddSyncedPending`. Synced records are pending until first read.
- **`inbound.List` → metadata only** (no blob reads, no eager reassembly); a body is resolved per-message via `Get` / the content fetcher.
- **Read face**: SELECT snapshots metadata; `Fetch` resolves content per message via a new **`ContentFetch`** ONLY when the request needs the body (RFC822Size / Envelope / BodyStructure / BodySection) — a **flags/UID-only FETCH never triggers a fetch**. `Search` resolves only for content-bearing criteria (size/header/body/text, recursing NOT/OR). **The metadata snapshot stays stable across a FETCH sequence** — seq numbers/UIDs don't shift when a body is filled mid-session.
- **serve** builds the syncer before the read face and wires `syncer.FetchContent` as the `ContentFetch`; with sync off it is nil and the read face reads straight from the store (bounce-only deploys have no pending records).

## The two notes
- **Read-time upstream dependency**: a pending body FETCH dials upstream and can fail if upstream is down; `FetchContent` returns a clean error (UIDVALIDITY-checked, upstream-gone-checked) so it surfaces as a **transient IMAP error, never empty/wrong content**. Cached as a present blob once fetched; present + pre-lazy records never touch upstream.
- **Concurrent FETCH of the same pending record**: `SetContent` is idempotent (same id, same content), so a double fetch is **benign** — only a redundant upstream round-trip. A per-record fetch-once guard is a **deferred optimization**, not needed for correctness (leaning on the idempotency).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: read face resolves a pending body on demand + caches it present, while a flags-only FETCH leaves the fetcher untouched; sync stores pending records whose bodies fill via `FetchContent`; List/legacy/tiered assertions updated for metadata-only List; bounce-flow reads content via `Get`.

Live verify (yours): fresh mail → sync ENVELOPE-only (pending) → FETCH body over the read face → on-demand `FetchContent` → present → reads correct; an old (present) message still reads without upstream contact. This closes the inbound-sync lazy arc; the filter (ADR 0008) is the next chunk.
