### PR TITLE
feat(imapsync): inbound-max-age recency cutoff via SEARCH SINCE (ADR 0008)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
+	"strings"
 	"syscall"
 	"text/tabwriter"
 	"time"
@@ -79,6 +81,7 @@ type CLI struct {
 	InboundIMAPMailbox      string        `name:"inbound-imap-mailbox" default:"INBOX" help:"Upstream mailbox to sync."`
 	InboundIMAPPollInterval time.Duration `name:"inbound-imap-poll-interval" default:"60s" help:"How often to poll the upstream mailbox for new mail."`
 	InboundSyncDB           string        `name:"inbound-sync-db" default:"darbaan-sync.db" help:"Path to the inbound sync-state (UIDVALIDITY + last UID) database." type:"path"`
+	InboundMaxAge           string        `name:"inbound-max-age" help:"Recency cutoff for the initial/full sync, e.g. 1y, 30d, 12h (ADR 0008). Empty = no cutoff (pull everything). Forward-only: widening it later needs a re-sync."`
 
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
@@ -155,13 +158,43 @@ func (cli *CLI) newSyncer(inbox inbound.InboundStore) (*imapsync.Syncer, func(),
 	if cli.InboundIMAPHost == "" {
 		return nil, func() {}, nil
 	}
+	maxAge, err := parseMaxAge(cli.InboundMaxAge)
+	if err != nil {
+		return nil, nil, fmt.Errorf("inbound-max-age: %w", err)
+	}
 	state, err := imapsync.NewStateStore(cli.InboundSyncDB)
 	if err != nil {
 		return nil, nil, err
 	}
 	dial := imapsync.Dialer(cli.InboundIMAPHost, cli.InboundIMAPUsername, os.Getenv("DARBAAN_INBOUND_IMAP_PASSWORD"))
-	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbox, state)
+	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbox, state, maxAge)
 	return syncer, func() { _ = state.Close() }, nil
+}
+
+// parseMaxAge parses the recency-cutoff duration: time.ParseDuration units
+// (h/m/s) plus the calendar-ish d/w/y suffixes it lacks (kong/ParseDuration would
+// reject "1y"). Empty or "0" means no cutoff. y is treated as 365 days.
+func parseMaxAge(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" || s == "0" {
+		return 0, nil
+	}
+	units := map[byte]time.Duration{
+		'd': 24 * time.Hour,
+		'w': 7 * 24 * time.Hour,
+		'y': 365 * 24 * time.Hour,
+	}
+	if mult, ok := units[s[len(s)-1]]; ok {
+		val, err := strconv.ParseFloat(s[:len(s)-1], 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		if val < 0 {
+			return 0, fmt.Errorf("invalid duration %q: must not be negative", s)
+		}
+		return time.Duration(val * float64(mult)), nil
+	}
+	return time.ParseDuration(s)
 }
 
 // imapContentFetch is the read face's on-demand content resolver: the syncer's

