### PR TITLE
feat(inbound): keyword write-through — STORE to local-canonical + best-effort upstream (ADR 0020 20b)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -208,6 +208,16 @@ func imapContentFetch(syncer *imapsync.Syncer) listener.ContentFetch {
 	return syncer.FetchContent
 }
 
+// imapKeywordWriter is the read face's label write-through (ADR 0020): the
+// syncer's WriteKeywords when sync is on, else nil (local-only labels — a
+// sync-disabled deploy has no upstream to replicate to).
+func imapKeywordWriter(syncer *imapsync.Syncer) listener.KeywordWriter {
+	if syncer == nil {
+		return nil
+	}
+	return syncer.WriteKeywords
+}
+
 // runSyncLoop polls the upstream mailbox on the configured interval until ctx is
 // cancelled. Sync errors are logged, never fatal — a flaky or unreachable
 // upstream must not take down serve.
@@ -365,7 +375,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, inbox, imapContentFetch(syncer))
+	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer))
 	if err != nil {
 		return err
 	}

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -80,6 +80,13 @@ func (failingInbound) AddSyncedPending(inbound.Delivery) (bool, inbound.Message,
 func (failingInbound) SetContent(string, string, []byte) (inbound.Message, error) {
 	return inbound.Message{}, errors.New("inbound store down")
 }
+func (failingInbound) SetKeywords(string, string, []string) (inbound.Message, error) {
+	return inbound.Message{}, errors.New("inbound store down")
+}
+func (failingInbound) ClearKeywordsDirty(string, string) error { return nil }
+func (failingInbound) DirtyKeywords(string) ([]inbound.Message, error) {
+	return nil, nil
+}
 func (failingInbound) List(string) ([]inbound.Message, error) { return nil, nil }
 func (failingInbound) Get(string, string) (inbound.Message, error) {
 	return inbound.Message{}, inbound.ErrNotFound

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -3,6 +3,7 @@ package imapsync
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strings"
 	"time"
@@ -89,6 +90,10 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 			return stored, err
 		}
 	}
+
+	// Retry any label writes that failed their immediate upstream replicate
+	// (ADR 0020 best-effort write-through). Best-effort; never fails the sync.
+	s.reconcileKeywords()
 	return stored, nil
 }
 
@@ -290,6 +295,113 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found", id, m.UpstreamUID)
 	}
 	return s.store.SetContent(owner, id, raw)
