### PR TITLE
docs: rewrite README to current state + refresh ADR 0004/0005 (closes #50)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,97 @@
 # Darbaan
 
-Darbaan is a mail-gate proxy. Agents talk to it over standard IMAP (read) and
-SMTP (send), and it enforces policy mechanically in front of the real mailboxes.
-Outbound mail is trapped in a default-deny sluice and released only after an
-approval pass; inbound mail is filtered by declarative rules. Darbaan holds the
-real mailbox credentials and the bounce-signing key, so a compromised agent only
-ever holds Darbaan credentials — never the upstream mailbox.
+Darbaan is a **mail-gate proxy**. An agent talks to it over standard **IMAP
+(read)** and **SMTP (send)**, and Darbaan enforces policy mechanically in front
+of the real mailbox. It holds the upstream mailbox credentials and the
+bounce-signing key, so a compromised agent only ever holds *Darbaan* credentials
+— never the real mailbox (credential isolation, [ADR 0002](adr/0002-policy-in-a-separate-box-credential-isolation.md)).
 
-This repository is the v1 skeleton; no behavior is wired yet. The design is
-recorded as Architecture Decision Records in [`adr/`](adr/) — start with
-[ADR 0001](adr/0001-mail-proxy-not-http-api.md).
+The design is recorded as Architecture Decision Records in [`adr/`](adr/) — start
+with [ADR 0001](adr/0001-mail-proxy-not-http-api.md).
+
+## Outbound — default-deny send
+
+An agent submits over SMTP; nothing leaves until it's approved.
+
+1. **Sluice trap.** Every submission is trapped in a default-deny sluice
+   ([ADR 0003](adr/0003-outbound-sluice-trap-default-deny.md)) — held, not sent.
+2. **Approval.** A pluggable approval chain ([ADR 0004](adr/0004-pluggable-approval-pipeline.md))
+   decides each held message. Approval is operator-driven (see the clients below).
+3. **Release or reject.** On approval Darbaan sends via the upstream; on rejection
+   it returns a **DKIM-signed DSN bounce** ([ADR 0006](adr/0006-rejection-as-async-dsn-bounce.md),
+   [ADR 0007](adr/0007-signed-bounce-trust.md)) that the agent reads back over IMAP.
+
+> The upstream sender is **stub by default** — it sends *nothing*. Real delivery is
+> a deliberate opt-in (`sender-type=smtp` + an app password); until then the
+> default-deny holds structurally.
+
+## Inbound — read the real mailbox, gated
+
+The agent reads its real mail *through* Darbaan ([ADR 0019](adr/0019-inbound-sync-store-canonical-lazy-no-filter.md)):
+
+- **Store-canonical incremental sync.** Darbaan pulls from the upstream mailbox
+  into its own store (UIDVALIDITY + cursor, idempotent re-sync). The upstream is
+  read-only except for label writes (below).
+- **Lazy content.** Headers/envelopes are synced eagerly; a message **body is
+  fetched on demand** the first time it's read, then cached. Listing the inbox
+  fetches zero bodies.
+- **Recency cutoff.** `inbound-max-age` (e.g. `1y`) bounds the sync to recent mail
+  ([ADR 0008](adr/0008-inbound-filter-yaml-rules.md), recency dimension), so a
+  deep mailbox doesn't pull decades of history.
+- **IMAP read face.** The synced mail is served back over IMAP.
+- **Agent labeling.** The agent labels mail via standard IMAP keywords
+  ([ADR 0020](adr/0020-agent-labeling-gmail-x-gm-labels.md)); on a Gmail backend
+  those map to real **X-GM-LABELS** (searchable as `label:...`), with the local
+  store canonical and the backend an eventually-consistent label replica.
+
+> The structured allow/hide/hold **inbound filter rules** (the rest of ADR 0008)
+> are still upcoming; v1 syncs the (recency-bounded) mailbox without per-message
+> rule evaluation.
+
+## Interfaces — clients over a local admin API
+
+`serve` runs the SMTP + IMAP faces and a **localhost-only admin API**. The
+operator-facing interfaces are **separate processes** that talk to that API
+([ADR 0017](adr/0017-interfaces-as-clients-over-local-api.md)), not compiled into
+the core:
+
+- **CLI** — `darbaan queue …` inspects and decides held messages.
+- **Telegram** — `darbaan telegram` notifies + approves/rejects from a phone.
+
+## Storage
+
+Tiered ([ADR 0018](adr/0018-tiered-storage-metadata-kv-content-filesystem.md)):
+message metadata lives in bbolt; raw content lives as filesystem blobs, written
+blob-first then metadata so a crash can only orphan a blob (swept at startup).
+The store is the canonical source; the IMAP/SMTP faces are translation adapters
+([ADR 0016](adr/0016-store-canonical-translation-faces.md)). An append-only audit
+log ([ADR 0011](adr/0011-append-only-audit-log.md)) records decisions.
+
+## Running it
+
+Darbaan is a single Go binary; the easiest deploy is Docker Compose. See
+[`docker-compose.yml`](docker-compose.yml) and [`.env.example`](.env.example).
+
+```sh
+cp .env.example .env        # fill DARBAAN_AGENT_PASS, DARBAAN_ADMIN_TOKEN
+# put a TLS cert+key in ./secrets/tls/ and an ed25519 DKIM key in ./secrets/dkim/
+docker compose up -d
+```
+
+Key configuration (file `<` env `<` flag; full list via `darbaan --help`):
+
+| Setting | Env | Purpose |
+|---|---|---|
+| agent credential | `DARBAAN_AGENT_USERNAME` / `DARBAAN_AGENT_PASS` | the agent's IMAP/SMTP login to Darbaan |
+| admin token | `DARBAAN_ADMIN_TOKEN` | bearer token for the localhost admin API |
+| sender | `sender-type` (`stub`/`smtp`) + `DARBAAN_SMTP_PASSWORD` | upstream delivery; **stub by default** |
+| DKIM | `DARBAAN_DKIM_KEY_FILE` / `dkim-selector` / `dkim-domain` | bounce signing |
+| inbound sync | `DARBAAN_INBOUND_IMAP_HOST` / `…_USERNAME` / `DARBAAN_INBOUND_IMAP_PASSWORD` | upstream mailbox to sync (empty = sync off) |
+| recency cutoff | `inbound-max-age` (e.g. `1y`) | bound the initial sync to recent mail |
+
+Ports bind to `127.0.0.1` only — Darbaan is a local-trusted-host service, not
+internet-facing. Secrets come from env/mounts, never the image
+([ADR 0012](adr/0012-deployment-and-secrets-at-rest.md)).
 
 ## License
 

--- a/adr/0004-pluggable-approval-pipeline.md
+++ b/adr/0004-pluggable-approval-pipeline.md
@@ -27,3 +27,12 @@ window, the message is **not** sent; it stays queued. A timeout never
 auto-sends, consistent with default-deny (ADR 0003). Operators may configure
 escalation or an explicit expiry-to-rejected (which then bounces per ADR 0006),
 but the default on timeout is "keep waiting," never "send."
+
+## Amendment (2026-06-27): compile-time selection removed
+The "compile time (Go build tags)" half of approver selection is gone. ADR 0017
+made the interfaces runtime clients over the local admin API, and the last build
+tag (`no_manual_approver`) was dropped (#50). Approvers are now **always
+compiled in** and selected purely at **runtime** via the configured chains
+(`approval-strict` / `approval-light`). The blank-import registry stays; only the
+build-tag gating is removed. The chain remains fail-closed — a path with no
+approver registered approves nothing.

--- a/adr/0005-agent-prescreener-plugin-risk-routing.md
+++ b/adr/0005-agent-prescreener-plugin-risk-routing.md
@@ -25,3 +25,11 @@ medium/high or any flag → the **strict** chain, per a configured routing table
 The pre-screener runs as the mandatory first stage when compiled in. **If it is
 not compiled in, the router defaults to the strict chain** (fail-safe) — absence
 of a risk signal is treated as "could be risky," never as "low."
+
+## Amendment (2026-06-27): no longer compile-time
+The pre-screener is no longer selected via a build tag — ADR 0004's compile-time
+mechanism was removed (#50), superseded by ADR 0017's runtime clients. It remains
+"just another approver," now selected at **runtime** via the approval chains; the
+"compile-time plugin" framing in the title and decision above is historical. The
+fail-safe still holds: when no pre-screener is registered, the router defaults to
+the strict chain.


### PR DESCRIPTION
**Docs pass — closes #50.** Hard-gate (docs + ADR → maintainer GitHub approval + 2-of-N agents).

## README rewrite
It still said *"v1 skeleton, no behavior wired yet"* — badly stale. Rewritten honestly to current state:
- What Darbaan is + credential isolation (ADR 0002).
- **Outbound**: default-deny sluice → approval chain → send / DKIM-signed DSN bounce; **sender stub-by-default** (sends nothing until the opt-in).
- **Inbound**: store-canonical sync → lazy content (headers eager, body on-demand) → recency cutoff (`inbound-max-age`) → IMAP read face → labeling via keywords→Gmail X-GM-LABELS; **structured filter rules noted as still upcoming**.
- Interfaces (admin API + CLI/Telegram clients, ADR 0017), tiered storage, audit log, docker-compose + key env vars, loopback-only, ADR index pointer.

## ADR 0004/0005
Amendment notes recording the compile-time approver build-tag removal (#50) — approvers always compiled, selection runtime (ADR 0017), chain still fail-closed. **Decisions left intact**; history preserved via amendments per ADR convention (not a rewrite).

All ADR links verified against `adr/`. Kept honest per the scope (no overclaiming).
