### PR TITLE
feat(filter): inbound filter engine + serve-time allow/hide (ADR 0021 21a)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/imapsync"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/listener"
@@ -82,6 +83,7 @@ type CLI struct {
 	InboundIMAPPollInterval time.Duration `name:"inbound-imap-poll-interval" default:"60s" help:"How often to poll the upstream mailbox for new mail."`
 	InboundSyncDB           string        `name:"inbound-sync-db" default:"darbaan-sync.db" help:"Path to the inbound sync-state (UIDVALIDITY + last UID) database." type:"path"`
 	InboundMaxAge           string        `name:"inbound-max-age" help:"Recency cutoff for the initial/full sync, e.g. 1y, 30d, 12h (ADR 0008). Empty = no cutoff (pull everything). Forward-only: widening it later needs a re-sync."`
+	InboundFilter           string        `name:"inbound-filter" help:"Path to the inbound filter rules (YAML, ADR 0021): serve-time allow/hide over synced mail. Empty = no filter (allow all)." type:"path"`
 
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
@@ -375,11 +377,15 @@ func (*ServeCmd) Run(cli *CLI) error {
 	}
 	defer stopSync()
 
+	flt, err := filter.Load(cli.InboundFilter)
+	if err != nil {
+		return err
+	}
 	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer))
