### PR TITLE
feat(telegram): inbound hold-for-human surface (ADR 0021 21c)

### DIFF
--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -1,0 +1,165 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/go-telegram/bot"
+	"github.com/go-telegram/bot/models"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// pollHolds lists the inbound hold-for-human queue (ADR 0021) and posts each new
+// held message to the operator with an [Expose] / [Drop] keyboard — the inbound
+// mirror of poll. Held metadata is enough to decide; no body is fetched (it would
+// trigger an on-demand upstream pull).
+func (c *Client) pollHolds(ctx context.Context) {
+	held, err := c.admin.HeldList(ctx)
+	if err != nil {
+		log.Printf("darbaan telegram: poll holds: %v", err)
+		return
+	}
+	c.prunePostedHolds(held)
+	for _, m := range held {
+		if c.seenHold(m.ID) {
+			continue
+		}
+		if err := c.notifyHold(ctx, m); err != nil {
+			log.Printf("darbaan telegram: notify hold %s: %v", m.ID, err)
+			continue
+		}
+		c.markPostedHold(m.ID)
+	}
+}
+
+func (c *Client) notifyHold(ctx context.Context, m inbound.Message) error {
+	_, err := c.bot.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID:      c.operatorID,
+		Text:        formatHold(m),
+		ReplyMarkup: holdKeyboard(m.ID),
+	})
+	return err
+}
+
+func formatHold(m inbound.Message) string {
+	return fmt.Sprintf("Held inbound message — expose to the agent?\nid: %s\nfrom: %s\nto: %s\nsubject: %s",
+		m.ID, m.From, m.To, displaySubject(m.Subject))
+}
+
+func holdKeyboard(id string) models.InlineKeyboardMarkup {
+	return models.InlineKeyboardMarkup{
+		InlineKeyboard: [][]models.InlineKeyboardButton{
+			{
+				{Text: "Expose", CallbackData: cbExpose + id},
+				{Text: "Drop", CallbackData: cbDrop + id},
+			},
+		},
+	}
+}
+
+// handleExpose is the [Expose] button: verify the operator, confirm it's still
+// held, expose it to the agent, and rewrite the notification.
+func (c *Client) handleExpose(ctx context.Context, b *bot.Bot, update *models.Update) {
+	cq := update.CallbackQuery
+	if !c.isOperator(cq) {
+		c.denyCallback(ctx, b, cq)
+		return
+	}
+	id := strings.TrimPrefix(cq.Data, cbExpose)
+	if !c.guardHeld(ctx, b, cq, id) {
+		return
+	}
+	m, err := c.admin.Expose(ctx, id)
+	c.finishHold(ctx, b, cq, "Exposed", id, m, err)
+}
+
+// handleDrop is the [Drop] button: keep the message hidden from the agent.
+func (c *Client) handleDrop(ctx context.Context, b *bot.Bot, update *models.Update) {
+	cq := update.CallbackQuery
+	if !c.isOperator(cq) {
+		c.denyCallback(ctx, b, cq)
+		return
+	}
+	id := strings.TrimPrefix(cq.Data, cbDrop)
+	if !c.guardHeld(ctx, b, cq, id) {
+		return
+	}
+	m, err := c.admin.Drop(ctx, id)
+	c.finishHold(ctx, b, cq, "Dropped", id, m, err)
+}
+
+// guardHeld pre-checks that a tapped message is still awaiting a decision, so a
+// stale tap on an already-decided hold is explained rather than silently flipping
+// the decision (there is no reconsider/undo in v1 — a deferred follow-up). It
+// returns true to proceed; on a lookup error it proceeds (acting is idempotent
+// for the live case).
+func (c *Client) guardHeld(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery, id string) bool {
+	held, err := c.admin.HeldList(ctx)
+	if err != nil {
+		return true // can't look up — let the action run (re-setting the same decision is harmless)
+	}
+	for _, m := range held {
+		if m.ID == id {
+			return true
+		}
+	}
+	msg := fmt.Sprintf("Message %s: already decided or gone", id)
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
+		CallbackQueryID: cq.ID, Text: msg, ShowAlert: true,
+	})
+	if m := cq.Message.Message; m != nil {
+		c.editResult(ctx, b, m.Chat.ID, m.ID, msg)
+	}
+	return false
+}
+
+// finishHold dismisses the spinner and rewrites the notification to the outcome,
+// clearing the keyboard so the decided hold can't be tapped again.
+func (c *Client) finishHold(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery, verb, id string, m inbound.Message, err error) {
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID, Text: verb})
+	if msg := cq.Message.Message; msg != nil {
+		c.editResult(ctx, b, msg.Chat.ID, msg.ID, holdResult(verb, id, err))
+	}
+	_ = m
+}
+
+func holdResult(verb, id string, err error) string {
+	if err != nil {
+		return fmt.Sprintf("%s failed (%s): %v", verb, id, err)
+	}
+	if verb == "Exposed" {
+		return fmt.Sprintf("Exposed %s — now visible to the agent", id)
+	}
+	return fmt.Sprintf("Dropped %s — stays hidden from the agent", id)
+}
+
+// prunePostedHolds drops de-dup entries for holds no longer awaiting a decision,
+// bounding the set to the live held queue.
+func (c *Client) prunePostedHolds(held []inbound.Message) {
+	live := make(map[string]bool, len(held))
+	for _, m := range held {
+		live[m.ID] = true
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id := range c.postedHolds {
+		if !live[id] {
+			delete(c.postedHolds, id)
+		}
+	}
+}
+
+func (c *Client) seenHold(id string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.postedHolds[id]
+}
+
+func (c *Client) markPostedHold(id string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.postedHolds[id] = true
+}

--- a/internal/telegram/holds_internal_test.go
+++ b/internal/telegram/holds_internal_test.go
@@ -1,0 +1,52 @@
+package telegram
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+func TestFormatHold(t *testing.T) {
+	s := formatHold(inbound.Message{ID: "7", From: "a@x.test", To: "b@y.test", Subject: "hello"})
+	assert.Contains(t, s, "expose to the agent?")
+	assert.Contains(t, s, "id: 7")
+	assert.Contains(t, s, "from: a@x.test")
+	assert.Contains(t, s, "to: b@y.test")
+	assert.Contains(t, s, "subject: hello")
+	assert.Contains(t, formatHold(inbound.Message{ID: "8"}), "(no subject)")
+}
+
+func TestHoldKeyboard(t *testing.T) {
+	kb := holdKeyboard("7")
+	var data []string
+	for _, row := range kb.InlineKeyboard {
+		for _, btn := range row {
+			data = append(data, btn.CallbackData)
+		}
+	}
+	assert.Contains(t, data, cbExpose+"7")
+	assert.Contains(t, data, cbDrop+"7")
+}
+
+func TestHoldResult(t *testing.T) {
+	assert.Contains(t, holdResult("Exposed", "7", nil), "visible to the agent")
+	assert.Contains(t, holdResult("Dropped", "7", nil), "stays hidden")
+	assert.True(t, strings.Contains(holdResult("Exposed", "7", errors.New("boom")), "failed"))
+}
+
+func TestPostedHoldsDedup(t *testing.T) {
+	c := &Client{postedHolds: map[string]bool{}}
+	assert.False(t, c.seenHold("1"))
+	c.markPostedHold("1")
+	c.markPostedHold("2")
+	assert.True(t, c.seenHold("1"))
+
+	// Prune drops entries no longer in the live held queue.
+	c.prunePostedHolds([]inbound.Message{{ID: "1"}})
+	assert.True(t, c.seenHold("1"))
+	assert.False(t, c.seenHold("2"))
+}

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -3,12 +3,15 @@
 // localhost-only admin API (#52). It is NOT compiled into serve; it holds only
 // a bot token and an admin-API token, never the mail credentials (ADR 0002).
 //
-// It polls the admin queue and posts each new held message to the operator
-// chat with an [Approve] / [Reject permanent] / [Reject retryable] keyboard,
-// then applies the operator's decision via the admin API: Approve sends through
+// It polls the admin queue and posts each new held OUTBOUND message to the
+// operator chat with an [Approve] / [Reject permanent] / [Reject retryable]
+// keyboard, then applies the decision via the admin API: Approve sends through
 // immediately; either Reject first prompts (force-reply) for a reason that
-// becomes the DSN bounce reason. Only the configured operator may decide
-// (ADR 0002) — both the button taps and the reason reply are gated to them.
+// becomes the DSN bounce reason. It also polls the INBOUND hold-for-human queue
+// (ADR 0021) and posts each held message with an [Expose] / [Drop] keyboard —
+// Expose reveals it to the agent, Drop keeps it hidden (see holds.go). Only the
+// configured operator may decide (ADR 0002) — every tap and reply is gated to
+// them.
 package telegram
 
 import (
@@ -33,6 +36,10 @@ const (
 	cbApprove     = "approve:"
 	cbRejectPerm  = "reject_perm:"
 	cbRejectRetry = "reject_retry:"
+	// Inbound hold-for-human decisions (ADR 0021): expose = show to the agent,
+	// drop = keep hidden.
+	cbExpose = "expose:"
+	cbDrop   = "drop:"
 )
 
 // Client is the Telegram approval interface.
@@ -42,9 +49,10 @@ type Client struct {
 	operatorID   int64
 	pollInterval time.Duration
 
-	mu      sync.Mutex
-	posted  map[string]bool     // message ids already sent to the operator
-	pending map[int]rejectState // reject reason prompts awaiting the operator's reply, keyed by prompt message id
+	mu          sync.Mutex
+	posted      map[string]bool     // sluice message ids already sent to the operator
+	postedHolds map[string]bool     // inbound-hold ids already sent (separate id space)
+	pending     map[int]rejectState // reject reason prompts awaiting the operator's reply, keyed by prompt message id
 }
 
 // rejectState remembers, for a reason force-reply prompt, which held message it
@@ -88,11 +96,17 @@ func New(token string, operatorID int64, pollInterval time.Duration, adminClient
 		operatorID:   operatorID,
 		pollInterval: pollInterval,
 		posted:       make(map[string]bool),
+		postedHolds:  make(map[string]bool),
 		pending:      make(map[int]rejectState),
 	}
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbApprove, bot.MatchTypePrefix, c.handleApprove)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbRejectPerm, bot.MatchTypePrefix, c.handleRejectPermanent)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbRejectRetry, bot.MatchTypePrefix, c.handleRejectRetryable)
+	// Inbound hold-for-human (ADR 0021). Drop is registered before Expose: the
+	// prefix matcher would let "drop:" be shadowed otherwise — distinct prefixes
+	// here, but keep them explicit.
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbExpose, bot.MatchTypePrefix, c.handleExpose)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbDrop, bot.MatchTypePrefix, c.handleDrop)
 	// The reason force-reply arrives as a normal reply message, not a callback.
 	b.RegisterHandlerMatchFunc(isReply, c.handleReasonReply)
 	return c, nil