+}
+
+// WriteKeywords replicates a message's keyword set to the upstream backend over a
+// SEPARATE read-write session — the narrow label-write exception to read-only
+// upstream (ADR 0020). It converges the upstream message to want by FETCHing its
+// current keywords and applying the +/- delta, so it is idempotent and handles
+// both additions and removals (content + delete stay read-only). The local store
+// is canonical; a failure here is returned so the caller logs + reconciles later.
+func (s *Syncer) WriteKeywords(owner, id string, want []string) error {
+	m, err := s.store.Get(owner, id)
+	if err != nil {
+		return err
+	}
+	if m.UpstreamUID == 0 {
+		return fmt.Errorf("imapsync: keyword write for %s: no upstream uid", id)
+	}
+
+	c, err := s.dial()
+	if err != nil {
+		return fmt.Errorf("imapsync: connect: %w", err)
+	}
+	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
+
+	sel, err := c.Select(s.mailbox, nil).Wait() // read-write session
+	if err != nil {
+		return fmt.Errorf("imapsync: select %q: %w", s.mailbox, err)
+	}
+	if sel.UIDValidity != m.UIDValidity {
+		return fmt.Errorf("imapsync: keyword write for %s: mailbox reset (uidvalidity %d != %d)", id, sel.UIDValidity, m.UIDValidity)
+	}
+
+	var set imap.UIDSet
+	set.AddNum(imap.UID(m.UpstreamUID))
+	fetched, err := c.Fetch(set, &imap.FetchOptions{UID: true, Flags: true}).Collect()
+	if err != nil {
+		return fmt.Errorf("imapsync: keyword write fetch: %w", err)
+	}
+	var current []string
+	if len(fetched) > 0 {
+		current = keywordsOf(fetched[0].Flags)
+	}
+	add, remove := diffKeywords(current, want)
+	if len(add) > 0 {
+		if err := c.Store(set, &imap.StoreFlags{Op: imap.StoreFlagsAdd, Silent: true, Flags: toFlags(add)}, nil).Close(); err != nil {
+			return fmt.Errorf("imapsync: keyword add: %w", err)
+		}
+	}
+	if len(remove) > 0 {
+		if err := c.Store(set, &imap.StoreFlags{Op: imap.StoreFlagsDel, Silent: true, Flags: toFlags(remove)}, nil).Close(); err != nil {
+			return fmt.Errorf("imapsync: keyword remove: %w", err)
+		}
+	}
+	return nil
+}
+
+// reconcileKeywords re-replicates locally-dirty keyword sets to upstream — a label
+// write whose immediate upstream replicate failed is retried here on the next sync
+// (ADR 0020). Best-effort: failures are logged, never fatal to the sync.
+func (s *Syncer) reconcileKeywords() {
+	dirty, err := s.store.DirtyKeywords(s.owner)
+	if err != nil {
+		log.Printf("darbaan: keyword reconcile list: %v", err)
+		return
+	}
+	for _, m := range dirty {
+		if err := s.WriteKeywords(s.owner, m.ID, m.Keywords); err != nil {
+			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
+			continue
+		}
+		if err := s.store.ClearKeywordsDirty(s.owner, m.ID); err != nil {
+			log.Printf("darbaan: keyword reconcile clear %s: %v", m.ID, err)
+		}
+	}
+}
+
+// diffKeywords returns the keywords to add and to remove to converge current to
+// want.
+func diffKeywords(current, want []string) (add, remove []string) {
+	cur := map[string]bool{}
+	for _, k := range current {
+		cur[k] = true
+	}
+	wnt := map[string]bool{}
+	for _, k := range want {
+		wnt[k] = true
+	}
+	for k := range wnt {
+		if !cur[k] {
+			add = append(add, k)
+		}
+	}
+	for k := range cur {
+		if !wnt[k] {
+			remove = append(remove, k)
+		}
+	}
+	sort.Strings(add)
+	sort.Strings(remove)
+	return add, remove
+}
+
+func toFlags(kw []string) []imap.Flag {
+	f := make([]imap.Flag, len(kw))
+	for i, k := range kw {
+		f[i] = imap.Flag(k)
+	}
+	return f
 }
 
 func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -249,6 +250,77 @@ func TestSyncPullsKeywords(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	assert.ElementsMatch(t, []string{"useless", "$Important"}, msgs[0].Keywords)
+}
+
+// upstreamKeywords reads a message's custom keywords from the upstream by UID.
+func upstreamKeywords(t *testing.T, addr string, uid uint32) []string {
+	t.Helper()
+	c, err := dialFor(addr)()
+	require.NoError(t, err)
+	defer func() { _ = c.Logout().Wait() }()
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	var set imap.UIDSet
+	set.AddNum(imap.UID(uid))
+	msgs, err := c.Fetch(set, &imap.FetchOptions{UID: true, Flags: true}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	var kw []string
+	for _, f := range msgs[0].Flags {
+		if !strings.HasPrefix(string(f), "\\") {
+			kw = append(kw, string(f))
+		}
+	}
+	return kw
+}
+
+// WriteKeywords replicates a keyword set to the upstream over a separate session,
+// converging by add/remove delta (ADR 0020 write-through).
+func TestWriteKeywordsToUpstream(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: x\r\n\r\ny") // upstream UID 1
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, []string{"useless", "handled"}))
+	assert.ElementsMatch(t, []string{"useless", "handled"}, upstreamKeywords(t, addr, 1))
+
+	// Converges: removing one upstream.
+	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, []string{"handled"}))
+	assert.ElementsMatch(t, []string{"handled"}, upstreamKeywords(t, addr, 1))
+}
+
+// A dirty keyword set (a failed immediate write) is reconciled to upstream on the
+// next sync, then the dirty flag clears.
+func TestSyncReconcilesDirtyKeywords(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: x\r\n\r\ny")
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+
+	// Mark dirty locally (as if the immediate upstream write had failed).
+	_, err = store.SetKeywords("agent", msgs[0].ID, []string{"useless"})
+	require.NoError(t, err)
+	dirty, err := store.DirtyKeywords("agent")
+	require.NoError(t, err)
+	require.Len(t, dirty, 1)
+
+	// Next sync reconciles it upstream and clears dirty.
+	_, err = syncer.Sync(context.Background())
+	require.NoError(t, err)
+	dirty, err = store.DirtyKeywords("agent")
+	require.NoError(t, err)
+	assert.Empty(t, dirty)
+	assert.ElementsMatch(t, []string{"useless"}, upstreamKeywords(t, addr, 1))
 }
 
 // A recency cutoff (inbound-max-age) pulls only messages newer than the cutoff

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -39,6 +39,10 @@ func init() {
 type stored struct {
 	Message
 	Blobbed bool `json:"blobbed,omitempty"`
+	// KeywordsDirty marks a record whose local keyword set has not yet been
+	// confirmed replicated to the upstream backend (ADR 0020 write-through). The
+	// local store is canonical; the sync reconciles dirty records best-effort.
+	KeywordsDirty bool `json:"keywords_dirty,omitempty"`
 }
 
 // bboltStore is the bbolt-backed InboundStore. Metadata lives in its database;
@@ -297,6 +301,70 @@ func (s *bboltStore) SetSeen(owner, id string, seen bool) error {
 		rec.Seen = seen
 		return putStored(tx, key, rec) // metadata only; the blob is untouched
 	})