+	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer), flt)
 	if err != nil {
 		return err
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,9 @@ services:
       # Forward-only: widening it later needs a re-sync (old UIDs are behind the
       # cursor). Bounds both the store and the first pull on a deep mailbox.
       # DARBAAN_INBOUND_MAX_AGE: "1y"
+      # Inbound filter rules (ADR 0021): serve-time allow/hide over synced mail.
+      # Mount a YAML rules file and point at it; empty = no filter (allow all).
+      # DARBAAN_INBOUND_FILTER: /etc/darbaan/inbound-filter.yaml
       DARBAAN_INBOUND_IMAP_PASSWORD: "${DARBAAN_INBOUND_IMAP_PASSWORD:-}"
     volumes:
       - darbaan-data:/data # the three bbolt DBs (sluice / audit / inbound)

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,0 +1,226 @@
+package filter
+
+import (
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// Action is a rule outcome (ADR 0008/0021).
+type Action string
+
+const (
+	Allow Action = "allow"
+	Hide  Action = "hide"
+	Hold  Action = "hold-for-human"
+)
+
+// Match fields and operators (ADR 0021). v1 matches metadata only — never the
+// body. `header` is restricted to envelope headers (the stored set).
+const (
+	fieldFrom    = "from"
+	fieldTo      = "to"
+	fieldCc      = "cc"
+	fieldSubject = "subject"
+	fieldHeader  = "header"
+	fieldLabel   = "label"
+	fieldAge     = "age"
+
+	opEquals    = "equals"
+	opContains  = "contains"
+	opRegex     = "regex"
+	opDomain    = "domain"
+	opOlderThan = "older_than" // age fields only
+	opNewerThan = "newer_than" // age fields only
+)
+
+// envelopeHeaders are the only headers matchable in v1 (the stored envelope set);
+// an arbitrary header would require the body, which v1 excludes.
+var envelopeHeaders = map[string]bool{
+	"from": true, "to": true, "cc": true, "subject": true,
+	"date": true, "message-id": true, "reply-to": true,
+}
+
+// Filter is a compiled, ordered rule set evaluated top-down, first-match-wins,
+// with a configurable default action on no match. It is evaluated fresh per serve
+// (no caching of rule-derived verdicts), so an edited rule set takes effect on
+// the next serve after a restart.
+type Filter struct {
+	rules []rule
+	def   Action
+}
+
+type rule struct {
+	conds  []cond
+	action Action
+}
+
+type cond struct {
+	field  string
+	header string // lower-cased header name when field == header
+	op     string
+	value  string         // lower-cased for string ops
+	re     *regexp.Regexp // compiled when op == regex
+	dur    time.Duration  // parsed when field == age
+}
+
+// Decide returns the action for a message: the first matching rule's action, or
+// the default. now is injected so callers (and tests) control the age clock.
+func (f *Filter) Decide(m inbound.Message, now time.Time) Action {
+	if f == nil {
+		return Allow
+	}
+	for _, r := range f.rules {
+		if r.matches(m, now) {
+			return r.action
+		}
+	}
+	return f.def
+}
+
+// Default returns the no-match action.
+func (f *Filter) Default() Action {
+	if f == nil {
+		return Allow
+	}
+	return f.def
+}
+
+func (r rule) matches(m inbound.Message, now time.Time) bool {
+	for _, c := range r.conds { // conditions are AND-ed
+		if !c.matches(m, now) {
+			return false
+		}
+	}
+	return true
+}
+
+func (c cond) matches(m inbound.Message, now time.Time) bool {
+	if c.field == fieldAge {
+		age := now.Sub(m.ReceivedAt)
+		if c.op == opOlderThan {
+			return age > c.dur
+		}
+		return age < c.dur // opNewerThan
+	}
+	for _, v := range fieldValues(m, c.field, c.header) {
+		if c.opMatch(v) {
+			return true // any candidate value matches (e.g. one of several recipients)
+		}
+	}
+	return false
+}
+
+func (c cond) opMatch(v string) bool {
+	switch c.op {
+	case opEquals:
+		return strings.EqualFold(v, c.value)
+	case opContains:
+		return strings.Contains(strings.ToLower(v), c.value)
+	case opRegex:
+		return c.re.MatchString(v)
+	case opDomain:
+		return strings.EqualFold(domainOf(v), c.value)
+	}
+	return false
+}
+
+// fieldValues returns the candidate match strings for a field. Address fields
+// yield mailbox@host strings (from the stored envelope when present, else the
+// formatted header string); header fields resolve to their envelope value.
+func fieldValues(m inbound.Message, field, header string) []string {
+	switch field {
+	case fieldFrom:
+		return addrValues(m.Envelope, envFrom, m.From)
+	case fieldTo:
+		return addrValues(m.Envelope, envTo, m.To)
+	case fieldCc:
+		return addrValues(m.Envelope, envCc, "")
+	case fieldSubject:
+		return []string{m.Subject}
+	case fieldLabel:
+		return m.Keywords
+	case fieldHeader:
+		return headerValues(m, header)
+	}
+	return nil
+}
+
+type envSel int
+
+const (
+	envFrom envSel = iota
+	envTo
+	envCc
+)
+
+// addrValues yields "mailbox@host" strings for an address field, preferring the
+// stored structured envelope; for records with no envelope (e.g. bounces) it
+// falls back to the formatted header string.
+func addrValues(e *inbound.Envelope, sel envSel, fallback string) []string {
+	if e != nil {
+		var as []inbound.Address
+		switch sel {
+		case envFrom:
+			as = e.From
+		case envTo:
+			as = e.To
+		case envCc:
+			as = e.Cc
+		}
+		if len(as) > 0 {
+			out := make([]string, 0, len(as))
+			for _, a := range as {
+				out = append(out, a.Mailbox+"@"+a.Host)
+			}
+			return out
+		}
+	}
+	if fallback != "" {
+		return []string{fallback}
+	}
+	return nil
+}
+
+func headerValues(m inbound.Message, header string) []string {
+	switch header {
+	case "from":
+		return addrValues(m.Envelope, envFrom, m.From)
+	case "to":
+		return addrValues(m.Envelope, envTo, m.To)
+	case "cc":
+		return addrValues(m.Envelope, envCc, "")
+	case "subject":
+		return []string{m.Subject}
+	}
+	if m.Envelope == nil {
+		return nil
+	}
+	switch header {
+	case "date":
+		if m.Envelope.Date.IsZero() {
+			return nil
+		}
+		return []string{m.Envelope.Date.Format(time.RFC1123Z)}
+	case "message-id":
+		return []string{m.Envelope.MessageID}
+	case "reply-to":
+		out := make([]string, 0, len(m.Envelope.ReplyTo))
+		for _, a := range m.Envelope.ReplyTo {
+			out = append(out, a.Mailbox+"@"+a.Host)
+		}
+		return out
+	}
+	return nil
+}
+
+// domainOf extracts the domain from an address ("mailbox@host" or "Name <a@b>").
+func domainOf(addr string) string {
+	addr = strings.TrimSuffix(addr, ">")
+	if i := strings.LastIndex(addr, "@"); i >= 0 {
+		return addr[i+1:]
+	}
+	return ""
+}

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -1,0 +1,96 @@
+package filter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/filter"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+func from(host string) *inbound.Envelope {
+	return &inbound.Envelope{From: []inbound.Address{{Mailbox: "x", Host: host}}}
+}
+
+func TestFilterDecide(t *testing.T) {
+	rules := `
+default: allow
+rules:
+  - match:
+      - {field: from, op: domain, value: spam.example}
+    action: hide
+  - match:
+      - {field: label, op: equals, value: useless}
+    action: hide
+  - match:
+      - {field: subject, op: contains, value: newsletter}
+      - {field: from, op: domain, value: news.example}
+    action: hold-for-human
+  - match:
+      - {field: age, op: older_than, value: 30d}
+    action: hide
+`
+	f, err := filter.Compile([]byte(rules))
+	require.NoError(t, err)
+	now := time.Now()
+
+	// from-domain → hide
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{Envelope: from("spam.example"), ReceivedAt: now}, now))
+	// label → hide
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{Keywords: []string{"useless"}, ReceivedAt: now}, now))
+	// subject AND from → hold (both conditions met)
+	assert.Equal(t, filter.Hold, f.Decide(inbound.Message{Subject: "Weekly Newsletter", Envelope: from("news.example"), ReceivedAt: now}, now))
+	// subject matches but from-domain doesn't → AND fails → default allow
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Subject: "Weekly Newsletter", Envelope: from("other.example"), ReceivedAt: now}, now))
+	// old message → hide (age)
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{ReceivedAt: now.Add(-60 * 24 * time.Hour)}, now))
+	// recent, unmatched → default allow
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Subject: "hi", ReceivedAt: now}, now))
+}
+
+func TestFilterFirstMatchWins(t *testing.T) {
+	f, err := filter.Compile([]byte(`
+default: hide
+rules:
+  - match: [{field: from, op: domain, value: trusted.example}]
+    action: allow
+  - match: [{field: subject, op: contains, value: x}]
+    action: hide
+`))
+	require.NoError(t, err)
+	now := time.Now()
+	// first rule (allow) wins even though the second would hide
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Subject: "xx", Envelope: from("trusted.example"), ReceivedAt: now}, now))
+	// no rule matches → default hide
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{Subject: "yy", Envelope: from("other.example"), ReceivedAt: now}, now))
+}
+
+func TestFilterNilAndEmptyAllow(t *testing.T) {
+	var nilF *filter.Filter
+	assert.Equal(t, filter.Allow, nilF.Decide(inbound.Message{}, time.Now()))
+
+	f, err := filter.Load("") // empty path → pass-through
+	require.NoError(t, err)
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Subject: "anything"}, time.Now()))
+}
+
+func TestFilterValidation(t *testing.T) {
+	bad := []string{
+		"rules: [{match: [{field: from, op: equals, value: a}], action: nope}]",                     // bad action
+		"rules: [{match: [{field: nope, op: equals, value: a}], action: hide}]",                     // bad field
+		"rules: [{match: [{field: from, op: nope, value: a}], action: hide}]",                       // bad op
+		"rules: [{match: [{field: header, header: x-spam, op: contains, value: a}], action: hide}]", // non-envelope header
+		"rules: [{match: [{field: subject, op: domain, value: a}], action: hide}]",                  // domain on non-address
+		"rules: [{match: [{field: subject, op: regex, value: \"(\"}], action: hide}]",               // bad regex
+		"rules: [{match: [{field: age, op: equals, value: 30d}], action: hide}]",                    // bad age op
+		"rules: [{match: [], action: hide}]",                                                        // no conditions
+		"default: bogus",                                                                            // bad default
+	}
+	for _, y := range bad {
+		_, err := filter.Compile([]byte(y))
+		assert.Error(t, err, y)
+	}
+}