@@ -116,12 +130,14 @@ func (c *Client) pollLoop(ctx context.Context) {
 	t := time.NewTicker(c.pollInterval)
 	defer t.Stop()
 	c.poll(ctx) // post anything already pending at startup
+	c.pollHolds(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
 			c.poll(ctx)
+			c.pollHolds(ctx)
 		}
 	}
 }

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -102,9 +102,7 @@ func New(token string, operatorID int64, pollInterval time.Duration, adminClient
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbApprove, bot.MatchTypePrefix, c.handleApprove)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbRejectPerm, bot.MatchTypePrefix, c.handleRejectPermanent)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbRejectRetry, bot.MatchTypePrefix, c.handleRejectRetryable)
-	// Inbound hold-for-human (ADR 0021). Drop is registered before Expose: the
-	// prefix matcher would let "drop:" be shadowed otherwise — distinct prefixes
-	// here, but keep them explicit.
+	// Inbound hold-for-human decisions (ADR 0021).
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbExpose, bot.MatchTypePrefix, c.handleExpose)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbDrop, bot.MatchTypePrefix, c.handleDrop)
 	// The reason force-reply arrives as a normal reply message, not a callback.


### PR DESCRIPTION
**ADR 0021, increment 21c** — the Telegram inbound hold-for-human surface, the inbound mirror of the outbound approval flow. Completes the inbound filter arc.

## What
- **`pollHolds`** lists the admin `/holds` queue and posts each held message with an **[Expose] / [Drop]** keyboard — **metadata only** (id/from/to/subject; no body fetch, which would trigger an on-demand upstream pull).
- **Expose** → `admin.Expose` (show to the agent); **Drop** → `admin.Drop` (keep hidden). Both **gated to the operator** (ADR 0002) and **guarded against a stale tap** on an already-decided hold (no accidental flip). Decided notifications are rewritten + keyboard cleared.
- Separate posted-dedup set for holds (distinct id space from the sluice), pruned against the live queue. Both queues poll on the same loop — **no new process or config** (the darbaan-telegram service already runs).

## Scope note
No reconsider/undo in v1 (a dropped hold can't be re-exposed via Telegram) — the guard prevents accidental flips; intentional undo is a deferred follow-up (would need a reconsider endpoint, per the 21b review note).

## Verification
build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean. Tests: formatHold, holdKeyboard (Expose/Drop callback data), holdResult, posted-holds dedup + prune. Live bot calls verified on the box like the outbound flow (when quota eases).

This closes the inbound-filter arc: 21a engine/allow-hide → 21b hold-for-human + admin/CLI → 21c Telegram.
