### PR TITLE
fix(inbound): don't reconcile keyword writes on local-only records (ADR 0020)

### DIFF
--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -317,7 +317,11 @@ func (s *bboltStore) SetKeywords(owner, id string, keywords []string) (Message, 
 			return ErrNotFound
 		}
 		rec.Keywords = keywords
-		rec.KeywordsDirty = true
+		// Only mark dirty when there is an upstream to replicate to. A
+		// locally-generated record (no UpstreamUID, e.g. a bounce) has no backend
+		// label to sync, so it must never enter reconcile (which would log on every
+		// poll). Its keywords are local-only and already "replicated".
+		rec.KeywordsDirty = rec.UpstreamUID != 0
 		msg = rec.Message
 		return putStored(tx, key, rec)
 	})

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -54,6 +54,35 @@ func TestAddSyncedDedup(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// SetKeywords marks a record dirty only when it has an upstream to replicate to;
+// a local-only record (no UpstreamUID, e.g. a bounce) gets keywords but stays
+// out of reconcile (ADR 0020).
+func TestSetKeywordsDirtyOnlyWithUpstream(t *testing.T) {
+	s := newStore(t)
+
+	// Local-only record (Add → no UpstreamUID): keywords set, not dirty.
+	local, err := s.Add(inbound.Delivery{Owner: "agent", Subject: "bounce"})
+	require.NoError(t, err)
+	_, err = s.SetKeywords("agent", local.ID, []string{"x"})
+	require.NoError(t, err)
+	got, err := s.Get("agent", local.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"x"}, got.Keywords)
+	dirty, err := s.DirtyKeywords("agent")
+	require.NoError(t, err)
+	assert.Empty(t, dirty)
+
+	// Synced record (has UpstreamUID): keyword change IS dirty.
+	_, synced, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 5, UIDValidity: 1})
+	require.NoError(t, err)
+	_, err = s.SetKeywords("agent", synced.ID, []string{"y"})
+	require.NoError(t, err)
+	dirty, err = s.DirtyKeywords("agent")
+	require.NoError(t, err)
+	require.Len(t, dirty, 1)
+	assert.Equal(t, synced.ID, dirty[0].ID)
+}
+
 func TestPendingThenSetContent(t *testing.T) {
 	s := newStore(t)
 	added, m, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "hi", UpstreamUID: 7, UIDValidity: 1})

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -286,7 +286,9 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 				m.Keywords = next // local store is canonical; update the snapshot
 				// Best-effort upstream replicate; a failure leaves the record dirty
 				// for the sync to reconcile, never an error to the agent (ADR 0020).
-				if s.writeKeywords != nil {
+				// Skip records with no upstream (locally-generated, e.g. bounces) —
+				// their labels are local-only, nothing to replicate.
+				if s.writeKeywords != nil && m.UpstreamUID != 0 {
 					if err := s.writeKeywords(s.owner, m.ID, next); err != nil {
 						log.Printf("darbaan: imap keyword write-through for %s deferred: %v", m.ID, err)
 					} else {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -375,6 +375,33 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 	assert.Len(t, dirty, 1) // stays dirty for reconcile
 }
 
+// A keyword STORE on a local-only record (a bounce, no UpstreamUID) commits
+// locally but does NOT attempt an upstream write or mark the record dirty —
+// nothing to replicate (ADR 0020).
+func TestIMAPStoreKeywordLocalOnlyNoUpstream(t *testing.T) {
+	store := seedInbound(t) // a bounce: Add → no UpstreamUID, seq 1
+	called := false
+	wk := func(owner, id string, want []string) error { called = true; return nil }
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	require.NoError(t, c.Store(imap.SeqSetNum(1),
+		&imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{"useless"}}, nil).Close())
+
+	got, err := store.Get("agent", "1")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"useless"}, got.Keywords) // local label still set
+	assert.False(t, called, "no upstream write for a local-only record")
+	dirty, err := store.DirtyKeywords("agent")
+	require.NoError(t, err)
+	assert.Empty(t, dirty) // not dirty → never enters reconcile
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Follow-up from #99 (review nit). A locally-generated record (no `UpstreamUID`, e.g. a bounce) has no backend label to replicate to, so a keyword set on it must never enter reconcile — otherwise `WriteKeywords` errors ("no upstream uid") and logs on every sync poll.

- `SetKeywords` marks dirty only when `UpstreamUID != 0`.
- The read face skips the immediate upstream write-through for a no-`UpstreamUID` record (avoids even the one-time attempt/log).

The label still commits locally (store is canonical). Tests cover both store + read-face paths. build/vet/race/lint green.
