### PR TITLE
feat(inbound): serve ENVELOPE/RFC822Size/header-search from stored metadata (ADR 0019 Inc 3b-iii)

### DIFF
--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -112,11 +112,13 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 		set.AddRange(imap.UID(last+1), 0) // fallback: dynamic "*"
 	}
 
-	// Headers-only: ENVELOPE (for the metadata) but no BODY[] — the body is
-	// fetched on demand when first read (lazy, ADR 0019).
+	// Headers-only: ENVELOPE + RFC822.SIZE (stored as metadata so the read face
+	// serves FETCH ENVELOPE / RFC822Size / header SEARCH without the body) but no
+	// BODY[] — the body is fetched on demand when first read (lazy, ADR 0019).
 	cmd := c.Fetch(set, &imap.FetchOptions{
-		UID:      true,
-		Envelope: true,
+		UID:        true,
+		Envelope:   true,
+		RFC822Size: true,
 	})
 
 	stored, highest := 0, last
@@ -219,13 +221,42 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 }
 
 func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {
-	d := inbound.Delivery{Owner: owner, Raw: rawBody(m)}
+	d := inbound.Delivery{Owner: owner, Raw: rawBody(m), Size: m.RFC822Size}
 	if m.Envelope != nil {
 		d.Subject = m.Envelope.Subject
 		d.From = firstAddr(m.Envelope.From)
 		d.To = joinAddrs(m.Envelope.To)
+		d.Envelope = mapEnvelope(m.Envelope)
 	}
 	return d
+}
+
+// mapEnvelope mirrors an IMAP envelope into the store's IMAP-free Envelope so the
+// read face can serve FETCH ENVELOPE / header SEARCH from metadata.
+func mapEnvelope(e *imap.Envelope) *inbound.Envelope {
+	return &inbound.Envelope{
+		Date:      e.Date,
+		Subject:   e.Subject,
+		From:      mapAddrs(e.From),
+		Sender:    mapAddrs(e.Sender),
+		ReplyTo:   mapAddrs(e.ReplyTo),
+		To:        mapAddrs(e.To),
+		Cc:        mapAddrs(e.Cc),
+		Bcc:       mapAddrs(e.Bcc),
+		InReplyTo: e.InReplyTo,
+		MessageID: e.MessageID,
+	}
+}
+
+func mapAddrs(as []imap.Address) []inbound.Address {
+	if len(as) == 0 {
+		return nil
+	}
+	out := make([]inbound.Address, len(as))
+	for i, a := range as {
+		out[i] = inbound.Address{Name: a.Name, Mailbox: a.Mailbox, Host: a.Host}
+	}
+	return out
 }
 
 func rawBody(m *imapclient.FetchMessageBuffer) []byte {

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -99,6 +99,11 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	assert.Equal(t, "agent", msgs[0].Owner) // synced to the agent's mailbox
 	assert.True(t, msgs[0].Pending)
 	assert.Empty(t, msgs[0].Raw)
+	// Envelope + size are stored as metadata (served by the read face without the
+	// body): the envelope subject matches and the size is non-zero.
+	require.NotNil(t, msgs[0].Envelope)
+	assert.True(t, subjects[msgs[0].Envelope.Subject], "envelope subject stored")
+	assert.Positive(t, msgs[0].Size)
 
 	// Idempotent: a second sync with no new mail pulls nothing.
 	n, err = syncer.Sync(context.Background())

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -222,6 +222,8 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byt
 		UpstreamUID: d.UpstreamUID,
 		UIDValidity: d.UIDValidity,
 		Pending:     pending,
+		Envelope:    d.Envelope,
+		Size:        d.Size,
 	}
 	key := seqkey.Encode(seq)
 	blobbed := false

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -16,6 +16,33 @@ import (
 // ErrNotFound is returned by Get when no message matches.
 var ErrNotFound = errors.New("inbound: message not found")
 
+// Address is one parsed envelope address. It mirrors the IMAP envelope address
+// (name + mailbox@host) without importing the IMAP library, keeping the store
+// IMAP-type-free (ADR 0016).
+type Address struct {
+	Name    string `json:"name,omitempty"`
+	Mailbox string `json:"mailbox,omitempty"`
+	Host    string `json:"host,omitempty"`
+}
+
+// Envelope is the parsed message envelope (RFC 3501 §7.4.2), stored as metadata
+// so the IMAP read face can serve FETCH ENVELOPE and header SEARCH from the store
+// without fetching the body (lazy, ADR 0019). nil for records synced before the
+// envelope was stored and for some locally-generated messages — callers fall
+// back to parsing the raw for those.
+type Envelope struct {
+	Date      time.Time `json:"date,omitempty"`
+	Subject   string    `json:"subject,omitempty"`
+	From      []Address `json:"from,omitempty"`
+	Sender    []Address `json:"sender,omitempty"`
+	ReplyTo   []Address `json:"reply_to,omitempty"`
+	To        []Address `json:"to,omitempty"`
+	Cc        []Address `json:"cc,omitempty"`
+	Bcc       []Address `json:"bcc,omitempty"`
+	InReplyTo []string  `json:"in_reply_to,omitempty"`
+	MessageID string    `json:"message_id,omitempty"`
+}
+
 // Delivery is a new inbound message to store.
 type Delivery struct {
 	Owner   string // the agent whose mailbox this is (whose send was rejected)
@@ -29,6 +56,13 @@ type Delivery struct {
 	// dedup an idempotent re-sync and (later) to fetch content on demand.
 	UpstreamUID uint32
 	UIDValidity uint32
+
+	// Envelope + Size are stored metadata so the IMAP read face serves FETCH
+	// ENVELOPE / RFC822Size / header SEARCH without the body (ADR 0019). Envelope
+	// is nil and Size 0 for locally-generated deliveries; the read face falls back
+	// to the raw for those.
+	Envelope *Envelope
+	Size     int64
 }
 
 // Message is a stored inbound message.
@@ -51,6 +85,14 @@ type Message struct {
 	// demand (Syncer.FetchContent → SetContent); callers must not treat a pending
 	// message's empty Raw as "no body".
 	Pending bool `json:"pending,omitempty"`
+
+	// Envelope + Size are stored metadata for the IMAP read face: FETCH ENVELOPE,
+	// RFC822Size, and header SEARCH (Subject/From/To/Date) serve from these
+	// without the body. Envelope is nil / Size 0 for records stored before the
+	// envelope was captured (pre-#93 syncs, bounces); the read face then derives
+	// from the raw.
+	Envelope *Envelope `json:"envelope,omitempty"`
+	Size     int64     `json:"size,omitempty"`
 }
 
 // InboundStore is the agent's served mailbox. Implementations are selected by

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -6,8 +6,10 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/emersion/go-imap/v2"
@@ -188,7 +190,6 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 		}
 	}
 