--- a/cmd/darbaan/maxage_test.go
+++ b/cmd/darbaan/maxage_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMaxAge(t *testing.T) {
+	ok := []struct {
+		in   string
+		want time.Duration
+	}{
+		{"", 0},
+		{"0", 0},
+		{" 1y ", 365 * 24 * time.Hour}, // trimmed
+		{"1y", 365 * 24 * time.Hour},
+		{"30d", 30 * 24 * time.Hour},
+		{"2w", 14 * 24 * time.Hour},
+		{"12h", 12 * time.Hour},
+		{"90m", 90 * time.Minute},
+	}
+	for _, c := range ok {
+		got, err := parseMaxAge(c.in)
+		require.NoError(t, err, c.in)
+		assert.Equal(t, c.want, got, c.in)
+	}
+
+	for _, bad := range []string{"abc", "1x", "yy", "-1y"} {
+		_, err := parseMaxAge(bad)
+		assert.Error(t, err, bad)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,11 @@ services:
       # DARBAAN_INBOUND_IMAP_HOST: "imap.gmail.com:993"
       # DARBAAN_INBOUND_IMAP_USERNAME: "" # e.g. you@gmail.com
       # DARBAAN_INBOUND_IMAP_MAILBOX: "INBOX"
+      # Recency cutoff for the first/full sync (ADR 0008): only mail newer than
+      # this is pulled, e.g. 1y / 30d / 12h. Empty = no cutoff (pull everything).
+      # Forward-only: widening it later needs a re-sync (old UIDs are behind the
+      # cursor). Bounds both the store and the first pull on a deep mailbox.
+      # DARBAAN_INBOUND_MAX_AGE: "1y"
       DARBAAN_INBOUND_IMAP_PASSWORD: "${DARBAAN_INBOUND_IMAP_PASSWORD:-}"
     volumes:
       - darbaan-data:/data # the three bbolt DBs (sluice / audit / inbound)

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -3,7 +3,9 @@ package imapsync
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -23,11 +25,13 @@ type Syncer struct {
 	owner   string // the agent whose mailbox this is
 	store   inbound.InboundStore
 	state   StateStore
+	maxAge  time.Duration // recency cutoff; 0 = no cutoff (ADR 0008)
 }
 
-// New builds a Syncer. owner is the agent the synced mail belongs to.
-func New(dial DialFunc, mailbox, owner string, store inbound.InboundStore, state StateStore) *Syncer {
-	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, store: store, state: state}
+// New builds a Syncer. owner is the agent the synced mail belongs to. maxAge is
+// the recency cutoff for the initial/full sync (0 = pull everything).
+func New(dial DialFunc, mailbox, owner string, store inbound.InboundStore, state StateStore, maxAge time.Duration) *Syncer {
+	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, store: store, state: state, maxAge: maxAge}
 }
 
 // Dialer is the production DialFunc: TLS-connect to addr and log in with the
@@ -89,27 +93,21 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 }
 
 // pull fetches new messages and stores them, returning the count stored and the
-// new cursor (the highest UID stored, or the prior cursor if nothing was new).
+// new cursor.
 //