--- a/internal/filter/load.go
+++ b/internal/filter/load.go
@@ -1,0 +1,180 @@
+package filter
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// YAML shapes. A filter is `default: <action>` plus an ordered `rules:` list;
+// each rule is `match:` (AND-ed conditions) + one `action:`.
+type fileConfig struct {
+	Default string       `yaml:"default"`
+	Rules   []ruleConfig `yaml:"rules"`
+}
+
+type ruleConfig struct {
+	Match  []condConfig `yaml:"match"`
+	Action string       `yaml:"action"`
+}
+
+type condConfig struct {
+	Field  string `yaml:"field"`
+	Header string `yaml:"header,omitempty"`
+	Op     string `yaml:"op"`
+	Value  string `yaml:"value"`
+}
+
+// Load reads and compiles a filter from a YAML file. An empty path yields a
+// pass-through filter (default allow, no rules) so the filter is off by default.
+func Load(path string) (*Filter, error) {
+	if path == "" {
+		return &Filter{def: Allow}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("filter: read %s: %w", path, err)
+	}
+	f, err := Compile(data)
+	if err != nil {
+		return nil, fmt.Errorf("filter: %s: %w", path, err)
+	}
+	return f, nil
+}
+
+// Compile parses + validates YAML into a Filter. Validation is fail-fast: a bad
+// rule set is a config error at serve start, never a silently-ignored rule.
+func Compile(data []byte) (*Filter, error) {
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("parse: %w", err)
+	}
+
+	def := Allow
+	if fc.Default != "" {
+		a, err := parseAction(fc.Default)
+		if err != nil {
+			return nil, fmt.Errorf("default: %w", err)
+		}
+		def = a
+	}
+
+	f := &Filter{def: def}
+	for i, rc := range fc.Rules {
+		action, err := parseAction(rc.Action)
+		if err != nil {
+			return nil, fmt.Errorf("rule %d: %w", i+1, err)
+		}
+		if len(rc.Match) == 0 {
+			return nil, fmt.Errorf("rule %d: no match conditions", i+1)
+		}
+		r := rule{action: action}
+		for j, cc := range rc.Match {
+			c, err := compileCond(cc)
+			if err != nil {
+				return nil, fmt.Errorf("rule %d condition %d: %w", i+1, j+1, err)
+			}
+			r.conds = append(r.conds, c)
+		}
+		f.rules = append(f.rules, r)
+	}
+	return f, nil
+}
+
+func parseAction(s string) (Action, error) {
+	switch Action(s) {
+	case Allow, Hide, Hold:
+		return Action(s), nil
+	}
+	return "", fmt.Errorf("unknown action %q (allow|hide|hold-for-human)", s)
+}
+
+func compileCond(cc condConfig) (cond, error) {
+	c := cond{field: strings.ToLower(cc.Field), op: strings.ToLower(cc.Op)}
+
+	if c.field == fieldAge {
+		if c.op != opOlderThan && c.op != opNewerThan {
+			return cond{}, fmt.Errorf("age op must be older_than|newer_than, got %q", cc.Op)
+		}
+		d, err := parseDur(cc.Value)
+		if err != nil {
+			return cond{}, err
+		}
+		c.dur = d
+		return c, nil
+	}
+
+	switch c.field {
+	case fieldFrom, fieldTo, fieldCc, fieldSubject, fieldLabel:
+	case fieldHeader:
+		c.header = strings.ToLower(cc.Header)
+		if !envelopeHeaders[c.header] {
+			return cond{}, fmt.Errorf("header %q not matchable in v1 (envelope headers only: from/to/cc/subject/date/message-id/reply-to)", cc.Header)
+		}
+	default:
+		return cond{}, fmt.Errorf("unknown field %q", cc.Field)
+	}
+
+	switch c.op {
+	case opEquals, opContains, opRegex:
+	case opDomain:
+		if !isAddressCond(c.field, c.header) {
+			return cond{}, fmt.Errorf("op domain only applies to address fields")
+		}
+	default:
+		return cond{}, fmt.Errorf("unknown op %q (equals|contains|regex|domain)", cc.Op)
+	}
+
+	if cc.Value == "" {
+		return cond{}, fmt.Errorf("empty value")
+	}
+	if c.op == opRegex {
+		re, err := regexp.Compile(cc.Value)
+		if err != nil {
+			return cond{}, fmt.Errorf("regex: %w", err)
+		}
+		c.re = re
+		c.value = cc.Value
+	} else {
+		c.value = strings.ToLower(cc.Value) // equals/contains/domain are case-insensitive
+	}
+	return c, nil
+}
+
+// isAddressCond reports whether a condition targets an address field (the only
+// fields the `domain` operator applies to).
+func isAddressCond(field, header string) bool {
+	switch field {
+	case fieldFrom, fieldTo, fieldCc:
+		return true
+	case fieldHeader:
+		return header == "from" || header == "to" || header == "cc" || header == "reply-to"
+	}
+	return false
+}
+
+// parseDur parses an age duration: time.ParseDuration units plus calendar d/w/y.
+func parseDur(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty duration")
+	}
+	units := map[byte]time.Duration{
+		'd': 24 * time.Hour,
+		'w': 7 * 24 * time.Hour,
+		'y': 365 * 24 * time.Hour,
+	}
+	if mult, ok := units[s[len(s)-1]]; ok {
+		val, err := strconv.ParseFloat(s[:len(s)-1], 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
+		}
+		return time.Duration(val * float64(mult)), nil
+	}
+	return time.ParseDuration(s)
+}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/emersion/go-imap/v2/imapserver"
 	"github.com/emersion/go-message/textproto"
 
