### PR TITLE
chore(deploy): configurable agent-face bind address (DARBAAN_FACE_BIND)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,11 @@ DARBAAN_AGENT_PASS=change-me
 # `docker exec darbaan darbaan queue ...` commands inherit it from the container.
 DARBAAN_ADMIN_TOKEN=change-me-too
 
+# Where the agent faces (SMTP/IMAP) bind. Default 127.0.0.1 (localhost only). Set
+# to 0.0.0.0 to reach Darbaan from a trusted LAN; the admin API stays
+# container-internal regardless. Leave unset for the safe localhost default.
+# DARBAAN_FACE_BIND=0.0.0.0
+
 # Upstream Gmail app password — ONLY needed once you flip DARBAAN_SENDER_TYPE=smtp
 # in docker-compose.yml. Leave blank while sender-type=stub (nothing sends).
 DARBAAN_SMTP_PASSWORD=

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ age-identity*
 
 # Sluice / bbolt database files
 *.db
+
+# Box-local deployment config / secrets — never commit
+secrets/
+docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,11 @@
 #   3. docker compose up -d
 #
 # Safe by default: sender-type=stub, so the container sends NOTHING until you set
-# DARBAAN_SENDER_TYPE=smtp + DARBAAN_SMTP_PASSWORD (a Gmail app password). Ports
-# bind to 127.0.0.1 only — Darbaan is a local-trusted-host service, not
-# internet-facing (ADR 0012). Secrets come from .env / mounts, never the image.
+# DARBAAN_SENDER_TYPE=smtp + DARBAAN_SMTP_PASSWORD (a Gmail app password). The
+# agent faces bind to 127.0.0.1 by default — Darbaan is a local-trusted-host
+# service, not internet-facing (ADR 0012). To reach it from a trusted LAN, set
+# DARBAAN_FACE_BIND=0.0.0.0 in .env (the admin API stays container-internal
+# regardless). Secrets come from .env / mounts, never the image.
 
 services:
   darbaan:
@@ -18,8 +20,8 @@ services:
       # Only the agent faces are published. The admin API (127.0.0.1:1144) is
       # deliberately NOT here — it stays container-internal, reached only via
       # `docker exec darbaan darbaan queue ...`, never from the host or the agent.
-      - "127.0.0.1:1465:1465"   # SMTP submission (agent -> Darbaan)
-      - "127.0.0.1:1143:1143"   # IMAP read (agent reads its bounces)
+      - "${DARBAAN_FACE_BIND:-127.0.0.1}:1465:1465"   # SMTP submission (agent -> Darbaan)
+      - "${DARBAAN_FACE_BIND:-127.0.0.1}:1143:1143"   # IMAP read (agent reads its bounces)
     environment:
       # Agent credential. Username here, password from .env.
       DARBAAN_AGENT_USERNAME: "agent"


### PR DESCRIPTION
Behavior-preserving deploy config. The published SMTP/IMAP face ports now bind to `${DARBAAN_FACE_BIND:-127.0.0.1}` — **localhost default unchanged**, so nothing moves unless the var is set. A deployment reaching Darbaan from a trusted LAN sets `DARBAAN_FACE_BIND=0.0.0.0` in `.env`. The **admin API stays 127.0.0.1 / container-internal regardless** (ADR 0012).

- `docker-compose.yml`: both face ports use the var; header comment documents it.
- `.env.example`: documents the var (commented, localhost default).
- `.gitignore`: ignore `secrets/` and `docker-compose.override.yml` (box-local config/secrets never committed).

Recreates the change already applied + working on the box, so a box git-pull won't clobber it. YAML validated; go build unaffected (config-only). 2-of-N + CI.
