### PR TITLE
feat(inbound): read upstream keywords into metadata + serve on FETCH FLAGS (ADR 0020 20a)

### DIFF
--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -115,6 +115,7 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 	// BODY[] — the body is fetched on demand when first read (lazy, ADR 0019).
 	cmd := c.Fetch(set, &imap.FetchOptions{
 		UID:        true,
+		Flags:      true, // custom keywords/labels (ADR 0020)
 		Envelope:   true,
 		RFC822Size: true,
 	})
@@ -292,7 +293,7 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 }
 
 func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {
-	d := inbound.Delivery{Owner: owner, Raw: rawBody(m), Size: m.RFC822Size}
+	d := inbound.Delivery{Owner: owner, Raw: rawBody(m), Size: m.RFC822Size, Keywords: keywordsOf(m.Flags)}
 	if m.Envelope != nil {
 		d.Subject = m.Envelope.Subject
 		d.From = firstAddr(m.Envelope.From)
@@ -300,6 +301,19 @@ func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery
 		d.Envelope = mapEnvelope(m.Envelope)
 	}
 	return d
+}
+
+// keywordsOf returns the custom keywords from a message's flags — the atoms that
+// are not backslash-prefixed system flags (\Seen, \Flagged, …). \Seen is tracked
+// separately as the Seen field, so it (and the other system flags) are dropped.
+func keywordsOf(flags []imap.Flag) []string {
+	var kw []string
+	for _, f := range flags {
+		if !strings.HasPrefix(string(f), "\\") {
+			kw = append(kw, string(f))
+		}
+	}
+	return kw
 }
 
 // mapEnvelope mirrors an IMAP envelope into the store's IMAP-free Envelope so the

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -56,6 +56,13 @@ func appendMsgAt(t *testing.T, user *imapmemserver.User, raw string, when time.T
 	require.NoError(t, err)
 }
 
