### PR TITLE
chore(telegram): tidy stale comments + unused param (inbound-filter sweep)

### DIFF
--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -72,8 +72,8 @@ func (c *Client) handleExpose(ctx context.Context, b *bot.Bot, update *models.Up
 	if !c.guardHeld(ctx, b, cq, id) {
 		return
 	}
-	m, err := c.admin.Expose(ctx, id)
-	c.finishHold(ctx, b, cq, "Exposed", id, m, err)
+	_, err := c.admin.Expose(ctx, id)
+	c.finishHold(ctx, b, cq, "Exposed", id, err)
 }
 
 // handleDrop is the [Drop] button: keep the message hidden from the agent.
@@ -87,8 +87,8 @@ func (c *Client) handleDrop(ctx context.Context, b *bot.Bot, update *models.Upda
 	if !c.guardHeld(ctx, b, cq, id) {
 		return
 	}
-	m, err := c.admin.Drop(ctx, id)
-	c.finishHold(ctx, b, cq, "Dropped", id, m, err)
+	_, err := c.admin.Drop(ctx, id)
+	c.finishHold(ctx, b, cq, "Dropped", id, err)
 }
 
 // guardHeld pre-checks that a tapped message is still awaiting a decision, so a
@@ -118,12 +118,11 @@ func (c *Client) guardHeld(ctx context.Context, b *bot.Bot, cq *models.CallbackQ
 
 // finishHold dismisses the spinner and rewrites the notification to the outcome,
 // clearing the keyboard so the decided hold can't be tapped again.
-func (c *Client) finishHold(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery, verb, id string, m inbound.Message, err error) {
+func (c *Client) finishHold(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery, verb, id string, err error) {
 	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID, Text: verb})
 	if msg := cq.Message.Message; msg != nil {
 		c.editResult(ctx, b, msg.Chat.ID, msg.ID, holdResult(verb, id, err))
 	}
-	_ = m
 }
 
 func holdResult(verb, id string, err error) string {

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -30,8 +30,8 @@ import (
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
-// Callback-data prefixes for the decision buttons. The message id is appended;
-// the handlers that parse these land in later increments.
+// Callback-data prefixes for the decision buttons; the message id is appended
+// and the matching handler parses it back off.
 const (
 	cbApprove     = "approve:"
 	cbRejectPerm  = "reject_perm:"
@@ -350,8 +350,8 @@ func attachmentsLine(atts []attachment) string {
 	return "attachments: " + strings.Join(parts, ", ")
 }
 
-// decisionKeyboard lays in all three decision buttons. The callbacks are wired
-// in later increments; the callback data carries the action + message id.
+// decisionKeyboard lays in all three decision buttons; the callback data carries
+// the action + message id (handled by handleApprove / handleReject*).
 func decisionKeyboard(id string) models.InlineKeyboardMarkup {
 	return models.InlineKeyboardMarkup{
 		InlineKeyboard: [][]models.InlineKeyboardButton{


### PR DESCRIPTION
Behavior-unchanged cleanup sweep over the inbound-filter arc (internal/filter + the 21b/21c read-face/admin/telegram code), the post-arc tidy.

The filter package + read-face/admin code were clean (no TODO/FIXME/debug/dead code). The telegram client had two incremental-build leftovers:
- Two **"wired in later increments"** comments (callback-data constants + decisionKeyboard) — the handlers exist now; reworded to current reality.
- `finishHold` took an **unused `inbound.Message` param** (a `_ = m` discard) — dropped it and the needless return capture at both call sites.

build/vet/gofmt/`go test -race` (all pkgs)/golangci-lint clean.