+}
+
+// SetKeywords replaces the owner's message's keyword set (ADR 0020) and marks it
+// dirty for upstream reconcile. The local store is canonical; the returned
+// message carries the new keywords (without content). Metadata-only write.
+func (s *bboltStore) SetKeywords(owner, id string, keywords []string) (Message, error) {
+	var msg Message
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		rec, key, err := loadStored(tx, id)
+		if err != nil {
+			return err
+		}
+		if rec.Owner != owner {
+			return ErrNotFound
+		}
+		rec.Keywords = keywords
+		rec.KeywordsDirty = true
+		msg = rec.Message
+		return putStored(tx, key, rec)
+	})
+	if err != nil {
+		return Message{}, fmt.Errorf("inbound: set keywords %s: %w", id, err)
+	}
+	return msg, nil
+}
+
+// ClearKeywordsDirty clears the dirty flag after a successful upstream replicate.
+func (s *bboltStore) ClearKeywordsDirty(owner, id string) error {
+	return s.db.Update(func(tx *bbolt.Tx) error {
+		rec, key, err := loadStored(tx, id)
+		if err != nil {
+			return err
+		}
+		if rec.Owner != owner {
+			return ErrNotFound
+		}
+		if !rec.KeywordsDirty {
+			return nil
+		}
+		rec.KeywordsDirty = false
+		return putStored(tx, key, rec)
+	})
+}
+
+// DirtyKeywords returns the owner's messages whose keywords await upstream
+// replication (metadata only), for the sync to reconcile.
+func (s *bboltStore) DirtyKeywords(owner string) ([]Message, error) {
+	var out []Message
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketInbound).ForEach(func(_, v []byte) error {
+			var rec stored
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return err
+			}
+			if rec.KeywordsDirty && rec.Owner == owner {
+				out = append(out, rec.Message)
+			}
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, fmt.Errorf("inbound: dirty keywords: %w", err)
+	}
+	return out, nil
 }
 
 func (s *bboltStore) Get(owner, id string) (Message, error) {

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -120,6 +120,13 @@ type InboundStore interface {
 	// SetContent fills a pending message's body (write the content blob, mark it
 	// present) and returns the now-complete message. Owner-scoped.
 	SetContent(owner, id string, raw []byte) (Message, error)
+	// SetKeywords replaces a message's keyword set (ADR 0020) and marks it dirty
+	// for upstream reconcile. Local store is canonical. Owner-scoped.
+	SetKeywords(owner, id string, keywords []string) (Message, error)
+	// ClearKeywordsDirty clears the dirty flag after upstream replication succeeds.
+	ClearKeywordsDirty(owner, id string) error
+	// DirtyKeywords returns messages whose keywords await upstream replication.
+	DirtyKeywords(owner string) ([]Message, error)
 	// List returns the owner's messages' metadata (no content/Raw) in receive
 	// order; a body is fetched per-message via Get / the content fetcher.
 	List(owner string) ([]Message, error)

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -38,6 +39,12 @@ type IMAPServerConfig struct {
 // (lazy, ADR 0019). It is called per-FETCH, never at SELECT.
 type ContentFetch func(owner, id string) (inbound.Message, error)
 
+// KeywordWriter replicates a message's keyword set to the upstream backend (the
+// label write-through, ADR 0020). The local store is canonical; a returned error
+// means the upstream replicate failed and is reconciled later. nil disables
+// write-through (local-only labels — e.g. sync disabled).
+type KeywordWriter func(owner, id string, want []string) error
+
 // IMAPServer serves the agent's mailbox (the InboundStore) over IMAP as a
 // translation adapter (ADR 0016): the store is canonical. SELECT snapshots
 // metadata only; a body FETCH resolves content per-message via a ContentFetch.
@@ -50,7 +57,7 @@ type IMAPServer struct {
 // content on demand; if nil it defaults to reading straight from the store
 // (no upstream — bounce-only / sync-disabled deployments have no pending
 // records).
-func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch) (*IMAPServer, error) {
+func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -59,7 +66,7 @@ func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundS
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{cred: cred, store: store, fetch: fetch}, nil, nil
+			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -80,12 +87,13 @@ func (s *IMAPServer) Close() error { return s.imap.Close() }
 // authenticated agent (owner). Every store access is owner-keyed, so a session
 // can only ever see the agent's own messages.
 type imapSession struct {
-	cred     Credential
-	store    inbound.InboundStore
-	fetch    ContentFetch // resolves message content on demand (per-FETCH)
-	owner    string
-	authed   bool
-	selected []inbound.Message // metadata snapshot taken at Select (no content)
+	cred          Credential
+	store         inbound.InboundStore
+	fetch         ContentFetch  // resolves message content on demand (per-FETCH)
+	writeKeywords KeywordWriter // replicates a keyword change upstream (nil = local-only)
+	owner         string
+	authed        bool
+	selected      []inbound.Message // metadata snapshot taken at Select (no content)
 }
 
 func (s *imapSession) Close() error { return nil }
@@ -127,9 +135,13 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 			}
 		}
 	}
+	// \* in PERMANENTFLAGS signals the client may create new keywords via STORE
+	// (ADR 0020 write-through).
+	permanent := append([]imap.Flag{imap.FlagSeen}, keywords...)
+	permanent = append(permanent, imap.FlagWildcard)
 	return &imap.SelectData{
 		Flags:             append([]imap.Flag{imap.FlagSeen}, keywords...),
-		PermanentFlags:    append([]imap.Flag{imap.FlagSeen}, keywords...),
+		PermanentFlags:    permanent,
 		NumMessages:       uint32(len(msgs)),
 		FirstUnseenSeqNum: firstUnseen,
 		UIDNext:           imap.UID(uidNext),
@@ -248,6 +260,8 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, _ *imap.StoreOptions) error {
 	seen, touchesSeen := seenFromStoreFlags(flags)
 
+	kw := keywordFlags(flags.Flags) // custom keywords in the STORE request (ADR 0020)
+
 	var serr error
 	s.forEach(numSet, func(seqNum uint32, m *inbound.Message) {
 		if serr != nil {
@@ -260,6 +274,27 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 			}
 			m.Seen = seen // also updates s.selected via the pointer
 		}
+		// Keyword change: a SET always recomputes (it can clear keywords); ADD/DEL
+		// only when keyword atoms are present.
+		if flags.Op == imap.StoreFlagsSet || len(kw) > 0 {
+			next, added, removed := applyKeywordOp(m.Keywords, flags.Op, kw)
+			if len(added) > 0 || len(removed) > 0 {
+				if _, err := s.store.SetKeywords(s.owner, m.ID, next); err != nil {
+					serr = err
+					return
+				}
+				m.Keywords = next // local store is canonical; update the snapshot
+				// Best-effort upstream replicate; a failure leaves the record dirty
+				// for the sync to reconcile, never an error to the agent (ADR 0020).
+				if s.writeKeywords != nil {
+					if err := s.writeKeywords(s.owner, m.ID, next); err != nil {
+						log.Printf("darbaan: imap keyword write-through for %s deferred: %v", m.ID, err)
+					} else {
+						_ = s.store.ClearKeywordsDirty(s.owner, m.ID)
+					}
+				}
+			}
+		}
 		if flags.Silent {
 			return
 		}
@@ -271,6 +306,67 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 		}
 	})
 	return serr