+// appendMsgKw appends a message carrying custom keyword flags (ADR 0020).
+func appendMsgKw(t *testing.T, user *imapmemserver.User, raw string, flags []imap.Flag) {
+	t.Helper()
+	_, err := user.Append("INBOX", bytes.NewReader([]byte(raw)), &imap.AppendOptions{Flags: flags})
+	require.NoError(t, err)
+}
+
 func dialFor(addr string) imapsync.DialFunc {
 	return func() (*imapclient.Client, error) {
 		c, err := imapclient.DialInsecure(addr, nil)
@@ -224,6 +231,24 @@ func TestSyncDedupsOnCursorReset(t *testing.T) {
 	msgs, err := store.List("agent")
 	require.NoError(t, err)
 	assert.Len(t, msgs, 2) // no duplicates
+}
+
+// Sync pulls a message's custom keywords into the record metadata (ADR 0020);
+// system flags like \Seen are not keywords and are dropped.
+func TestSyncPullsKeywords(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsgKw(t, user, "Subject: tagged\r\n\r\nx", []imap.Flag{"useless", "$Important", imap.FlagSeen})
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	n, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.ElementsMatch(t, []string{"useless", "$Important"}, msgs[0].Keywords)
 }
 
 // A recency cutoff (inbound-max-age) pulls only messages newer than the cutoff

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -224,6 +224,7 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byt
 		Pending:     pending,
 		Envelope:    d.Envelope,
 		Size:        d.Size,
+		Keywords:    d.Keywords,
 	}
 	key := seqkey.Encode(seq)
 	blobbed := false

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -63,6 +63,10 @@ type Delivery struct {
 	// to the raw for those.
 	Envelope *Envelope
 	Size     int64
+
+	// Keywords are the message's custom IMAP keywords/labels (ADR 0020), pulled
+	// from upstream by the sync; nil for locally-generated deliveries.
+	Keywords []string
 }
 
 // Message is a stored inbound message.
@@ -93,6 +97,10 @@ type Message struct {
 	// from the raw.
 	Envelope *Envelope `json:"envelope,omitempty"`
 	Size     int64     `json:"size,omitempty"`
+
+	// Keywords are the message's custom IMAP keywords/labels (ADR 0020), served
+	// on FETCH FLAGS. The agent sets them via STORE (write-through to upstream).
+	Keywords []string `json:"keywords,omitempty"`
 }
 
 // InboundStore is the agent's served mailbox. Implementations are selected by

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -110,6 +110,8 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 	s.selected = msgs
 
 	firstUnseen, uidNext := uint32(0), uint32(1) // UID 0 is invalid (RFC 3501)
+	seen := map[imap.Flag]bool{}
+	keywords := []imap.Flag{}
 	for i, m := range msgs {
 		uid := uint32(uidOf(m))
 		if uid >= uidNext {
@@ -118,10 +120,16 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 		if !m.Seen && firstUnseen == 0 {
 			firstUnseen = uint32(i) + 1
 		}
+		for _, k := range m.Keywords { // advertise the keywords in use (ADR 0020)
+			if f := imap.Flag(k); !seen[f] {
+				seen[f] = true
+				keywords = append(keywords, f)
+			}
+		}
 	}
 	return &imap.SelectData{
-		Flags:             []imap.Flag{imap.FlagSeen},
-		PermanentFlags:    []imap.Flag{imap.FlagSeen},
+		Flags:             append([]imap.Flag{imap.FlagSeen}, keywords...),
+		PermanentFlags:    append([]imap.Flag{imap.FlagSeen}, keywords...),
 		NumMessages:       uint32(len(msgs)),
 		FirstUnseenSeqNum: firstUnseen,
 		UIDNext:           imap.UID(uidNext),
@@ -658,10 +666,14 @@ func toIMAPAddrs(as []inbound.Address) []imap.Address {
 }
 
 func flagList(m inbound.Message) []imap.Flag {
+	flags := make([]imap.Flag, 0, len(m.Keywords)+1)
 	if m.Seen {
-		return []imap.Flag{imap.FlagSeen}
+		flags = append(flags, imap.FlagSeen)
 	}
-	return []imap.Flag{}
+	for _, k := range m.Keywords { // custom keywords/labels (ADR 0020)
+		flags = append(flags, imap.Flag(k))
+	}
+	return flags
 }
 
 func seenFromStoreFlags(sf *imap.StoreFlags) (seen, touches bool) {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -281,6 +281,32 @@ func TestIMAPHeaderSearchFallsBackToRaw(t *testing.T) {
 	assert.Equal(t, []uint32{1}, res.AllSeqNums())
 }
 
+// FETCH FLAGS serves a message's custom keywords (ADR 0020), and SELECT
+// advertises them in FLAGS/PERMANENTFLAGS.
+func TestIMAPFetchServesKeywords(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"useless", "$Important"},
+	})
+	require.NoError(t, err)
+
+	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Contains(t, sel.Flags, imap.Flag("useless"))
+
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{Flags: true}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Contains(t, msgs[0].Flags, imap.Flag("useless"))
+	assert.Contains(t, msgs[0].Flags, imap.Flag("$Important"))
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**ADR 0020, increment 20a** — read-keywords. Surface a message's custom IMAP keywords to the agent. **Read-only** — the agent setting keywords (STORE) + write-through is 20b; the Gmail X-GM-LABELS mapping is 20c.

## What
- `inbound.Message`/`Delivery` gain **`Keywords`**; the sync FETCHes FLAGS and stores the custom keywords (the non-backslash atoms; system flags like `\Seen` are dropped — `\Seen` is tracked separately) into the record metadata.
- The read face serves keywords on **FETCH FLAGS** alongside `\Seen`, and **SELECT advertises** the keywords in use in FLAGS/PERMANENTFLAGS.

Universal IMAP keywords (RFC 3501) — no Gmail coupling (that's 20c, capability-negotiated).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: sync pulls custom keywords (dropping `\Seen`); FETCH FLAGS serves them and SELECT advertises them.

Next: 20b write-through (STORE keyword → store-canonical local commit + best-effort upstream keyword STORE over a separate RW session, failed upstream logged + retried on next reconcile).