-// It uses a CONCRETE upper bound from the mailbox's UIDNEXT — go-imap's dynamic
-// "*" range (Stop 0) is mis-encoded on the wire against strict servers (e.g.
-// Gmail) and silently matches nothing; only when a server reports no UIDNEXT do
-// we fall back to the dynamic range, guarded against the "N:*" past-the-end
-// re-return.
-//
-// The fetch is STREAMED (one message buffered at a time via cmd.Next), so a
-// large mailbox never loads into memory at once. On a mid-stream error the
-// cursor is not advanced, so the next run re-syncs — at-least-once, no gaps.
+// The set to fetch comes from pullSet: a CONCRETE (last+1):(uidNext-1) range
+// normally, or — with a recency cutoff (ADR 0008) — exactly the messages newer
+// than the cutoff date AND the cursor. The fetch is STREAMED (one message
+// buffered at a time via cmd.Next), so a large mailbox never loads into memory at
+// once. On a mid-stream error the cursor is not advanced, so the next run
+// re-syncs — at-least-once, no gaps.
 func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (int, uint32, error) {
-	var set imap.UIDSet
-	if uidNext > 0 {
-		hi := uidNext - 1 // highest possible existing UID
-		if last+1 > hi {
-			return 0, last, nil // no new messages
-		}
-		set.AddRange(imap.UID(last+1), imap.UID(hi))
-	} else {
-		set.AddRange(imap.UID(last+1), 0) // fallback: dynamic "*"
+	set, ceiling, skip, err := s.pullSet(c, uidNext, last)
+	if err != nil {
+		return 0, last, err
+	}
+	if skip {
+		return 0, ceiling, nil // nothing to fetch; advance the cursor to the ceiling
 	}
 
 	// Headers-only: ENVELOPE + RFC822.SIZE (stored as metadata so the read face
@@ -157,7 +155,80 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 	if err := cmd.Close(); err != nil {
 		return stored, highest, fmt.Errorf("imapsync: fetch: %w", err)
 	}
+	// On the recency-cutoff path, advance the cursor to the covered ceiling
+	// (uidNext-1) so we step past skipped-old mail — including a high-UID /
+	// old-INTERNALDATE message SEARCH SINCE excludes — and never re-evaluate it.
+	if ceiling > highest {
+		highest = ceiling
+	}
 	return stored, highest, nil
+}
+
+// pullSet builds the UID set to fetch plus the cursor ceiling. Normally that is
+// the concrete (last+1):(uidNext-1) range (UIDNEXT gives a strict upper bound —
+// go-imap's dynamic "*" is mis-encoded against Gmail; fall back to it only when a
+// server reports no UIDNEXT). With a recency cutoff it is the exact intersection
+// of "newer than the cutoff date" (UID SEARCH SINCE) and "newer than the cursor"
+// — an exact set, not a UID floor, so a high-UID/old-date message is excluded.
+//
+// Note (forward-only, v1): on the cutoff path the cursor advances to uidNext-1
+// regardless, so WIDENING the window later (e.g. 1y→2y) does NOT retroactively
+// pull the now-in-range older mail — those UIDs are already behind the cursor.
+// Widening requires a cursor reset / re-sync.
+func (s *Syncer) pullSet(c *imapclient.Client, uidNext, last uint32) (set imap.UIDSet, ceiling uint32, skip bool, err error) {
+	ceiling = last
+	if s.maxAge > 0 {
+		cutoff := time.Now().Add(-s.maxAge)
+		res, e := c.UIDSearch(&imap.SearchCriteria{Since: cutoff}, nil).Wait()
+		if e != nil {
+			return set, last, false, fmt.Errorf("imapsync: search since %s: %w", cutoff.Format("2006-01-02"), e)
+		}
+		uids := filterAbove(res.AllUIDs(), last)
+		if uidNext > 0 {
+			ceiling = uidNext - 1 // the whole range is covered; old mail is skipped
+		}
+		if len(uids) == 0 {
+			return set, ceiling, true, nil
+		}
+		return uidSetOf(uids), ceiling, false, nil
+	}
+	if uidNext > 0 {
+		hi := uidNext - 1 // highest possible existing UID
+		if last+1 > hi {
+			return set, last, true, nil // no new messages
+		}
+		set.AddRange(imap.UID(last+1), imap.UID(hi))
+		return set, hi, false, nil
+	}
+	set.AddRange(imap.UID(last+1), 0) // fallback: dynamic "*"
+	return set, last, false, nil
+}
+
+// filterAbove returns the UIDs strictly greater than last.
+func filterAbove(uids []imap.UID, last uint32) []imap.UID {
+	out := uids[:0:0]
+	for _, u := range uids {
+		if uint32(u) > last {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// uidSetOf builds a UID set from a list, coalescing consecutive UIDs into ranges
+// so the FETCH command stays compact even for a large recent window.
+func uidSetOf(uids []imap.UID) imap.UIDSet {
+	sort.Slice(uids, func(i, j int) bool { return uids[i] < uids[j] })
+	var set imap.UIDSet
+	for i := 0; i < len(uids); {
+		j := i
+		for j+1 < len(uids) && uids[j+1] == uids[j]+1 {
+			j++
+		}
+		set.AddRange(uids[i], uids[j])
+		i = j + 1
+	}
+	return set
 }
 
 // FetchContent fills a pending message's body on demand (ADR 0019, the read-time

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -48,6 +49,13 @@ func appendMsg(t *testing.T, user *imapmemserver.User, raw string) {
 	require.NoError(t, err)
 }
 
+// appendMsgAt appends a message with a specific INTERNALDATE (for SEARCH SINCE).
+func appendMsgAt(t *testing.T, user *imapmemserver.User, raw string, when time.Time) {
+	t.Helper()
+	_, err := user.Append("INBOX", bytes.NewReader([]byte(raw)), &imap.AppendOptions{Time: when})
+	require.NoError(t, err)
+}
+
 func dialFor(addr string) imapsync.DialFunc {
 	return func() (*imapclient.Client, error) {
 		c, err := imapclient.DialInsecure(addr, nil)
@@ -84,7 +92,7 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	appendMsg(t, user, "From: bob@x.test\r\nTo: agent@d.test\r\nSubject: two\r\n\r\nbody two")
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
@@ -134,7 +142,7 @@ func TestSyncStreamsManyMessages(t *testing.T) {
 		appendMsg(t, user, fmt.Sprintf("Subject: m%d\r\n\r\nbody %d", i, i))
 	}
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 
 	got, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
@@ -158,7 +166,7 @@ func TestFetchContentFillsPending(t *testing.T) {
 	appendMsg(t, user, "Subject: real\r\n\r\nreal body") // upstream UID 1, UIDVALIDITY 1
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "real", UpstreamUID: 1, UIDValidity: 1})
 	require.NoError(t, err)
@@ -187,7 +195,7 @@ func TestFetchContentStaleUIDValidity(t *testing.T) {
 	appendMsg(t, user, "Subject: x\r\n\r\ny")
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t))
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 999})
 	require.NoError(t, err)
 
@@ -204,18 +212,42 @@ func TestSyncDedupsOnCursorReset(t *testing.T) {
 
 	store := newInbound(t) // shared across both syncers
 
-	n, err := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t)).Sync(context.Background())
+	n, err := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0).Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 2, n)
 
 	// A second syncer with a FRESH cursor re-fetches both, but dedups: 0 new.
