### PR TITLE
chore(cmd): always-compile the manual approver, drop the build-tag (part of #50)

### DIFF
--- a/cmd/darbaan/approvers.go
+++ b/cmd/darbaan/approvers.go
@@ -1,9 +1,7 @@
-//go:build !no_manual_approver
-
 package main
 
-// Compile in the manual (human) approver by registering it via blank import
-// (ADR 0004). Build with -tags no_manual_approver to exclude it; with no
-// approver compiled in, the approval chain fails closed and nothing can be
-// approved.
+// Register the manual (human) approver via blank import. It is always compiled
+// in; approver selection is a runtime concern (the approval-strict/-light chains,
+// ADR 0017), not a build-time one. The chain is fail-closed: with no approver
+// registered for a path, nothing on it can be approved.
 import _ "github.com/yaad-index/darbaan/internal/approver/manual"

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -43,8 +43,8 @@ func New(dial DialFunc, mailbox, owner string, store inbound.InboundStore, state
 }
 
 // Dialer is the production DialFunc: TLS-connect to addr and log in with the
-// Darbaan-held upstream credentials. The connection is exercised live (Inc 2);
-// the engine is tested with an injected DialFunc.
+// Darbaan-held upstream credentials. The engine is tested with an injected
+// DialFunc against an in-process server.
 func Dialer(addr, username, password string) DialFunc {
 	return func() (*imapclient.Client, error) {
 		c, err := imapclient.DialTLS(addr, nil)

--- a/internal/imapsync/xgmlabels.go
+++ b/internal/imapsync/xgmlabels.go
@@ -24,8 +24,8 @@ type LabelStoreFunc func(uid, uidValidity uint32, add, remove []string) error
 // — it is the narrow label-write exception to read-only upstream, reusing the
 // app password. Write-only: it never reads/parses X-GM-LABELS. Capability-gated
 // (X-GM-EXT-1); on any other backend it reports ErrNotXGM and the caller uses
-// plain keywords. Tracking issue #101 covers swapping this for upstream go-imap
-// support when it lands.
+// plain keywords. Issue #103 tracks swapping this for upstream go-imap support
+// when it lands.
 func RawGmailLabelStore(addr, username, password, mailbox string) LabelStoreFunc {
 	host := addr
 	if i := strings.LastIndex(addr, ":"); i > 0 {


### PR DESCRIPTION
Behavior-identical cleanup (part of #50).

- **Drop the `//go:build !no_manual_approver` build-tag** (`cmd/darbaan/approvers.go`): the manual approver was already compiled by default; this opt-out was the last compile-time plugin selection, superseded by runtime approver chains (ADR 0017). Now unconditionally registered; selection stays runtime (`approval-strict`/`-light`), chain remains **fail-closed**.
- Trim two stale build-era comments: an `(Inc 2)` increment marker, and a now-closed `#101` ref → live follow-up `#103`.

The inbound sweep (imapsync/inbound/listener) found nothing else — no TODO/FIXME/debug, lint clean.

**Part of #50** — the ADR 0004/0005 compile-time-plugin note refresh follows in the docs pass (hard-gate), where #50 closes. Verified: builds default + with the now-inert `-tags no_manual_approver`; vet/race/lint green.