+}
+
+// keywordFlags returns the custom keyword atoms from a STORE's flags (dropping
+// backslash-prefixed system flags like \Seen, handled separately).
+func keywordFlags(flags []imap.Flag) []string {
+	var kw []string
+	for _, f := range flags {
+		if !strings.HasPrefix(string(f), "\\") {
+			kw = append(kw, string(f))
+		}
+	}
+	return kw
+}
+
+// applyKeywordOp applies an IMAP STORE op to a keyword set, returning the new set
+// plus the keywords added and removed (for the upstream delta). SET replaces the
+// whole set; ADD/DEL adjust it.
+func applyKeywordOp(current []string, op imap.StoreFlagsOp, kw []string) (next, added, removed []string) {
+	set := map[string]bool{}
+	for _, k := range current {
+		set[k] = true
+	}
+	switch op {
+	case imap.StoreFlagsAdd:
+		for _, k := range kw {
+			if !set[k] {
+				set[k] = true
+				added = append(added, k)
+			}
+		}
+	case imap.StoreFlagsDel:
+		for _, k := range kw {
+			if set[k] {
+				delete(set, k)
+				removed = append(removed, k)
+			}
+		}
+	case imap.StoreFlagsSet:
+		want := map[string]bool{}
+		for _, k := range kw {
+			want[k] = true
+		}
+		for _, k := range kw {
+			if !set[k] {
+				added = append(added, k)
+			}
+		}
+		for k := range set {
+			if !want[k] {
+				removed = append(removed, k)
+			}
+		}
+		set = want
+	}
+	for k := range set {
+		next = append(next, k)
+	}
+	sort.Strings(next)
+	sort.Strings(added)
+	sort.Strings(removed)
+	return next, added, removed
 }
 
 // forEach calls fn for each selected message matching numSet, computing its

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -1,6 +1,7 @@
 package listener_test
 
 import (
+	"errors"
 	"net"
 	"path/filepath"
 	"testing"
@@ -35,11 +36,15 @@ func startIMAP(t *testing.T, store inbound.InboundStore) string {
 }
 
 func startIMAPWithFetch(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch) string {
+	return startIMAPFull(t, store, fetch, nil)
+}
+
+func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch, wk listener.KeywordWriter) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store, fetch)
+		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -307,6 +312,69 @@ func TestIMAPFetchServesKeywords(t *testing.T) {
 	assert.Contains(t, msgs[0].Flags, imap.Flag("$Important"))
 }
 
