### PR TITLE
feat(inbound): hold-for-human queue + UIDNEXT-from-full-store (ADR 0021 21b)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -95,6 +95,7 @@ type CLI struct {
 
 	Serve      ServeCmd      `cmd:"" help:"Run the SMTP + IMAP faces and the admin API."`
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
+	Holds      HoldsCmd      `cmd:"" help:"Inspect and decide inbound messages held for a human (ADR 0021)."`
 	Telegram   TelegramCmd   `cmd:"" help:"Run the Telegram approval client (a separate admin-API client process)."`
 	DkimPubkey DkimPubkeyCmd `cmd:"" name:"dkim-pubkey" help:"Print the DKIM public-key record to pin to the agent."`
 	Version    VersionCmd    `cmd:"" help:"Print version and exit."`
@@ -381,6 +382,9 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
+	// The admin hold-for-human queue and the read face share one filter + owner
+	// (ADR 0021): the read face hides held mail, the admin surface decides it.
+	svc.SetInboundHolds(flt, cli.AgentUsername)
 	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
@@ -535,5 +539,73 @@ func printOutcome(out admin.Outcome) error {
 	if out.Warn != "" {
 		return fmt.Errorf("%s", out.Warn)
 	}
+	return nil
+}
+
+// HoldsCmd decides inbound messages held for a human (ADR 0021), the inbound
+// mirror of `queue`.
+type HoldsCmd struct {
+	Ls     HoldsLsCmd     `cmd:"" help:"List inbound messages held for a decision."`
+	Expose HoldsExposeCmd `cmd:"" help:"Expose a held message to the agent (approve)."`
+	Drop   HoldsDropCmd   `cmd:"" help:"Keep a held message hidden from the agent (reject)."`
+}
+
+type HoldsLsCmd struct{}
+
+func (*HoldsLsCmd) Run(cli *CLI) error {
+	c, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	held, err := c.HeldList(context.Background())
+	if err != nil {
+		return err
+	}
+	if len(held) == 0 {
+		fmt.Fprintln(os.Stderr, "no messages held for a decision")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tFROM\tSUBJECT\tRECEIVED")
+	for _, m := range held {
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
+			m.ID, m.From, truncate(m.Subject, 40), m.ReceivedAt.Format(time.RFC3339))
+	}
+	return w.Flush()
+}
+
+// HoldsExposeCmd exposes a held message to the agent.
+type HoldsExposeCmd struct {
+	ID string `arg:"" help:"Message id."`
+}
+
+func (c *HoldsExposeCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	m, err := client.Expose(context.Background(), c.ID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("message %s exposed to the agent\n", m.ID)
+	return nil
+}
+
+// HoldsDropCmd keeps a held message hidden from the agent.
+type HoldsDropCmd struct {
+	ID string `arg:"" help:"Message id."`
+}
+
+func (c *HoldsDropCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	m, err := client.Drop(context.Background(), c.ID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("message %s dropped (stays hidden from the agent)\n", m.ID)
 	return nil
 }

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -92,6 +93,49 @@ func (c *Client) Approve(ctx context.Context, id string) (Outcome, error) {
 func (c *Client) Reject(ctx context.Context, id, reason string, retryable bool) (Outcome, error) {
 	body, _ := json.Marshal(map[string]any{"reason": reason, "retryable": retryable})
 	return c.action(ctx, "/queue/"+id+"/reject", bytes.NewReader(body))
+}
+
+// HeldList returns the inbound messages held for a human decision (ADR 0021).
+func (c *Client) HeldList(ctx context.Context) ([]inbound.Message, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/holds", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errorFrom(resp)
+	}
+	var held []inbound.Message
+	if err := json.NewDecoder(resp.Body).Decode(&held); err != nil {
+		return nil, err
+	}
+	return held, nil
+}
+
+// Expose approves a held message for the agent to see (ADR 0021).
+func (c *Client) Expose(ctx context.Context, id string) (inbound.Message, error) {
+	return c.hold(ctx, "/holds/"+id+"/expose")
+}
+
+// Drop rejects a held message — it stays hidden from the agent (ADR 0021).
+func (c *Client) Drop(ctx context.Context, id string) (inbound.Message, error) {
+	return c.hold(ctx, "/holds/"+id+"/drop")
+}
+
+func (c *Client) hold(ctx context.Context, path string) (inbound.Message, error) {
+	resp, err := c.request(ctx, http.MethodPost, path, nil)
+	if err != nil {
+		return inbound.Message{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return inbound.Message{}, errorFrom(resp)
+	}
+	var m inbound.Message
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return inbound.Message{}, err
+	}
+	return m, nil
 }
 
 func (c *Client) action(ctx context.Context, path string, body io.Reader) (Outcome, error) {

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -33,6 +34,12 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 	mux.HandleFunc("GET /queue/{id}", s.auth(s.handleShow))
 	mux.HandleFunc("POST /queue/{id}/approve", s.auth(s.handleApprove))
 	mux.HandleFunc("POST /queue/{id}/reject", s.auth(s.handleReject))
+
+	// Inbound hold-for-human queue (ADR 0021): expose = show to the agent, drop =
+	// keep hidden.
+	mux.HandleFunc("GET /holds", s.auth(s.handleHeldList))
+	mux.HandleFunc("POST /holds/{id}/expose", s.auth(s.handleExpose))
+	mux.HandleFunc("POST /holds/{id}/drop", s.auth(s.handleDrop))
 
 	s.http = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	return s, nil
@@ -89,6 +96,40 @@ func (s *Server) handleShow(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 	out, err := s.svc.ApproveID(r.Context(), r.PathValue("id"))
 	writeAction(w, out, err)
+}
+
+func (s *Server) handleHeldList(w http.ResponseWriter, _ *http.Request) {
+	held, err := s.svc.HeldList()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	if held == nil {
+		held = []inbound.Message{}
+	}
+	writeJSON(w, http.StatusOK, held)
+}
+
+func (s *Server) handleExpose(w http.ResponseWriter, r *http.Request) {
+	m, err := s.svc.ExposeHeld(r.PathValue("id"))
+	s.writeHold(w, m, err)
+}
+
+func (s *Server) handleDrop(w http.ResponseWriter, r *http.Request) {
+	m, err := s.svc.DropHeld(r.PathValue("id"))
+	s.writeHold(w, m, err)
+}
+
+func (s *Server) writeHold(w http.ResponseWriter, m inbound.Message, err error) {
+	if errors.Is(err, inbound.ErrNotFound) {
+		writeErr(w, http.StatusNotFound, err)
+		return
+	}
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, m)
 }
 
 func (s *Server) handleReject(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/filter"
+	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -85,4 +87,34 @@ func TestAdminShowNotFound(t *testing.T) {
 	addr := startServer(t, svc, "tok")
 	_, err := admin.NewClient(addr, "tok").Show(context.Background(), "999")
 	require.Error(t, err)
+}
+
+func TestHoldsRoundtrip(t *testing.T) {
+	q, _ := seedStore(t)
+	inbox := newInbound(t)
+	svc := admin.NewService(q, inbox, fakeSender{nil}, testSigner(t), strictRouter(), "darbaan.test")
+	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
+	require.NoError(t, err)
+	svc.SetInboundHolds(flt, "agent")
+	_, held, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "review me", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+
+	c := admin.NewClient(startServer(t, svc, "tok"), "tok")
+	ctx := context.Background()
+
+	list, err := c.HeldList(ctx)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, held.ID, list[0].ID)
+
+	m, err := c.Expose(ctx, held.ID)
+	require.NoError(t, err)
+	assert.Equal(t, held.ID, m.ID)
+
+	list, err = c.HeldList(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, list) // decided -> off the queue
+
+	_, err = c.Expose(ctx, "999") // unknown id -> error
+	assert.Error(t, err)
 }

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -11,10 +11,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/yaad-index/darbaan/internal/approver"
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/bounce"
+	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/policy"
 	"github.com/yaad-index/darbaan/internal/sluice"
@@ -33,6 +35,8 @@ type Service struct {
 	signer Signer
 	router *policy.Router
 	domain string
+	filter *filter.Filter // inbound filter, for the hold-for-human queue (ADR 0021)
+	owner  string         // the agent whose inbound mailbox the holds belong to
 }
 
 // NewService wires the approval service. inbox and signer may be nil only when
@@ -40,6 +44,44 @@ type Service struct {
 // serve they are always provided.
 func NewService(store sluice.MessageStore, inbox inbound.InboundStore, sender backend.Sender, signer Signer, router *policy.Router, domain string) *Service {
 	return &Service{store: store, inbox: inbox, sender: sender, signer: signer, router: router, domain: domain}
+}
+
+// SetInboundHolds wires the inbound hold-for-human queue (ADR 0021): the filter
+// that decides which synced messages are held, and the agent (owner) they belong
+// to. Without it, HeldList is empty.
+func (s *Service) SetInboundHolds(flt *filter.Filter, owner string) {
+	s.filter, s.owner = flt, owner
+}
+
+// HeldList returns the inbound messages held for a human decision (a hold-rule
+// match with no decision yet, ADR 0021) — the inbound mirror of the outbound
+// List.
+func (s *Service) HeldList() ([]inbound.Message, error) {
+	if s.inbox == nil {
+		return nil, nil
+	}
+	msgs, err := s.inbox.List(s.owner)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now()
+	var held []inbound.Message
+	for _, m := range msgs {
+		if s.filter.Decide(m, now) == filter.Hold && m.HoldDecision == "" {
+			held = append(held, m)
+		}
+	}
+	return held, nil
+}
+
+// ExposeHeld approves a held message for the agent to see (ADR 0021).
+func (s *Service) ExposeHeld(id string) (inbound.Message, error) {
+	return s.inbox.SetHoldDecision(s.owner, id, inbound.HoldApproved)
+}
+
+// DropHeld rejects a held message — it stays hidden from the agent (ADR 0021).
+func (s *Service) DropHeld(id string) (inbound.Message, error) {
+	return s.inbox.SetHoldDecision(s.owner, id, inbound.HoldRejected)
 }
 
 // Outcome is the result of an approve/reject action. Status is the committed

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/policy"
 	"github.com/yaad-index/darbaan/internal/signer"
@@ -86,6 +87,9 @@ func (failingInbound) SetKeywords(string, string, []string) (inbound.Message, er
 func (failingInbound) ClearKeywordsDirty(string, string) error { return nil }
 func (failingInbound) DirtyKeywords(string) ([]inbound.Message, error) {
 	return nil, nil
+}
+func (failingInbound) SetHoldDecision(string, string, string) (inbound.Message, error) {
+	return inbound.Message{}, errors.New("inbound store down")
 }
 func (failingInbound) List(string) ([]inbound.Message, error) { return nil, nil }
 func (failingInbound) Get(string, string) (inbound.Message, error) {
@@ -211,4 +215,39 @@ func TestListAndShow(t *testing.T) {
 
 	_, err = svc.Show("999")
 	require.ErrorIs(t, err, sluice.ErrNotFound)
+}
+
+func TestInboundHoldQueue(t *testing.T) {
+	q, _ := seedStore(t)
+	inbox := newInbound(t)
+	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
+	require.NoError(t, err)
+	svc.SetInboundHolds(flt, "agent")
+
+	_, _, err = inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1}) // allowed
+	require.NoError(t, err)
+	_, held, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 2, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+
+	list, err := svc.HeldList()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, held.ID, list[0].ID)
+
+	// Expose decides it → off the held list, and the read face would now show it.
+	_, err = svc.ExposeHeld(held.ID)
+	require.NoError(t, err)
+	list, err = svc.HeldList()
+	require.NoError(t, err)
+	assert.Empty(t, list)
+
+	// Drop also decides (stays hidden) → off the held list.
+	_, held2, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 3, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+	_, err = svc.DropHeld(held2.ID)
+	require.NoError(t, err)
+	list, err = svc.HeldList()
+	require.NoError(t, err)
+	assert.Empty(t, list)
 }

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -349,6 +349,28 @@ func (s *bboltStore) ClearKeywordsDirty(owner, id string) error {
 	})
 }
 
+// SetHoldDecision persists the human's hold-for-human decision (ADR 0021) on the
+// owner's message (metadata only; the blob is untouched) and returns it.
+func (s *bboltStore) SetHoldDecision(owner, id, decision string) (Message, error) {
+	var msg Message
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		rec, key, err := loadStored(tx, id)
+		if err != nil {
+			return err
+		}
+		if rec.Owner != owner {
+			return ErrNotFound
+		}
+		rec.HoldDecision = decision
+		msg = rec.Message
+		return putStored(tx, key, rec)
+	})
+	if err != nil {
+		return Message{}, fmt.Errorf("inbound: set hold decision %s: %w", id, err)
+	}
+	return msg, nil
+}
+
 // DirtyKeywords returns the owner's messages whose keywords await upstream
 // replication (metadata only), for the sync to reconcile.
 func (s *bboltStore) DirtyKeywords(owner string) ([]Message, error) {

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -101,7 +101,19 @@ type Message struct {
 	// Keywords are the message's custom IMAP keywords/labels (ADR 0020), served
 	// on FETCH FLAGS. The agent sets them via STORE (write-through to upstream).
 	Keywords []string `json:"keywords,omitempty"`
+
+	// HoldDecision records the human's call on a hold-for-human message (ADR
+	// 0021): "" = undecided (held, hidden from the agent), "approved" = exposed to
+	// the agent, "rejected" = stays hidden. Only meaningful while a hold rule
+	// matches the message; it is the one persisted, human-supplied filter state.
+	HoldDecision string `json:"hold_decision,omitempty"`
 }
+
+// Hold decision values for Message.HoldDecision (ADR 0021).
+const (
+	HoldApproved = "approved"
+	HoldRejected = "rejected"
+)
 
 // InboundStore is the agent's served mailbox. Implementations are selected by
 // config (inbound-type) and constructed through New.
@@ -127,6 +139,9 @@ type InboundStore interface {
 	ClearKeywordsDirty(owner, id string) error
 	// DirtyKeywords returns messages whose keywords await upstream replication.
 	DirtyKeywords(owner string) ([]Message, error)
+	// SetHoldDecision persists the human's hold-for-human decision (ADR 0021):
+	// "approved" exposes the message, "rejected" keeps it hidden. Owner-scoped.
+	SetHoldDecision(owner, id, decision string) (Message, error)
 	// List returns the owner's messages' metadata (no content/Raw) in receive
 	// order; a body is fetched per-message via Get / the content fetcher.
 	List(owner string) ([]Message, error)

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -99,25 +99,46 @@ type imapSession struct {
 	selected      []inbound.Message // metadata snapshot taken at Select (no content)
 }
 
-// visible lists the owner's messages and applies the inbound filter (ADR 0021):
-// only allow-verdict messages are returned (hide / hold-for-human are omitted
-// from the read face in this increment). Evaluated fresh each call (no cache).
-func (s *imapSession) visible() ([]inbound.Message, error) {
-	msgs, err := s.store.List(s.owner)
+// listAndFilter returns the owner's full message list and the filtered-visible
+// subset (ADR 0021). The full list is kept so UIDNEXT can be derived from the
+// highest UID overall — deriving it from the visible subset would under-report
+// when the highest-UID messages are hidden, breaking client sync. allow is
+// visible; hide and undecided/rejected hold are omitted. Evaluated fresh each
+// call (no cache).
+func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err error) {
+	full, err = s.store.List(s.owner)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if s.filter == nil {
-		return msgs, nil
+		return full, full, nil
 	}
 	now := time.Now()
-	out := msgs[:0] // in-place filter; msgs is a fresh slice per call
-	for _, m := range msgs {
-		if s.filter.Decide(m, now) == filter.Allow {
-			out = append(out, m)
+	for _, m := range full { // new backing slice — leave full intact for UIDNEXT
+		switch s.filter.Decide(m, now) {
+		case filter.Allow:
+			visible = append(visible, m)
+		case filter.Hold:
+			// Held messages are hidden until a human approves exposure (ADR 0021);
+			// rejected/undecided stay hidden (fail-safe).
+			if m.HoldDecision == inbound.HoldApproved {
+				visible = append(visible, m)
+			}
 		}
 	}
-	return out, nil
+	return full, visible, nil
+}
+
+// uidNext returns the next UID, derived from the highest UID across ALL stored
+// messages (not the filtered view), so a client never sees a too-low UIDNEXT.
+func uidNext(full []inbound.Message) imap.UID {
+	next := uint32(1) // UID 0 is invalid (RFC 3501)
+	for _, m := range full {
+		if u := uint32(uidOf(m)); u >= next {
+			next = u + 1
+		}
+	}
+	return imap.UID(next)
 }
 
 func (s *imapSession) Close() error { return nil }
@@ -135,20 +156,16 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 	if mailbox != imapMailbox {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
 	}
-	msgs, err := s.visible()
+	full, visible, err := s.listAndFilter()
 	if err != nil {
 		return nil, err
 	}
-	s.selected = msgs
+	s.selected = visible
 
-	firstUnseen, uidNext := uint32(0), uint32(1) // UID 0 is invalid (RFC 3501)
+	firstUnseen := uint32(0)
 	seen := map[imap.Flag]bool{}
 	keywords := []imap.Flag{}
-	for i, m := range msgs {
-		uid := uint32(uidOf(m))
-		if uid >= uidNext {
-			uidNext = uid + 1
-		}
+	for i, m := range visible {
 		if !m.Seen && firstUnseen == 0 {
 			firstUnseen = uint32(i) + 1
 		}
@@ -166,9 +183,9 @@ func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.Selec
 	return &imap.SelectData{
 		Flags:             append([]imap.Flag{imap.FlagSeen}, keywords...),
 		PermanentFlags:    permanent,
-		NumMessages:       uint32(len(msgs)),
+		NumMessages:       uint32(len(visible)),
 		FirstUnseenSeqNum: firstUnseen,
-		UIDNext:           imap.UID(uidNext),
+		UIDNext:           uidNext(full), // from the full store, not the visible view
 		UIDValidity:       1,
 	}, nil
 }
@@ -182,32 +199,26 @@ func (s *imapSession) Status(mailbox string, options *imap.StatusOptions) (*imap
 	if mailbox != imapMailbox {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
 	}
-	msgs, err := s.visible()
+	full, visible, err := s.listAndFilter()
 	if err != nil {
 		return nil, err
 	}
 	data := &imap.StatusData{Mailbox: mailbox}
 	if options.NumMessages {
-		n := uint32(len(msgs))
+		n := uint32(len(visible))
 		data.NumMessages = &n
 	}
 	if options.NumUnseen {
 		var unseen uint32
-		for _, m := range msgs {
+		for _, m := range visible {
 			if !m.Seen {
 				unseen++
 			}
 		}
 		data.NumUnseen = &unseen
 	}
-	uidNext := uint32(1) // UID 0 is invalid (RFC 3501)
-	for _, m := range msgs {
-		if u := uint32(uidOf(m)); u >= uidNext {
-			uidNext = u + 1
-		}
-	}
 	if options.UIDNext {
-		data.UIDNext = imap.UID(uidNext)
+		data.UIDNext = uidNext(full) // from the full store, not the visible view
 	}
 	if options.UIDValidity {
 		data.UIDValidity = 1

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -438,6 +438,72 @@ func TestIMAPFilterHidesMessages(t *testing.T) {
 	assert.Equal(t, "keep", msgs[0].Envelope.Subject) // only the allowed one is served
 }
 
+// A hold-for-human message is hidden until approved, then becomes visible (ADR
+// 0021): undecided → hidden; HoldApproved → served.
+func TestIMAPHoldForHuman(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "keep", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "keep"},
+	})
+	require.NoError(t, err)
+	_, held, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "review-me", UpstreamUID: 2, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "review-me"}, Keywords: []string{"review"},
+	})
+	require.NoError(t, err)
+
+	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
+	require.NoError(t, err)
+	addr := startIMAPFull(t, store, nil, nil, flt)
+
+	c, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), sel.NumMessages) // held one hidden pending decision
+
+	// A human approves exposure → it becomes visible on the next select.
+	_, err = store.SetHoldDecision("agent", held.ID, inbound.HoldApproved)
+	require.NoError(t, err)
+	c2, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = c2.Close() }()
+	require.NoError(t, c2.Login("agent", "pw").Wait())
+	sel, err = c2.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(2), sel.NumMessages) // now exposed
+}
+
+// UIDNEXT is derived from the full store, so hiding the highest-UID message does
+// not under-report it (ADR 0021).
+func TestIMAPUIDNextFromFullStore(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, _, err = store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1}) // id 1, visible
+	require.NoError(t, err)
+	_, _, err = store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 2, UIDValidity: 1, Keywords: []string{"junk"}}) // id 2, hidden
+	require.NoError(t, err)
+
+	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: junk}], action: hide}]"))
+	require.NoError(t, err)
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, nil, flt), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), sel.NumMessages) // only id 1 visible
+	assert.Equal(t, imap.UID(3), sel.UIDNext)   // but UIDNEXT reflects hidden id 2
+}
+
 func TestIMAPBadAuthRejected(t *testing.T) {
 	c, err := imapclient.DialInsecure(startIMAP(t, seedInbound(t)), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
**ADR 0021, increment 21b** — hold-for-human, the inbound mirror of the outbound sluice. A `hold-for-human` rule holds a synced message **hidden from the agent until a human exposes it**. Also folds the UIDNEXT fix from the 21a review.

## What
- **inbound**: `Message.HoldDecision` (""=undecided / approved / rejected) — the one persisted, human-supplied filter state; `SetHoldDecision` persists it.
- **Read face**: a hold-verdict message is served only when `HoldDecision==approved`; undecided/rejected stay hidden (**fail-safe**). Rule-derived allow/hide stay fresh-each-serve; only the human hold decision persists.
- **Admin surface (the 2nd queue)**: `Service.HeldList/ExposeHeld/DropHeld` (wired via `SetInboundHolds`); HTTP `GET /holds` + `POST /holds/{id}/expose|drop`; `Client.HeldList/Expose/Drop`; and a **`darbaan holds ls|expose|drop`** CLI — mirroring `queue`'s shape.
- **UIDNEXT fix** (the 21a review catch): UIDNEXT comes from the **full store**, NumMessages/FirstUnseen from the **visible** set — hiding the highest-UID messages no longer under-reports UIDNEXT.

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: read face holds-then-exposes; UIDNEXT reflects a hidden high-UID message; admin HeldList/Expose/Drop; holds HTTP round-trip via the Client (incl. 404 on unknown id).

**21c** (Telegram inbound-hold surface) follows. Live verify (yours, when quota eases): a hold rule holds real mail; `holds expose` reveals it to the agent.
