### PR TITLE
feat(imapsync): Gmail X-GM-LABELS write-through (ADR 0020 20c)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -166,8 +166,12 @@ func (cli *CLI) newSyncer(inbox inbound.InboundStore) (*imapsync.Syncer, func(),
 	if err != nil {
 		return nil, nil, err
 	}
-	dial := imapsync.Dialer(cli.InboundIMAPHost, cli.InboundIMAPUsername, os.Getenv("DARBAAN_INBOUND_IMAP_PASSWORD"))
+	pass := os.Getenv("DARBAAN_INBOUND_IMAP_PASSWORD")
+	dial := imapsync.Dialer(cli.InboundIMAPHost, cli.InboundIMAPUsername, pass)
 	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbox, state, maxAge)
+	// Gmail label write-through (ADR 0020 20c): capability-gated, so harmless on a
+	// non-Gmail backend (reports not-supported → WriteKeywords uses plain keywords).
+	syncer.SetLabelStore(imapsync.RawGmailLabelStore(cli.InboundIMAPHost, cli.InboundIMAPUsername, pass, cli.InboundIMAPMailbox))
 	return syncer, func() { _ = state.Close() }, nil
 }
 

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -2,6 +2,7 @@ package imapsync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -21,13 +22,19 @@ type DialFunc func() (*imapclient.Client, error)
 
 // Syncer pulls new messages from one upstream mailbox into the inbound store.
 type Syncer struct {
-	dial    DialFunc
-	mailbox string
-	owner   string // the agent whose mailbox this is
-	store   inbound.InboundStore
-	state   StateStore
-	maxAge  time.Duration // recency cutoff; 0 = no cutoff (ADR 0008)
+	dial       DialFunc
+	mailbox    string
+	owner      string // the agent whose mailbox this is
+	store      inbound.InboundStore
+	state      StateStore
+	maxAge     time.Duration  // recency cutoff; 0 = no cutoff (ADR 0008)
+	labelStore LabelStoreFunc // Gmail X-GM-LABELS writer; nil = plain keywords only (ADR 0020)
 }
+
+// SetLabelStore installs the Gmail X-GM-LABELS label writer (ADR 0020 20c). When
+// set, WriteKeywords replicates label changes via X-GM-LABELS on a Gmail backend
+// (capability-gated) and falls back to plain keywords elsewhere.
+func (s *Syncer) SetLabelStore(fn LabelStoreFunc) { s.labelStore = fn }
 
 // New builds a Syncer. owner is the agent the synced mail belongs to. maxAge is
 // the recency cutoff for the initial/full sync (0 = pull everything).
@@ -303,7 +310,10 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 // current keywords and applying the +/- delta, so it is idempotent and handles
 // both additions and removals (content + delete stay read-only). The local store
 // is canonical; a failure here is returned so the caller logs + reconciles later.