+	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 )
 
@@ -58,7 +59,7 @@ type IMAPServer struct {
 // content on demand; if nil it defaults to reading straight from the store
 // (no upstream — bounce-only / sync-disabled deployments have no pending
 // records).
-func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter) (*IMAPServer, error) {
+func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, flt *filter.Filter) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -67,7 +68,7 @@ func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundS
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords}, nil, nil
+			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords, filter: flt}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -90,11 +91,33 @@ func (s *IMAPServer) Close() error { return s.imap.Close() }
 type imapSession struct {
 	cred          Credential
 	store         inbound.InboundStore
-	fetch         ContentFetch  // resolves message content on demand (per-FETCH)
-	writeKeywords KeywordWriter // replicates a keyword change upstream (nil = local-only)
+	fetch         ContentFetch   // resolves message content on demand (per-FETCH)
+	writeKeywords KeywordWriter  // replicates a keyword change upstream (nil = local-only)
+	filter        *filter.Filter // serve-time inbound filter (nil = allow all; ADR 0021)
 	owner         string
 	authed        bool
 	selected      []inbound.Message // metadata snapshot taken at Select (no content)
+}
+
+// visible lists the owner's messages and applies the inbound filter (ADR 0021):
+// only allow-verdict messages are returned (hide / hold-for-human are omitted
+// from the read face in this increment). Evaluated fresh each call (no cache).
+func (s *imapSession) visible() ([]inbound.Message, error) {
+	msgs, err := s.store.List(s.owner)
+	if err != nil {
+		return nil, err
+	}
+	if s.filter == nil {
+		return msgs, nil
+	}
+	now := time.Now()
+	out := msgs[:0] // in-place filter; msgs is a fresh slice per call
+	for _, m := range msgs {
+		if s.filter.Decide(m, now) == filter.Allow {
+			out = append(out, m)
+		}
+	}
+	return out, nil
 }
 
 func (s *imapSession) Close() error { return nil }