+// STORE +FLAGS of a keyword commits locally (canonical) and replicates upstream
+// via the writer; on success the record is no longer dirty (ADR 0020).
+func TestIMAPStoreKeywordWritesThrough(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+
+	var wroteID string
+	var wrote []string
+	wk := func(owner, id string, want []string) error { wroteID, wrote = id, want; return nil }
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	require.NoError(t, c.Store(imap.SeqSetNum(1),
+		&imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{"useless"}}, nil).Close())
+
+	got, err := store.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"useless"}, got.Keywords) // local store is canonical
+	assert.Equal(t, m.ID, wroteID)
+	assert.Equal(t, []string{"useless"}, wrote) // replicated the new set upstream
+	dirty, err := store.DirtyKeywords("agent")
+	require.NoError(t, err)
+	assert.Empty(t, dirty) // cleared on successful replicate
+}
+
+// If the upstream replicate fails, the keyword still commits locally and the
+// record stays dirty for the sync to reconcile — never an error to the agent.
+func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+
+	wk := func(owner, id string, want []string) error { return errors.New("upstream down") }
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	// The STORE itself succeeds for the agent even though upstream failed.
+	require.NoError(t, c.Store(imap.SeqSetNum(1),
+		&imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{"useless"}}, nil).Close())
+
+	got, err := store.Get("agent", m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"useless"}, got.Keywords) // committed locally
+	dirty, err := store.DirtyKeywords("agent")
+	require.NoError(t, err)
+	assert.Len(t, dirty, 1) // stays dirty for reconcile
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)
@@ -316,6 +384,6 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil)
+		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil, nil)
 	require.Error(t, err)
 }


### PR DESCRIPTION
**ADR 0020, increment 20b** — keyword write-through. The agent sets keywords via IMAP STORE; they commit locally (canonical) and replicate to the upstream backend best-effort.

## What
- **Read face** accepts `STORE [+|-|set]FLAGS` for custom keywords: computes the new set, commits via `SetKeywords` (**local store is source of truth**), and replicates upstream via an injected `KeywordWriter`. A failed replicate is logged + leaves the record dirty — **never an error to the agent**. SELECT now advertises `\*` in PERMANENTFLAGS.
- **inbound store**: `SetKeywords` (set + mark dirty), `ClearKeywordsDirty`, `DirtyKeywords` (for reconcile); the dirty flag lives on the bbolt record, not the IMAP-facing `Message`.
- **`imapsync.WriteKeywords`** replicates over a **SEPARATE read-write session** (the narrow label-write exception — content + delete stay read-only). It converges the upstream message by FETCHing current keywords + applying the +/- delta, so it is idempotent and handles removals.
- **Sync reconciles**: after each pull it retries dirty keyword sets upstream + clears the flag on success (best-effort, never fatal) — the eventually-consistent replication the ADR names.

Local store canonical, backend an eventually-consistent label replica (same spirit as ADR 0019 at-least-once).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: STORE commits locally + writes through + clears dirty; a write failure stays dirty + still commits locally; `WriteKeywords` converges upstream (add + remove); Sync reconciles a dirty set.

Next: 20c Gmail X-GM-LABELS mapping (keywords ↔ labels on X-GM-EXT-1). Live verify (yours): label a message via the read face → round-trips to the agent backend.