-func (s *Syncer) WriteKeywords(owner, id string, want []string) error {
+func (s *Syncer) WriteKeywords(owner, id string, add, remove []string) error {
+	if len(add) == 0 && len(remove) == 0 {
+		return nil
+	}
 	m, err := s.store.Get(owner, id)
 	if err != nil {
 		return err
@@ -312,6 +322,16 @@ func (s *Syncer) WriteKeywords(owner, id string, want []string) error {
 		return fmt.Errorf("imapsync: keyword write for %s: no upstream uid", id)
 	}
 
+	// Gmail: replicate as real labels via X-GM-LABELS (capability-gated, ADR 0020
+	// 20c). On any other backend the writer reports ErrNotXGM and we fall through
+	// to plain keywords.
+	if s.labelStore != nil {
+		if err := s.labelStore(m.UpstreamUID, m.UIDValidity, add, remove); !errors.Is(err, ErrNotXGM) {
+			return err // success, or a real Gmail error
+		}
+	}
+
+	// Plain IMAP keywords (RFC 3501) — the universal path.
 	c, err := s.dial()
 	if err != nil {
 		return fmt.Errorf("imapsync: connect: %w", err)
@@ -325,18 +345,8 @@ func (s *Syncer) WriteKeywords(owner, id string, want []string) error {
 	if sel.UIDValidity != m.UIDValidity {
 		return fmt.Errorf("imapsync: keyword write for %s: mailbox reset (uidvalidity %d != %d)", id, sel.UIDValidity, m.UIDValidity)
 	}
-
 	var set imap.UIDSet
 	set.AddNum(imap.UID(m.UpstreamUID))
-	fetched, err := c.Fetch(set, &imap.FetchOptions{UID: true, Flags: true}).Collect()
-	if err != nil {
-		return fmt.Errorf("imapsync: keyword write fetch: %w", err)
-	}
-	var current []string
-	if len(fetched) > 0 {
-		current = keywordsOf(fetched[0].Flags)
-	}
-	add, remove := diffKeywords(current, want)
 	if len(add) > 0 {
 		if err := c.Store(set, &imap.StoreFlags{Op: imap.StoreFlagsAdd, Silent: true, Flags: toFlags(add)}, nil).Close(); err != nil {
 			return fmt.Errorf("imapsync: keyword add: %w", err)
@@ -360,7 +370,8 @@ func (s *Syncer) reconcileKeywords() {
 		return
 	}
 	for _, m := range dirty {
-		if err := s.WriteKeywords(s.owner, m.ID, m.Keywords); err != nil {
+		// Additive re-apply (reconcile has the wanted set, not a delta).
+		if err := s.WriteKeywords(s.owner, m.ID, m.Keywords, nil); err != nil {
 			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
 			continue
 		}
@@ -368,32 +379,6 @@ func (s *Syncer) reconcileKeywords() {
 			log.Printf("darbaan: keyword reconcile clear %s: %v", m.ID, err)
 		}
 	}
-}
-
-// diffKeywords returns the keywords to add and to remove to converge current to
-// want.
-func diffKeywords(current, want []string) (add, remove []string) {
-	cur := map[string]bool{}
-	for _, k := range current {
-		cur[k] = true
-	}
-	wnt := map[string]bool{}
-	for _, k := range want {
-		wnt[k] = true
-	}
-	for k := range wnt {
-		if !cur[k] {
-			add = append(add, k)
-		}
-	}
-	for k := range cur {
-		if !wnt[k] {
-			remove = append(remove, k)
-		}
-	}
-	sort.Strings(add)
-	sort.Strings(remove)
-	return add, remove
 }
 
 func toFlags(kw []string) []imap.Flag {

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -370,7 +370,10 @@ func (s *Syncer) reconcileKeywords() {
 		return
 	}
 	for _, m := range dirty {
-		// Additive re-apply (reconcile has the wanted set, not a delta).
+		// Additive re-apply: reconcile has the wanted set, not a delta, so a
+		// failed immediate label REMOVE is NOT reconciled (the label lingers
+		// upstream). Deliberate — acceptable for the add-dominated labeling flow;
+		// the deferred convergent read-side / go-imap upstream swap cleans it up.
 		if err := s.WriteKeywords(s.owner, m.ID, m.Keywords, nil); err != nil {
 			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
 			continue

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -275,7 +275,8 @@ func upstreamKeywords(t *testing.T, addr string, uid uint32) []string {
 }
 
 // WriteKeywords replicates a keyword set to the upstream over a separate session,
-// converging by add/remove delta (ADR 0020 write-through).
+// applies an add/remove keyword delta to the upstream (plain-keyword path, no
+// X-GM-EXT-1 on the memserver; ADR 0020 write-through).
 func TestWriteKeywordsToUpstream(t *testing.T) {
 	addr, user := startUpstream(t)
 	appendMsg(t, user, "Subject: x\r\n\r\ny") // upstream UID 1
@@ -287,12 +288,40 @@ func TestWriteKeywordsToUpstream(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 
-	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, []string{"useless", "handled"}))
+	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, []string{"useless", "handled"}, nil))
 	assert.ElementsMatch(t, []string{"useless", "handled"}, upstreamKeywords(t, addr, 1))
 
-	// Converges: removing one upstream.
-	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, []string{"handled"}))
+	// Removing one via the delta.
+	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, nil, []string{"useless"}))
 	assert.ElementsMatch(t, []string{"handled"}, upstreamKeywords(t, addr, 1))
+}
+
+// WriteKeywords routes to the label store when set, and falls back to plain
+// keywords when the label store reports the backend isn't Gmail (ErrNotXGM).
+func TestWriteKeywordsRoutesToLabelStore(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: x\r\n\r\ny")
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	msgs, err := store.List("agent")
+	require.NoError(t, err)
+	id := msgs[0].ID
+
+	// Label store handles it → no plain-keyword STORE to upstream.
+	var gotUID uint32
+	var gotAdd []string
+	syncer.SetLabelStore(func(uid, _ uint32, add, remove []string) error { gotUID, gotAdd = uid, add; return nil })
+	require.NoError(t, syncer.WriteKeywords("agent", id, []string{"useless"}, nil))
+	assert.Equal(t, uint32(1), gotUID)
+	assert.Equal(t, []string{"useless"}, gotAdd)
+	assert.Empty(t, upstreamKeywords(t, addr, 1)) // went the label path, not keywords
+
+	// ErrNotXGM → fall back to a plain keyword STORE.
+	syncer.SetLabelStore(func(uid, _ uint32, add, remove []string) error { return imapsync.ErrNotXGM })
+	require.NoError(t, syncer.WriteKeywords("agent", id, []string{"plainkw"}, nil))
+	assert.ElementsMatch(t, []string{"plainkw"}, upstreamKeywords(t, addr, 1))
 }
 
 // A dirty keyword set (a failed immediate write) is reconciled to upstream on the

--- a/internal/imapsync/xgmlabels.go
+++ b/internal/imapsync/xgmlabels.go
@@ -1,0 +1,165 @@
+package imapsync
+
+import (
+	"bufio"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// ErrNotXGM means the upstream did not advertise X-GM-EXT-1 (not Gmail), so the
+// caller should fall back to plain IMAP keywords.
+var ErrNotXGM = errors.New("imapsync: backend does not support X-GM-LABELS")
+
+// LabelStoreFunc replicates a label change to a Gmail backend via X-GM-LABELS, by
+// the message's upstream UID. It returns ErrNotXGM when the backend isn't Gmail
+// (the caller then falls back to plain keywords). add/remove are label names.
+type LabelStoreFunc func(uid, uidValidity uint32, add, remove []string) error
+
+// RawGmailLabelStore builds a LabelStoreFunc that applies +/-X-GM-LABELS over a
+// dedicated raw IMAP session (ADR 0020 20c). go-imap/v2 has no X-GM-LABELS
+// support and no extension hook, so this speaks the few needed commands directly
+// — it is the narrow label-write exception to read-only upstream, reusing the
+// app password. Write-only: it never reads/parses X-GM-LABELS. Capability-gated
+// (X-GM-EXT-1); on any other backend it reports ErrNotXGM and the caller uses
+// plain keywords. Tracking issue #101 covers swapping this for upstream go-imap
+// support when it lands.
+func RawGmailLabelStore(addr, username, password, mailbox string) LabelStoreFunc {
+	host := addr
+	if i := strings.LastIndex(addr, ":"); i > 0 {
+		host = addr[:i]
+	}
+	dial := func() (net.Conn, error) { return tls.Dial("tcp", addr, &tls.Config{ServerName: host}) }
+	return newLabelStore(dial, username, password, mailbox)
+}
+
+// newLabelStore is the dialer-injected core of RawGmailLabelStore (production
+// uses a TLS dialer; tests inject a plaintext one).
+func newLabelStore(dial func() (net.Conn, error), username, password, mailbox string) LabelStoreFunc {
+	return func(uid, _ uint32, add, remove []string) error {
+		if len(add) == 0 && len(remove) == 0 {
+			return nil
+		}
+		rc, err := dialRaw(dial)
+		if err != nil {
+			return err
+		}
+		defer rc.close()
+
+		if err := rc.do("a1", fmt.Sprintf("LOGIN %s %s", imapQuote(username), imapQuote(password))); err != nil {
+			return err
+		}
+		caps, err := rc.collect("a2", "CAPABILITY")
+		if err != nil {
+			return err
+		}
+		if !hasCap(caps, "X-GM-EXT-1") {
+			return ErrNotXGM
+		}
+		if err := rc.do("a3", fmt.Sprintf("SELECT %s", imapQuote(mailbox))); err != nil {
+			return err
+		}
+		if len(add) > 0 {
+			if err := rc.do("a4", fmt.Sprintf("UID STORE %d +X-GM-LABELS (%s)", uid, labelList(add))); err != nil {
+				return err
+			}
+		}
+		if len(remove) > 0 {
+			if err := rc.do("a5", fmt.Sprintf("UID STORE %d -X-GM-LABELS (%s)", uid, labelList(remove))); err != nil {
+				return err
+			}
+		}
+		_ = rc.do("a6", "LOGOUT")
+		return nil
+	}
+}
+
+// rawConn is a minimal IMAP client: just enough to log in, select, and issue a
+// fixed handful of commands, reading each tagged response. It deliberately does
+// not parse untagged data beyond capability scanning.
+type rawConn struct {
+	conn net.Conn
+	r    *bufio.Reader
+}
+
+func dialRaw(dial func() (net.Conn, error)) (*rawConn, error) {
+	conn, err := dial()
+	if err != nil {
+		return nil, fmt.Errorf("imapsync: xgm dial: %w", err)
+	}
+	rc := &rawConn{conn: conn, r: bufio.NewReader(conn)}
+	if _, err := rc.r.ReadString('\n'); err != nil { // server greeting
+		_ = conn.Close()
+		return nil, fmt.Errorf("imapsync: xgm greeting: %w", err)
+	}
+	return rc, nil
+}
+
+func (rc *rawConn) close() { _ = rc.conn.Close() }
+
+// do sends a tagged command and waits for its tagged completion, discarding
+// untagged data. A non-OK completion is an error.
+func (rc *rawConn) do(tag, cmd string) error {
+	_, err := rc.collect(tag, cmd)
+	return err
+}
+
+// collect sends a tagged command and returns the untagged response lines up to
+// the tagged completion (used to read CAPABILITY).
+func (rc *rawConn) collect(tag, cmd string) ([]string, error) {
+	if _, err := fmt.Fprintf(rc.conn, "%s %s\r\n", tag, cmd); err != nil {
+		return nil, fmt.Errorf("imapsync: xgm write: %w", err)
+	}
+	var untagged []string
+	for {
+		line, err := rc.r.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("imapsync: xgm read: %w", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if rest, ok := strings.CutPrefix(line, tag+" "); ok {
+			if strings.HasPrefix(rest, "OK") {
+				return untagged, nil
+			}
+			return nil, fmt.Errorf("imapsync: xgm %q: %s", firstWord(cmd), rest)
+		}
+		untagged = append(untagged, line)
+	}
+}
+
+func hasCap(lines []string, want string) bool {
+	for _, l := range lines {
+		for _, tok := range strings.Fields(l) {
+			if strings.EqualFold(tok, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// labelList renders label names as a space-separated, individually-quoted list
+// for an X-GM-LABELS parenthesized argument.
+func labelList(labels []string) string {
+	parts := make([]string, len(labels))
+	for i, l := range labels {
+		parts[i] = imapQuote(l)
+	}
+	return strings.Join(parts, " ")
+}
+
+// imapQuote renders an IMAP quoted-string (RFC 3501), escaping " and \.
+func imapQuote(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
+}
+
+func firstWord(s string) string {
+	if i := strings.IndexByte(s, ' '); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/internal/imapsync/xgmlabels_internal_test.go
+++ b/internal/imapsync/xgmlabels_internal_test.go
@@ -1,0 +1,50 @@
+package imapsync
+
+import (
+	"bytes"
+	"net"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+	"github.com/stretchr/testify/require"
+)
+
+// The raw label writer reports ErrNotXGM against a server with no X-GM-EXT-1
+// (the in-process memserver), exercising the session mechanics over plaintext:
+// dial → greeting → LOGIN → CAPABILITY → capability gate. The actual
+// X-GM-LABELS STORE only runs on a Gmail backend and is live-verified.
+func TestLabelStoreNotGmail(t *testing.T) {
+	user := imapmemserver.NewUser("u", "p")
+	require.NoError(t, user.Create("INBOX", nil))
+	_, err := user.Append("INBOX", bytes.NewReader([]byte("Subject: x\r\n\r\ny")), &imap.AppendOptions{})
+	require.NoError(t, err)
+	mem := imapmemserver.New()
+	mem.AddUser(user)
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return mem.NewSession(), nil, nil
+		},
+		InsecureAuth: true,
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = ln.Close() })
+
+	ls := newLabelStore(
+		func() (net.Conn, error) { return net.Dial("tcp", ln.Addr().String()) },
+		"u", "p", "INBOX",
+	)
+	err = ls(1, 1, []string{"useless"}, nil)
+	require.ErrorIs(t, err, ErrNotXGM)
+}
+
+func TestImapQuote(t *testing.T) {
+	require.Equal(t, `"useless"`, imapQuote("useless"))
+	require.Equal(t, `"a b"`, imapQuote("a b"))
+	require.Equal(t, `"a\"b"`, imapQuote(`a"b`))
+	require.Equal(t, `"a\\b"`, imapQuote(`a\b`))
+	require.Equal(t, `"x" "y z"`, labelList([]string{"x", "y z"}))
+}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -39,11 +39,12 @@ type IMAPServerConfig struct {
 // (lazy, ADR 0019). It is called per-FETCH, never at SELECT.
 type ContentFetch func(owner, id string) (inbound.Message, error)
 
-// KeywordWriter replicates a message's keyword set to the upstream backend (the
-// label write-through, ADR 0020). The local store is canonical; a returned error
-// means the upstream replicate failed and is reconciled later. nil disables
-// write-through (local-only labels — e.g. sync disabled).
-type KeywordWriter func(owner, id string, want []string) error
+// KeywordWriter replicates a keyword change to the upstream backend as an
+// add/remove delta (the label write-through, ADR 0020). The local store is
+// canonical; a returned error means the upstream replicate failed and is
+// reconciled later. nil disables write-through (local-only labels — e.g. sync
+// disabled).
+type KeywordWriter func(owner, id string, add, remove []string) error
 
 // IMAPServer serves the agent's mailbox (the InboundStore) over IMAP as a
 // translation adapter (ADR 0016): the store is canonical. SELECT snapshots
@@ -289,7 +290,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 				// Skip records with no upstream (locally-generated, e.g. bounces) —
 				// their labels are local-only, nothing to replicate.
 				if s.writeKeywords != nil && m.UpstreamUID != 0 {
-					if err := s.writeKeywords(s.owner, m.ID, next); err != nil {
+					if err := s.writeKeywords(s.owner, m.ID, added, removed); err != nil {
 						log.Printf("darbaan: imap keyword write-through for %s deferred: %v", m.ID, err)
 					} else {
 						_ = s.store.ClearKeywordsDirty(s.owner, m.ID)

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -322,8 +322,8 @@ func TestIMAPStoreKeywordWritesThrough(t *testing.T) {
 	require.NoError(t, err)
 
 	var wroteID string
-	var wrote []string
-	wk := func(owner, id string, want []string) error { wroteID, wrote = id, want; return nil }
+	var wroteAdd []string
+	wk := func(owner, id string, add, remove []string) error { wroteID, wroteAdd = id, add; return nil }
 
 	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
 	require.NoError(t, err)
@@ -339,7 +339,7 @@ func TestIMAPStoreKeywordWritesThrough(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string{"useless"}, got.Keywords) // local store is canonical
 	assert.Equal(t, m.ID, wroteID)
-	assert.Equal(t, []string{"useless"}, wrote) // replicated the new set upstream
+	assert.Equal(t, []string{"useless"}, wroteAdd) // replicated the add delta upstream
 	dirty, err := store.DirtyKeywords("agent")
 	require.NoError(t, err)
 	assert.Empty(t, dirty) // cleared on successful replicate
@@ -354,7 +354,7 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1})
 	require.NoError(t, err)
 
-	wk := func(owner, id string, want []string) error { return errors.New("upstream down") }
+	wk := func(owner, id string, add, remove []string) error { return errors.New("upstream down") }
 
 	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
 	require.NoError(t, err)
@@ -381,7 +381,7 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 func TestIMAPStoreKeywordLocalOnlyNoUpstream(t *testing.T) {
 	store := seedInbound(t) // a bounce: Add → no UpstreamUID, seq 1
 	called := false
-	wk := func(owner, id string, want []string) error { called = true; return nil }
+	wk := func(owner, id string, add, remove []string) error { called = true; return nil }
 
 	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**ADR 0020, increment 20c** — Gmail X-GM-LABELS write-through. Agent keyword changes become **real, searchable Gmail labels** (`label:useless`), not just IMAP keyword flags (20b verify: a plain keyword persists on Gmail but never becomes a label; raw `+X-GM-LABELS` does). closes #101.

## What
- New isolated raw IMAP writer (`xgmlabels.go`): go-imap/v2 has no X-GM-LABELS support + no extension hook, so it speaks the few needed commands directly (LOGIN / CAPABILITY / SELECT / UID STORE ±X-GM-LABELS), **capability-gated on X-GM-EXT-1**, reusing the app password. **Write-only** (never reads/parses X-GM-LABELS). Dialer injected (prod TLS; tests plaintext).
- **`WriteKeywords` is delta-based + routes**: Gmail backend → X-GM-LABELS; any other backend → writer reports `ErrNotXGM` → falls back to the plain RFC3501 keyword STORE. Read face passes the agent add/remove delta; reconcile re-applies additively.
- serve wires the writer (capability-gated → no-op on non-Gmail).

## Scope / follow-ups
- **Read side deferred** (surfacing EXISTING Gmail labels as keywords) — the need is write.
- An **upstream go-imap X-GM-LABELS contribution** remains the eventual swap-in to retire this raw writer (I'll open it as a separate effort; it forks/PRs another repo).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: `ErrNotXGM` gate over a plaintext in-process server (dial/login/capability mechanics); `imapQuote`/`labelList`; `WriteKeywords` routes to the label store + falls back on `ErrNotXGM`; plain-keyword delta to upstream; reconcile. **The real Gmail label is your live-verify** (agent tags `useless` → `label:useless` findable).