@@ -112,7 +135,7 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 	if mailbox != imapMailbox {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
 	}
-	msgs, err := s.store.List(s.owner)
+	msgs, err := s.visible()
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +182,7 @@ func (s *imapSession) Status(mailbox string, options *imap.StatusOptions) (*imap
 	if mailbox != imapMailbox {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
 	}
-	msgs, err := s.store.List(s.owner)
+	msgs, err := s.visible()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/listener"
 )
@@ -36,15 +37,15 @@ func startIMAP(t *testing.T, store inbound.InboundStore) string {
 }
 
 func startIMAPWithFetch(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch) string {
-	return startIMAPFull(t, store, fetch, nil)
+	return startIMAPFull(t, store, fetch, nil, nil)
 }
 
-func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch, wk listener.KeywordWriter) string {
+func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch, wk listener.KeywordWriter, flt *filter.Filter) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk)
+		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk, flt)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -325,7 +326,7 @@ func TestIMAPStoreKeywordWritesThrough(t *testing.T) {
 	var wroteAdd []string
 	wk := func(owner, id string, add, remove []string) error { wroteID, wroteAdd = id, add; return nil }
 
-	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk, nil), nil)
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.Login("agent", "pw").Wait())
@@ -356,7 +357,7 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 
 	wk := func(owner, id string, add, remove []string) error { return errors.New("upstream down") }
 