-	n, err = imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t)).Sync(context.Background())
+	n, err = imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0).Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 
 	msgs, err := store.List("agent")
 	require.NoError(t, err)
 	assert.Len(t, msgs, 2) // no duplicates
+}
+
+// A recency cutoff (inbound-max-age) pulls only messages newer than the cutoff
+// date; old mail is skipped and the cursor advances past it (no re-pull).
+func TestSyncRecencyCutoff(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsgAt(t, user, "Subject: ancient\r\n\r\nx", time.Now().AddDate(-2, 0, 0)) // 2y old
+	appendMsgAt(t, user, "Subject: fresh\r\n\r\ny", time.Now())
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 365*24*time.Hour) // 1y
+
+	n, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n) // only the fresh message, ancient one skipped
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "fresh", msgs[0].Subject)
+
+	// The cursor advanced past the skipped-old message → next sync is a no-op.
+	n, err = syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
 }
 
 // A recorded cursor for a different UIDVALIDITY (mailbox reset) is discarded and
@@ -228,7 +260,7 @@ func TestSyncResetsOnUIDValidityMismatch(t *testing.T) {
 	state := newState(t)
 	require.NoError(t, state.Save("INBOX", imapsync.State{UIDValidity: 424242, LastUID: 99}))
 
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, state)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, state, 0)
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, n) // mismatch → cursor reset to 0 → message re-pulled despite LastUID=99


### PR DESCRIPTION
**First inbound-filter increment** (ADR 0008): the recency dimension. Bound the initial/full sync — and the store — to recent mail, so a deep mailbox (the test box goes back to Gmail's 2004 launch) doesn't pull decades of history.

## What
- New config **`inbound-max-age`** (e.g. `1y` / `30d` / `12h`). **Empty/0 = no cutoff = current behavior** — existing + bounce-only deploys unchanged. Parsed by a small helper adding calendar `d`/`w`/`y` on top of `time.ParseDuration` (which rejects `1y`).
- When set, the pull computes `cutoff = now - max-age` and uses **UID SEARCH SINCE `<cutoff>`** for the messages newer than the cutoff date, then fetches **exactly the intersection** of that set with `UID > cursor`. An exact set, **not a UID floor** — so a high-UID / old-INTERNALDATE message (appended-late old mail) is correctly excluded. Falls back to the `(last+1):(uidNext-1)` range when no cutoff.
- The **cursor advances to `uidNext-1`** on the cutoff path, stepping past all skipped-old mail in one shot — later pulls never re-evaluate it (incl. that high-UID/old-date edge), steady state stays a no-op. Applies on initial + UIDVALIDITY-reset; incremental is already recent.

## Forward-only (v1) — named, not a surprise
Because the cursor steps past skipped-old, **WIDENING the window later (1y→2y) does NOT retroactively pull** the now-in-range older mail — those UIDs are behind the cursor. Widening needs a cursor reset / re-sync. Documented in the config help, the code, and docker-compose.

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Streamed/best-effort like the rest. Tests: a 1y cutoff pulls only the recent message (a 2y-old one is skipped) and the next sync is a no-op (cursor stepped past); `parseMaxAge` covers y/w/d/h/m + empty + invalid.

Live verify (yours): wire `inbound-max-age=1y` on the box → first pull shrinks from ~22 years to the last year. Next increment: the structured allow/hide/hold rules once you draft the ADR 0008 update.