-	needRaw := fetchNeedsRaw(options)
 	var ferr error
 	s.forEach(numSet, func(seqNum uint32, m *inbound.Message) {
 		if ferr != nil {
@@ -201,28 +202,39 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 			}
 			m.Seen = true // also updates s.selected via the pointer
 		}
-		msg := *m
-		if needRaw {
-			// Resolve content on demand (blob, or upstream for a pending record).
-			// A failure surfaces as an IMAP error, never empty/wrong content.
-			full, err := s.fetch(s.owner, m.ID)
-			if err != nil {
-				ferr = err
-				return
-			}
-			full.Seen = m.Seen // keep the in-session flag state
-			msg = full
-		}
-		ferr = fetchMessage(w.CreateMessage(seqNum), msg, options)
+		// fetchMessage resolves content lazily: ENVELOPE / RFC822Size / header
+		// fields serve from stored metadata when present, and only a body request
+		// (or a record with no stored metadata) triggers getRaw. A resolve failure
+		// surfaces as an IMAP error, never empty/wrong content.
+		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options, s.rawResolver(*m))
 	})
 	return ferr
 }
 
-// fetchNeedsRaw reports whether any requested item requires the message body;
-// flags/UID/internal-date alone do not, so a metadata-only FETCH never triggers
-// an on-demand content fetch.
-func fetchNeedsRaw(o *imap.FetchOptions) bool {
-	return o.RFC822Size || o.Envelope || o.BodyStructure != nil || len(o.BodySection) > 0
+// rawFunc lazily resolves a message's raw content.
+type rawFunc func() ([]byte, error)
+
+// rawResolver returns a memoized resolver for a message's raw content: it calls
+// the content fetcher at most once, and only when a field actually needs the body
+// (BodyStructure/BodySection, or ENVELOPE/size/header on a record with no stored
+// metadata). Present records resolve from a local blob; a pending record fetches
+// upstream once, then is cached present.
+func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
+	var (
+		raw  []byte
+		err  error
+		done bool
+	)
+	return func() ([]byte, error) {
+		if !done {
+			done = true
+			var full inbound.Message
+			if full, err = s.fetch(s.owner, m.ID); err == nil {
+				raw = full.Raw
+			}
+		}
+		return raw, err
+	}
 }
 
 func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, _ *imap.StoreOptions) error {
@@ -295,7 +307,6 @@ func (s *imapSession) Append(string, imap.LiteralReader, *imap.AppendOptions) (*
 // matching for HEADER/BODY/TEXT. (Returning an error here surfaces as a
 // NO [SERVERBUG] and breaks real clients — #53.)
 func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCriteria, _ *imap.SearchOptions) (*imap.SearchData, error) {
-	needRaw := searchNeedsRaw(criteria)
 	var (
 		data   imap.SearchData
 		seqSet imap.SeqSet
@@ -304,18 +315,16 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 	for i := range s.selected {
 		m := &s.selected[i]
 		seqNum := uint32(i) + 1
-		cand := *m
-		if needRaw {
-			// Content-bearing criteria (size / header / body / text) need the
-			// body — resolve it on demand for this candidate.
-			full, err := s.fetch(s.owner, m.ID)
-			if err != nil {
-				return nil, err
-			}
-			full.Seen = m.Seen
-			cand = full
+		// matchSearch resolves content lazily and only for content-bearing
+		// criteria on records without stored metadata. If a candidate's content
+		// can't be resolved, skip it (degrade, don't [SERVERBUG] the whole SEARCH)
+		// — but log it: a skipped candidate is a silently-missing result.
+		ok, err := matchSearch(seqNum, m, criteria, s.rawResolver(*m))
+		if err != nil {
+			log.Printf("darbaan: imap search skipped message %s: %v", m.ID, err)
+			continue
 		}
-		if !matchSearch(seqNum, &cand, criteria) {
+		if !ok {
 			continue
 		}
 		uid := uidOf(*m)
@@ -346,89 +355,181 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 	return &data, nil
 }
 
-// searchNeedsRaw reports whether any criterion needs the message body (size /
-// header / body / text), recursing into NOT/OR — so a metadata-only search
-// (seq/uid/flags/date) never triggers an on-demand content fetch.
-func searchNeedsRaw(c *imap.SearchCriteria) bool {
-	if c.Larger != 0 || c.Smaller != 0 || len(c.Header) > 0 || len(c.Body) > 0 || len(c.Text) > 0 {
-		return true
-	}
-	for i := range c.Not {
-		if searchNeedsRaw(&c.Not[i]) {
-			return true
-		}
-	}
-	for _, or := range c.Or {
-		if searchNeedsRaw(&or[0]) || searchNeedsRaw(&or[1]) {
-			return true
-		}
-	}
-	return false
-}
-
-func matchSearch(seqNum uint32, m *inbound.Message, c *imap.SearchCriteria) bool {
+// matchSearch reports whether a message matches the criteria. Metadata criteria
+// (seq/uid/flags/date) and stored-metadata criteria (size, and Subject/From/To/
+// Date/... headers when the envelope is stored) match without the body; only
+// BODY/TEXT and headers on records with no stored envelope call getRaw. An error
+// means the content couldn't be resolved (caller skips + logs the candidate).
+func matchSearch(seqNum uint32, m *inbound.Message, c *imap.SearchCriteria, getRaw rawFunc) (bool, error) {
 	for _, set := range c.SeqNum {
 		if !set.Contains(seqNum) {
-			return false
+			return false, nil
 		}
 	}
 	for _, set := range c.UID {
 		if !set.Contains(uidOf(*m)) {
-			return false
+			return false, nil
 		}
 	}
 	if !matchDate(m.ReceivedAt, c.Since, c.Before) {
-		return false
+		return false, nil
 	}
 	for _, f := range c.Flag {
 		if !hasFlag(m, f) {
-			return false
+			return false, nil
 		}
 	}
 	for _, f := range c.NotFlag {
 		if hasFlag(m, f) {
-			return false
+			return false, nil
 		}
 	}
-	if c.Larger != 0 && int64(len(m.Raw)) <= c.Larger {
-		return false
-	}
-	if c.Smaller != 0 && int64(len(m.Raw)) >= c.Smaller {
-		return false
-	}
-	// Only lower-case the (potentially large) raw message when a content
-	// criterion actually needs it — the common SEARCH (ALL / flags / seq) skips
-	// this allocation entirely (#56).
-	if len(c.Header) > 0 || len(c.Text) > 0 || len(c.Body) > 0 {
-		low := bytes.ToLower(m.Raw)
-		for _, h := range c.Header {
-			if !bytes.Contains(low, bytes.ToLower([]byte(h.Key))) ||
-				(h.Value != "" && !bytes.Contains(low, bytes.ToLower([]byte(h.Value)))) {
-				return false
-			}
+	if c.Larger != 0 || c.Smaller != 0 {
+		size, err := sizeOf(m, getRaw)
+		if err != nil {
+			return false, err
 		}
+		if c.Larger != 0 && size <= c.Larger {
+			return false, nil
+		}
+		if c.Smaller != 0 && size >= c.Smaller {
+			return false, nil
+		}
+	}
+	for _, h := range c.Header {
+		ok, err := matchHeader(m, h, getRaw)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+	if len(c.Text) > 0 || len(c.Body) > 0 {
+		raw, err := getRaw()
+		if err != nil {
+			return false, err
+		}
+		low := bytes.ToLower(raw)
 		for _, t := range c.Text {
 			if !bytes.Contains(low, bytes.ToLower([]byte(t))) {
-				return false
+				return false, nil
 			}
 		}
 		for _, b := range c.Body {
 			if !bytes.Contains(low, bytes.ToLower([]byte(b))) {
-				return false
+				return false, nil
 			}
 		}
 	}
 	for i := range c.Not {
-		if matchSearch(seqNum, m, &c.Not[i]) {
-			return false
+		ok, err := matchSearch(seqNum, m, &c.Not[i], getRaw)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return false, nil
 		}
 	}
 	for _, or := range c.Or {
-		if !matchSearch(seqNum, m, &or[0]) && !matchSearch(seqNum, m, &or[1]) {
-			return false
+		a, err := matchSearch(seqNum, m, &or[0], getRaw)
+		if err != nil {
+			return false, err
+		}
+		b := false
+		if !a {
+			if b, err = matchSearch(seqNum, m, &or[1], getRaw); err != nil {
+				return false, err
+			}
+		}
+		if !a && !b {
+			return false, nil
 		}
 	}
-	return true
+	return true, nil
+}
+
+// sizeOf returns the message size from stored metadata, falling back to the raw
+// length for records synced before the size was stored.
+func sizeOf(m *inbound.Message, getRaw rawFunc) (int64, error) {
+	if m.Size > 0 {
+		return m.Size, nil
+	}
+	raw, err := getRaw()
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(raw)), nil
+}
+
+// matchHeader matches one SEARCH HEADER criterion. Stored-envelope headers
+// (Subject/From/To/Cc/Bcc/Sender/Reply-To/Date/Message-Id/In-Reply-To) match
+// against the stored envelope (no body fetch); any other header — or a record
+// with no stored envelope — falls back to a substring match over the raw.
+func matchHeader(m *inbound.Message, h imap.SearchCriteriaHeaderField, getRaw rawFunc) (bool, error) {
+	if m.Envelope != nil {
+		if v, ok := envelopeHeader(m.Envelope, h.Key); ok {
+			if h.Value == "" {
+				return v != "", nil // header-present check
+			}
+			return strings.Contains(strings.ToLower(v), strings.ToLower(h.Value)), nil
+		}
+	}
+	raw, err := getRaw()
+	if err != nil {
+		return false, err
+	}
+	low := bytes.ToLower(raw)
+	if !bytes.Contains(low, bytes.ToLower([]byte(h.Key))) {
+		return false, nil
+	}
+	return h.Value == "" || bytes.Contains(low, bytes.ToLower([]byte(h.Value))), nil
+}
+
+// envelopeHeader renders a stored-envelope field for substring matching, or
+// ok=false for a header not carried by the envelope (match via raw instead).
+func envelopeHeader(e *inbound.Envelope, key string) (string, bool) {
+	switch strings.ToLower(key) {
+	case "subject":
+		return e.Subject, true
+	case "from":
+		return formatAddrs(e.From), true
+	case "sender":
+		return formatAddrs(e.Sender), true
+	case "reply-to":
+		return formatAddrs(e.ReplyTo), true
+	case "to":
+		return formatAddrs(e.To), true
+	case "cc":
+		return formatAddrs(e.Cc), true
+	case "bcc":
+		return formatAddrs(e.Bcc), true
+	case "message-id":
+		return e.MessageID, true
+	case "in-reply-to":
+		return strings.Join(e.InReplyTo, " "), true
+	case "date":
+		if e.Date.IsZero() {
+			return "", true
+		}
+		return e.Date.Format(time.RFC1123Z), true
+	}
+	return "", false
+}
+
+func formatAddrs(as []inbound.Address) string {
+	if len(as) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(as))
+	for _, a := range as {
+		addr := a.Mailbox + "@" + a.Host
+		if a.Name != "" {
+			addr = a.Name + " <" + addr + ">"
+		}
+		parts = append(parts, addr)
+	}
+	return strings.Join(parts, ", ")
 }
 
 // hasFlag reports whether the message has an IMAP flag. v1 persists only \Seen.
@@ -462,7 +563,7 @@ func (s *imapSession) Idle(_ *imapserver.UpdateWriter, stop <-chan struct{}) err
 	return nil
 }
 
-func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions) error {
+func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions, getRaw rawFunc) error {
 	w.WriteUID(uidOf(m))
 	if options.Flags {
 		w.WriteFlags(flagList(m))
@@ -471,18 +572,34 @@ func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options 
 		w.WriteInternalDate(m.ReceivedAt)
 	}
 	if options.RFC822Size {
-		w.WriteRFC822Size(int64(len(m.Raw)))
+		size, err := sizeOf(&m, getRaw)
+		if err != nil {
+			return err
+		}
+		w.WriteRFC822Size(size)
 	}
 	if options.Envelope {
-		if h, err := textproto.ReadHeader(bufio.NewReader(bytes.NewReader(m.Raw))); err == nil {
-			w.WriteEnvelope(imapserver.ExtractEnvelope(h))
+		env, err := envelopeFor(m, getRaw)
+		if err != nil {
+			return err
+		}
+		if env != nil {
+			w.WriteEnvelope(env)
 		}
 	}
 	if options.BodyStructure != nil {
-		w.WriteBodyStructure(imapserver.ExtractBodyStructure(bytes.NewReader(m.Raw)))
+		raw, err := getRaw()
+		if err != nil {
+			return err
+		}
+		w.WriteBodyStructure(imapserver.ExtractBodyStructure(bytes.NewReader(raw)))
 	}
 	for _, bs := range options.BodySection {
-		buf := imapserver.ExtractBodySection(bytes.NewReader(m.Raw), bs)
+		raw, err := getRaw()
+		if err != nil {
+			return err
+		}
+		buf := imapserver.ExtractBodySection(bytes.NewReader(raw), bs)
 		wc := w.WriteBodySection(bs, int64(len(buf)))
 		_, writeErr := wc.Write(buf)
 		closeErr := wc.Close()
@@ -494,6 +611,50 @@ func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options 
 		}
 	}
 	return w.Close()
+}
+
+// envelopeFor returns the IMAP envelope from stored metadata when present, else
+// parses it from the (lazily-resolved) raw — for records synced before the
+// envelope was stored, and for locally-generated messages.
+func envelopeFor(m inbound.Message, getRaw rawFunc) (*imap.Envelope, error) {
+	if m.Envelope != nil {
+		return toIMAPEnvelope(m.Envelope), nil
+	}
+	raw, err := getRaw()
+	if err != nil {
+		return nil, err
+	}
+	h, err := textproto.ReadHeader(bufio.NewReader(bytes.NewReader(raw)))
+	if err != nil {
+		return nil, nil // unparseable header: omit the envelope (prior behavior)
+	}
+	return imapserver.ExtractEnvelope(h), nil
+}
+
+func toIMAPEnvelope(e *inbound.Envelope) *imap.Envelope {
+	return &imap.Envelope{
+		Date:      e.Date,
+		Subject:   e.Subject,
+		From:      toIMAPAddrs(e.From),
+		Sender:    toIMAPAddrs(e.Sender),
+		ReplyTo:   toIMAPAddrs(e.ReplyTo),
+		To:        toIMAPAddrs(e.To),
+		Cc:        toIMAPAddrs(e.Cc),
+		Bcc:       toIMAPAddrs(e.Bcc),
+		InReplyTo: e.InReplyTo,
+		MessageID: e.MessageID,
+	}
+}
+
+func toIMAPAddrs(as []inbound.Address) []imap.Address {
+	if len(as) == 0 {
+		return nil
+	}
+	out := make([]imap.Address, len(as))
+	for i, a := range as {
+		out[i] = imap.Address{Name: a.Name, Mailbox: a.Mailbox, Host: a.Host}
+	}
+	return out
 }
 
 func flagList(m inbound.Message) []imap.Flag {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -205,6 +205,82 @@ func TestIMAPSearch(t *testing.T) {
 	assert.Equal(t, []imap.UID{1}, uids.AllUIDs())
 }
 
+// A record with a stored envelope serves FETCH ENVELOPE + RFC822Size and SUBJECT
+// SEARCH from metadata, touching no body; only a body FETCH resolves content.
+// (Fully-lazy listing + the #92 SUBJECT-search [SERVERBUG] regression fix, #93.)
+func TestIMAPEnvelopeAndHeaderSearchFromMetadata(t *testing.T) {
+	// A fresh store holding ONLY an envelope-carrying synced record (seq 1) — so
+	// no envelope-less record forces a raw fallback and muddies the fetch count.
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "Quarterly report", UpstreamUID: 5, UIDValidity: 1,
+		Size: 4096,
+		Envelope: &inbound.Envelope{
+			Subject: "Quarterly report",
+			From:    []inbound.Address{{Name: "Alice", Mailbox: "alice", Host: "x.test"}},
+		},
+	})
+	require.NoError(t, err)
+
+	var fetchCalls int
+	fetch := func(owner, id string) (inbound.Message, error) {
+		fetchCalls++
+		return store.Get(owner, id)
+	}
+	c, err := imapclient.DialInsecure(startIMAPWithFetch(t, store, fetch), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	// FETCH ENVELOPE + RFC822Size → served from metadata.
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		UID: true, Envelope: true, RFC822Size: true,
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.NotNil(t, msgs[0].Envelope)
+	assert.Equal(t, "Quarterly report", msgs[0].Envelope.Subject)
+	assert.Equal(t, int64(4096), msgs[0].RFC822Size)
+	assert.Equal(t, 0, fetchCalls, "ENVELOPE/size served from metadata, no body fetch")
+
+	// SUBJECT SEARCH → matches from metadata, no body fetch (was [SERVERBUG]).
+	res, err := c.Search(&imap.SearchCriteria{
+		Header: []imap.SearchCriteriaHeaderField{{Key: "Subject", Value: "quarterly"}},
+	}, nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{1}, res.AllSeqNums())
+	assert.Equal(t, 0, fetchCalls, "SUBJECT search served from metadata, no body fetch")
+
+	// A body FETCH does resolve content.
+	_, err = c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, fetchCalls, 1)
+}
+
+// A SUBJECT search over an envelope-less record (legacy/bounce) falls back to the
+// raw header block — still works (and the bounce's subject is matchable).
+func TestIMAPHeaderSearchFallsBackToRaw(t *testing.T) {
+	store := seedInbound(t) // present bounce, no stored envelope, subject "Undelivered..."
+	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	res, err := c.Search(&imap.SearchCriteria{
+		Header: []imap.SearchCriteriaHeaderField{{Key: "Subject", Value: "Undelivered"}},
+	}, nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, []uint32{1}, res.AllSeqNums())
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**Inc 3b-iii** (ADR 0019, closes #93): completes the lazy goal — **listing the inbox fetches zero bodies** — and **fixes the SUBJECT-search `[SERVERBUG]` regression** from the lazy flip (#92).

The store now keeps the parsed envelope + RFC822 size as metadata, so the read face answers FETCH ENVELOPE, RFC822Size, and header SEARCH from the store and touches the body only for an actual body request.

## What
- `inbound.Message`/`Delivery` gain **`Envelope`** (an IMAP-free mirror struct) + **`Size`**; `put()` persists them. nil/0 for records stored before this (pre-#93 syncs, bounces) — read face falls back to the raw for those.
- **imapsync** requests `ENVELOPE` + `RFC822.SIZE` (no body) and stores both via `AddSyncedPending`.
- **Read face**: content resolved **per-field, per-message** via a memoized lazy resolver (replacing the global per-options `needRaw` flag, which could not express "this record has no stored envelope"). ENVELOPE/RFC822Size/header-search serve from metadata when present; only `BodyStructure`/`BodySection` — or a record with no stored metadata — call the resolver. An envelope-carrying record touches **zero** bodies for listing/search; an envelope-less record (legacy/bounce, all present) falls back to a cheap **local blob** read.

## Regression fix (#92 SUBJECT search)
A header SEARCH on an envelope-carrying record matches from metadata (no per-candidate body fetch, no crash); on an envelope-less record it matches via the raw fallback. SEARCH **degrades rather than `[SERVERBUG]`ing** — a candidate whose content can't be resolved is skipped **and logged** (id + reason), never a silently-missing result.

## Why per-field/per-message (not a global flag)
The box is heterogeneous: ~2019 records synced before this + bounces have no stored envelope. A global per-options flag can't say "fall back to raw for this record only." Per-message nails it: new synced records serve metadata (no body); the envelope-less set reads a local blob (no upstream, no crash).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: envelope-carrying record serves ENVELOPE + RFC822Size + SUBJECT search from metadata with **zero** body fetches, then a body FETCH resolves; envelope-less record SUBJECT search falls back to raw and still matches; sync stores envelope+size; pending on-demand body resolve still works.

Live verify (yours): SUBJECT search that crashed now returns clean; an ENVELOPE/size listing pulls no bodies; an old/present message still reads. Then the inbound filter (ADR 0008).