-	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk, nil), nil)
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.Login("agent", "pw").Wait())
@@ -383,7 +384,7 @@ func TestIMAPStoreKeywordLocalOnlyNoUpstream(t *testing.T) {
 	called := false
 	wk := func(owner, id string, add, remove []string) error { called = true; return nil }
 
-	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk), nil)
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk, nil), nil)
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.Login("agent", "pw").Wait())
@@ -402,6 +403,41 @@ func TestIMAPStoreKeywordLocalOnlyNoUpstream(t *testing.T) {
 	assert.Empty(t, dirty) // not dirty → never enters reconcile
 }
 
+// A hide rule omits matching messages from the read face (ADR 0021): SELECT
+// counts and serves only the allowed ones.
+func TestIMAPFilterHidesMessages(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "keep", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "keep"},
+	})
+	require.NoError(t, err)
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "junk", UpstreamUID: 2, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "junk"}, Keywords: []string{"useless"},
+	})
+	require.NoError(t, err)
+
+	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: useless}], action: hide}]"))
+	require.NoError(t, err)
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, nil, flt), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), sel.NumMessages) // the "useless" message is hidden
+
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{Envelope: true}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.NotNil(t, msgs[0].Envelope)
+	assert.Equal(t, "keep", msgs[0].Envelope.Subject) // only the allowed one is served
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)
@@ -411,6 +447,6 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil, nil)
+		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil, nil, nil)
 	require.Error(t, err)
 }


### PR DESCRIPTION
**ADR 0021, increment 21a** — the inbound filter engine + serve-time allow/hide. Declarative YAML rules decide what synced mail the agent sees, as a **view over the store-canonical records**.

## What
- **`internal/filter`**: rule schema + match engine. Fields `from`/`to`/`cc`/`subject`/`header`/`label`/`age`; operators `equals`/`contains`/`regex`/`domain` (+ age `older_than`/`newer_than`); conditions **AND-ed**; **top-down first-match**; configurable default (**default allow**). `header` is **envelope-headers-only** in v1 (arbitrary headers would need the body, excluded). **Metadata-only — never forces a body fetch.** `Compile()` **fail-fast** validates the rule set.
- **Read face**: SELECT/STATUS list through a serve-time filter view — `allow` served, `hide`/`hold-for-human` **omitted** (hold's approval routing is 21b; until then a held message stays hidden — the fail-safe). **Re-evaluated fresh each serve** (no cache), so an edited rule set takes effect next serve. Darbaan owns its UID namespace → omitting is just a filtered view, no live-proxy UID hazard.
- **Config**: `inbound-filter` (YAML path), loaded at serve start; empty = no filter (allow all).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: engine (domain/label/subject/age/regex, AND, first-match, default, nil/empty pass-through, full validation matrix); read face hides a labeled message from SELECT + serves only the allowed one.

Live verify (yours): a rule actually hides/allows real synced mail. **21b** (hold-for-human + the second approval queue) follows.
