### PR TITLE
docs: public README + INSTALL + USAGE (standalone, shareable)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,205 @@
+# Installing Darbaan with Docker
+
+This is the full, from-scratch guide to running Darbaan as a mail gate using
+Docker Compose. By the end you will have Darbaan reading your mailbox over IMAP
+and holding outbound mail for your approval over SMTP.
+
+## 1. Prerequisites
+
+- **Docker** and the **Docker Compose plugin** (`docker compose version`).
+- An **upstream mailbox** you want to gate, plus credentials for it. For Gmail
+  this means an **app password** (with 2-Step Verification enabled on the
+  account); a normal password will not work for IMAP/SMTP.
+- (Optional) A **Telegram bot token** and your Telegram user ID, if you want to
+  approve outbound mail from your phone.
+- A shell with `openssl` for generating the TLS and signing keys below.
+
+## 2. Get the code
+
+```sh
+git clone https://github.com/yaad-index/darbaan.git
+cd darbaan
+```
+
+Everything below is run from the repository root.
+
+## 3. Create the secrets
+
+Darbaan never bakes secrets into the image — they are mounted from `./secrets/`
+and read from `.env`. Create the key material first.
+
+### TLS (required unless you explicitly allow plaintext)
+
+The agent connects to Darbaan over STARTTLS. For a trusted-LAN / localhost
+deployment a self-signed certificate is fine:
+
+```sh
+mkdir -p secrets/tls
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout secrets/tls/key.pem -out secrets/tls/cert.pem \
+  -days 3650 -subj "/CN=darbaan.local"
+```
+
+(For a localhost-only first run you can instead skip TLS — see the
+`DARBAAN_LISTENER_ALLOW_INSECURE` note in `docker-compose.yml` — but TLS is the
+default and recommended path.)
+
+### DKIM signing key (for trustworthy bounces)
+
+When Darbaan rejects a send it returns a **DKIM-signed bounce**, so the agent can
+trust it. Generate an ed25519 key:
+
+```sh
+mkdir -p secrets/dkim
+openssl genpkey -algorithm ed25519 -out secrets/dkim/dkim.pem
+```
+
+Publish the matching public key as a DKIM `TXT` record for your bounce domain
+(selector `darbaan` by default), so signatures verify:
+
+```
+darbaan._domainkey.<your-bounce-domain>   TXT   "v=DKIM1; k=ed25519; p=<base64-public-key>"
+```
+
+Extract the public key with:
+
+```sh
+openssl pkey -in secrets/dkim/dkim.pem -pubout -outform DER | tail -c 32 | base64
+```
+
+## 4. Configure `.env`
+
+```sh
+cp .env.example .env
+```
+
+Edit `.env` and set:
+
+| Variable | Required | Purpose |
+|---|---|---|
+| `DARBAAN_AGENT_PASS` | yes | the agent's login password to Darbaan's IMAP/SMTP faces |
+| `DARBAAN_ADMIN_TOKEN` | yes | bearer token for the localhost-only admin API (approval) |
+| `DARBAAN_SMTP_PASSWORD` | to deliver | upstream app password (only when sending is switched on) |
+| `DARBAAN_INBOUND_IMAP_PASSWORD` | to read | upstream app password for the mailbox to sync |
+| `DARBAAN_FACE_BIND` | optional | `0.0.0.0` to reach the faces from a trusted LAN; default `127.0.0.1` |
+| `DARBAAN_TELEGRAM_TOKEN` | for Telegram | bot token for the phone approval client |
+| `DARBAAN_TELEGRAM_OPERATOR_ID` | for Telegram | your Telegram user ID (only this user may approve) |
+
+The agent username defaults to `agent` (set in `docker-compose.yml`).
+
+## 5. Choose what's switched on (in `docker-compose.yml`)
+
+Darbaan is **safe by default**: it sends nothing and syncs nothing until you opt
+in. In the `darbaan` service's `environment:`:
+
+### Outbound delivery (default: stub = nothing leaves)
+
+```yaml
+DARBAAN_SENDER_TYPE: "smtp"            # was "stub"
+DARBAAN_SMTP_HOST: "smtp.gmail.com:587"
+DARBAAN_SMTP_USERNAME: "you@gmail.com"
+# DARBAAN_SMTP_PASSWORD comes from .env
+```
+
+While `sender-type=stub`, submissions are still held and approvable, but an
+approved message is **not actually delivered** — a deliberate safety default.
+
+### Inbound sync (default: off)
+
+```yaml
+DARBAAN_INBOUND_IMAP_HOST: "imap.gmail.com:993"
+DARBAAN_INBOUND_IMAP_USERNAME: "you@gmail.com"
+DARBAAN_INBOUND_IMAP_MAILBOX: "INBOX"
+DARBAAN_INBOUND_MAX_AGE: "1y"          # only sync mail newer than this
+# DARBAAN_INBOUND_IMAP_PASSWORD comes from .env
+```
+
+`inbound-max-age` is **forward-only**: widening it later requires a re-sync.
+
+### Bounce identity
+
+```yaml
+DARBAAN_DKIM_SELECTOR: "darbaan"
+DARBAAN_DKIM_DOMAIN: "<your-bounce-domain>"
+```
+
+## 6. Start it
+
+```sh
+docker compose up -d --build
+```
+
+This starts two containers: `darbaan` (the SMTP + IMAP faces and the
+localhost-only admin API) and `darbaan-telegram` (the optional phone approval
+client; harmless if you have not set a token, but you can remove that service
+from the compose file if unused).
+
+Check it came up:
+
+```sh
+docker compose ps
+docker compose logs darbaan | tail
+```
+
+You should see a line reporting the SMTP, IMAP, and admin addresses, and (if
+enabled) the inbound sync target and interval.
+
+## 7. Verify the faces
+
+The agent faces are published on:
+
+- **IMAP** `<host>:1143` — read mail
+- **SMTP** `<host>:1465` — submit mail
+
+(`<host>` is `127.0.0.1` by default, or the LAN address if you set
+`DARBAAN_FACE_BIND=0.0.0.0`.) Connect with any IMAP/SMTP client using the agent
+username/password over STARTTLS. The admin API on `127.0.0.1:1144` is **not**
+published to the network and is for the operator only.
+
+## 8. Approving outbound mail
+
+Submitted mail is **held** until you approve it. Two operator interfaces:
+
+**CLI** (runs inside the container, authenticates via the admin token it
+inherits):
+
+```sh
+docker exec darbaan-darbaan-1 darbaan queue ls          # list held + decided
+docker exec darbaan-darbaan-1 darbaan queue approve <id>
+docker exec darbaan-darbaan-1 darbaan queue reject <id>
+```
+
+**Telegram**: once `DARBAAN_TELEGRAM_TOKEN` + `DARBAAN_TELEGRAM_OPERATOR_ID` are
+set, the `darbaan-telegram` container messages you on each held item with
+approve/reject buttons.
+
+## 9. End-to-end smoke test
+
+1. Submit a message through the SMTP face (any SMTP client, agent creds, STARTTLS).
+2. `docker exec darbaan-darbaan-1 darbaan queue ls` — it shows `pending`.
+3. Approve it (CLI or Telegram).
+4. With `sender-type=smtp` it is delivered; reject one instead and a
+   **DKIM-signed bounce** appears in the IMAP inbox.
+
+## 10. Troubleshooting
+
+- **`AUTHENTICATIONFAILED` to the upstream** — the app password is wrong or
+  revoked, or 2-Step Verification is not enabled on the upstream account.
+- **Agent can't connect / connection refused from another host** — set
+  `DARBAAN_FACE_BIND=0.0.0.0` and recreate (`docker compose up -d`); by default
+  the faces bind to localhost only.
+- **Approved mail doesn't arrive** — `sender-type` is still `stub`; flip it to
+  `smtp` and set the username + `DARBAAN_SMTP_PASSWORD`.
+- **TLS errors on a self-signed cert** — the client must accept the self-signed
+  certificate (or use a real one); for a localhost-only trial you can enable the
+  insecure-plaintext option noted in `docker-compose.yml`.
+- **Bounce won't verify** — confirm the DKIM `TXT` record matches the generated
+  public key and the configured selector/domain.
+
+## Configuration reference
+
+The full list of settings (file `<` env `<` flag precedence) is available from:
+
+```sh
+docker exec darbaan-darbaan-1 darbaan --help
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -116,6 +116,13 @@ DARBAAN_INBOUND_MAX_AGE: "1y"          # only sync mail newer than this
 
 `inbound-max-age` is **forward-only**: widening it later requires a re-sync.
 
+**Optional inbound filter.** You can gate what the client sees: mount a YAML
+rules file and point at it with `DARBAAN_INBOUND_FILTER`. Rules match on message
+fields and **allow**, **hide**, or **hold-for-review** each message, with a
+configurable default. Left unset, the client sees the full synced mailbox. Note
+that a configured filter means the client's inbox may intentionally show fewer
+messages than the real mailbox.
+
 ### Bounce identity
 
 ```yaml

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,8 +118,8 @@ DARBAAN_INBOUND_MAX_AGE: "1y"          # only sync mail newer than this
 
 **Optional inbound filter.** You can gate what the client sees: mount a YAML
 rules file and point at it with `DARBAAN_INBOUND_FILTER`. Rules match on message
-fields and **allow**, **hide**, or **hold-for-review** each message, with a
-configurable default. Left unset, the client sees the full synced mailbox. Note
+fields and **allow**, **hide**, or **hold-for-human** each message (those are the
+literal action values), with a configurable default. Left unset, the client sees the full synced mailbox. Note
 that a configured filter means the client's inbox may intentionally show fewer
 messages than the real mailbox.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -123,6 +123,31 @@ DARBAAN_DKIM_SELECTOR: "darbaan"
 DARBAAN_DKIM_DOMAIN: "<your-bounce-domain>"
 ```
 
+### Telegram approval (optional)
+
+The Telegram client lets you approve or reject held mail from your phone. To set
+it up:
+
+1. **Create a bot.** In Telegram, open a chat with **@BotFather**, send
+   `/newbot`, and follow the prompts. BotFather replies with a **bot token** —
+   put it in `.env` as `DARBAAN_TELEGRAM_TOKEN`.
+2. **Find your user ID.** Message a bot such as **@userinfobot**; it replies with
+   your numeric Telegram user ID. Put it in `.env` as
+   `DARBAAN_TELEGRAM_OPERATOR_ID`. **Only this user ID can approve or reject** —
+   any other person who messages the bot is ignored.
+3. **Start the chat.** Send `/start` to your new bot once, so Telegram allows the
+   bot to message you.
+
+With both values set, the `darbaan-telegram` container polls the admin API and
+sends you a message for each held outbound item, with **Approve** / **Reject**
+buttons; tapping one decides that message and the buttons clear. It holds no mail
+credentials and only talks to the localhost admin API — it is purely a remote
+control for the approval queue.
+
+If you do not want phone approval, leave these two values unset and remove the
+`darbaan-telegram` service from `docker-compose.yml`; the CLI (section 8) approves
+mail on its own.
+
 ## 6. Start it
 
 ```sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -198,7 +198,8 @@ inherits):
 ```sh
 docker exec darbaan-darbaan-1 darbaan queue ls          # list held + decided
 docker exec darbaan-darbaan-1 darbaan queue approve <id>
-docker exec darbaan-darbaan-1 darbaan queue reject <id>
+docker exec darbaan-darbaan-1 darbaan queue reject <id> --reason "not allowed"
+# reject requires --reason; add --retryable to mark it a transient failure
 ```
 
 **Telegram**: once `DARBAAN_TELEGRAM_TOKEN` + `DARBAAN_TELEGRAM_OPERATOR_ID` are

--- a/README.md
+++ b/README.md
@@ -1,76 +1,65 @@
 # Darbaan
 
-Darbaan is a **mail-gate proxy**. An agent talks to it over standard **IMAP
-(read)** and **SMTP (send)**, and Darbaan enforces policy mechanically in front
-of the real mailbox. It holds the upstream mailbox credentials and the
-bounce-signing key, so a compromised agent only ever holds *Darbaan* credentials
-— never the real mailbox (credential isolation, [ADR 0002](adr/0002-policy-in-a-separate-box-credential-isolation.md)).
+**Darbaan is a mail-gate proxy.** An agent (or any client) talks to it over
+standard **IMAP** to read mail and **SMTP** to send mail, and Darbaan enforces
+policy in front of the real mailbox. Darbaan holds the upstream mailbox
+credentials and the bounce-signing key, so a compromised client only ever holds
+*Darbaan* credentials — never the real mailbox.
 
-The design is recorded as Architecture Decision Records in [`adr/`](adr/) — start
-with [ADR 0001](adr/0001-mail-proxy-not-http-api.md).
+Two properties define it:
 
-## Outbound — default-deny send
+- **Outbound is default-deny.** Nothing a client submits is sent until a human
+  approves it.
+- **Inbound is gated.** The client reads a synced, recency-bounded view of the
+  real mailbox, never the live account directly.
 
-An agent submits over SMTP; nothing leaves until it's approved.
+## Outbound — nothing leaves without approval
 
-1. **Sluice trap.** Every submission is trapped in a default-deny sluice
-   ([ADR 0003](adr/0003-outbound-sluice-trap-default-deny.md)) — held, not sent.
-2. **Approval.** A pluggable approval chain ([ADR 0004](adr/0004-pluggable-approval-pipeline.md))
-   decides each held message. Approval is operator-driven (see the clients below).
-3. **Release or reject.** On approval Darbaan sends via the upstream; on rejection
-   it returns a **DKIM-signed DSN bounce** ([ADR 0006](adr/0006-rejection-as-async-dsn-bounce.md),
-   [ADR 0007](adr/0007-signed-bounce-trust.md)) that the agent reads back over IMAP.
+A client submits a message over SMTP, and:
 
-> The upstream sender is **stub by default** — it sends *nothing*. Real delivery is
-> a deliberate opt-in (`sender-type=smtp` + an app password); until then the
-> default-deny holds structurally.
+1. **It is held.** Every submission is trapped in a default-deny sluice — queued,
+   not sent.
+2. **A human decides.** An operator approves or rejects each held message through
+   one of the approval clients (below). The client never approves its own mail.
+3. **Release or bounce.** On approval Darbaan delivers via the upstream provider
+   and signs the message; on rejection it returns a **DKIM-signed bounce** that
+   the client reads back over IMAP and can cryptographically trust.
+
+The upstream sender is **stub by default** — it delivers *nothing*. Real delivery
+is a deliberate opt-in, so the default-deny holds even before any policy is
+configured.
 
 ## Inbound — read the real mailbox, gated
 
-The agent reads its real mail *through* Darbaan ([ADR 0019](adr/0019-inbound-sync-store-canonical-lazy-no-filter.md)):
+- **Synced into Darbaan's own store.** Darbaan pulls from the upstream mailbox
+  incrementally (idempotent re-sync); the upstream is read-only except for label
+  writes.
+- **Lazy content.** Envelopes and headers sync eagerly; a message body is fetched
+  on first read and then cached, so listing the inbox downloads no bodies.
+- **Recency cutoff.** A configurable max age bounds the sync to recent mail, so a
+  deep mailbox doesn't pull years of history.
+- **Served over IMAP** as a single `INBOX`.
+- **Labeling.** A client labels mail with standard IMAP keywords; on a Gmail
+  backend these map to real Gmail labels (searchable as `label:...`), with
+  Darbaan's store canonical and the backend an eventually-consistent replica.
 
-- **Store-canonical incremental sync.** Darbaan pulls from the upstream mailbox
-  into its own store (UIDVALIDITY + cursor, idempotent re-sync). The upstream is
-  read-only except for label writes (below).
-- **Lazy content.** Headers/envelopes are synced eagerly; a message **body is
-  fetched on demand** the first time it's read, then cached. Listing the inbox
-  fetches zero bodies.
-- **Recency cutoff.** `inbound-max-age` (e.g. `1y`) bounds the sync to recent mail
-  ([ADR 0008](adr/0008-inbound-filter-yaml-rules.md), recency dimension), so a
-  deep mailbox doesn't pull decades of history.
-- **IMAP read face.** The synced mail is served back over IMAP.
-- **Agent labeling.** The agent labels mail via standard IMAP keywords
-  ([ADR 0020](adr/0020-agent-labeling-gmail-x-gm-labels.md)); on a Gmail backend
-  those map to real **X-GM-LABELS** (searchable as `label:...`), with the local
-  store canonical and the backend an eventually-consistent label replica.
+## Approval clients
 
-> The structured allow/hide/hold **inbound filter rules** (the rest of ADR 0008)
-> are still upcoming; v1 syncs the (recency-bounded) mailbox without per-message
-> rule evaluation.
+Darbaan's core runs the SMTP + IMAP faces and a **localhost-only admin API**. The
+operator-facing tools are separate processes that talk to that API, not compiled
+into the core:
 
-## Interfaces — clients over a local admin API
+- **CLI** — `darbaan queue …` lists and decides held messages.
+- **Telegram** — approve or reject from your phone.
 
-`serve` runs the SMTP + IMAP faces and a **localhost-only admin API**. The
-operator-facing interfaces are **separate processes** that talk to that API
-([ADR 0017](adr/0017-interfaces-as-clients-over-local-api.md)), not compiled into
-the core:
+## Install / run
 
-- **CLI** — `darbaan queue …` inspects and decides held messages.
-- **Telegram** — `darbaan telegram` notifies + approves/rejects from a phone.
+Darbaan is a single Go binary; the easiest deployment is Docker Compose. See
+**[INSTALL.md](INSTALL.md)** for a complete, from-scratch walkthrough (secrets,
+configuration, switching on delivery and inbound sync, approving mail, and an
+end-to-end smoke test).
 
-## Storage
-
-Tiered ([ADR 0018](adr/0018-tiered-storage-metadata-kv-content-filesystem.md)):
-message metadata lives in bbolt; raw content lives as filesystem blobs, written
-blob-first then metadata so a crash can only orphan a blob (swept at startup).
-The store is the canonical source; the IMAP/SMTP faces are translation adapters
-([ADR 0016](adr/0016-store-canonical-translation-faces.md)). An append-only audit
-log ([ADR 0011](adr/0011-append-only-audit-log.md)) records decisions.
-
-## Running it
-
-Darbaan is a single Go binary; the easiest deploy is Docker Compose. See
-[`docker-compose.yml`](docker-compose.yml) and [`.env.example`](.env.example).
+The short version:
 
 ```sh
 cp .env.example .env        # fill DARBAAN_AGENT_PASS, DARBAAN_ADMIN_TOKEN
@@ -78,20 +67,14 @@ cp .env.example .env        # fill DARBAAN_AGENT_PASS, DARBAAN_ADMIN_TOKEN
 docker compose up -d
 ```
 
-Key configuration (file `<` env `<` flag; full list via `darbaan --help`):
+The agent faces bind to `127.0.0.1` by default (set `DARBAAN_FACE_BIND=0.0.0.0`
+to reach them from a trusted LAN); the admin API is always localhost-only.
 
-| Setting | Env | Purpose |
-|---|---|---|
-| agent credential | `DARBAAN_AGENT_USERNAME` / `DARBAAN_AGENT_PASS` | the agent's IMAP/SMTP login to Darbaan |
-| admin token | `DARBAAN_ADMIN_TOKEN` | bearer token for the localhost admin API |
-| sender | `sender-type` (`stub`/`smtp`) + `DARBAAN_SMTP_PASSWORD` | upstream delivery; **stub by default** |
-| DKIM | `DARBAAN_DKIM_KEY_FILE` / `dkim-selector` / `dkim-domain` | bounce signing |
-| inbound sync | `DARBAAN_INBOUND_IMAP_HOST` / `…_USERNAME` / `DARBAAN_INBOUND_IMAP_PASSWORD` | upstream mailbox to sync (empty = sync off) |
-| recency cutoff | `inbound-max-age` (e.g. `1y`) | bound the initial sync to recent mail |
+## Design notes
 
-Ports bind to `127.0.0.1` only — Darbaan is a local-trusted-host service, not
-internet-facing. Secrets come from env/mounts, never the image
-([ADR 0012](adr/0012-deployment-and-secrets-at-rest.md)).
+The architecture and the reasoning behind each decision are recorded as
+Architecture Decision Records in [`adr/`](adr/), for those who want the detail.
+They are reference material — you do not need them to run or use Darbaan.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ operator-facing tools are separate processes that talk to that API, not compiled
 into the core:
 
 - **CLI** — `darbaan queue …` lists and decides held messages.
-- **Telegram** — approve or reject from your phone.
+- **Telegram** — approve or reject from your phone (setup in [INSTALL.md](INSTALL.md)).
 
 ## Install / run
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,129 @@
+# Working with Darbaan (the mail gate)
+
+Darbaan is a **mail-gate proxy**. Instead of talking to your email provider
+directly, your agent reads inbound mail and submits outbound mail **through
+Darbaan** over standard **IMAP** and **SMTP**. Darbaan holds the real mailbox
+credentials and enforces policy in front of them, so the agent only ever holds
+*Darbaan* credentials — never the real mailbox.
+
+Two things define how you work with it:
+
+- **Reading is gated and read-only.** You read a synced view of the real mailbox.
+- **Sending is default-deny.** Every message you submit is **held for human
+  approval** — a successful submit means "queued", not "delivered". Rejections
+  come back to you as a **signed bounce**.
+
+---
+
+## Connecting
+
+Darbaan exposes two agent-facing services. Both use **STARTTLS** and require the
+**agent login** (a username + password issued by the deployment — not the real
+mailbox credentials):
+
+| Face | Port | Use |
+|---|---|---|
+| IMAP | `1143` | read mail, label mail, read bounces |
+| SMTP | `1465` | submit mail for sending |
+
+- Connect plaintext, issue `STARTTLS`, then authenticate (`AUTH PLAIN`).
+- On a trusted deployment Darbaan may present a **self-signed certificate**; a
+  client on the trusted network skips certificate verification.
+- A separate admin API exists for the operator only — it is **not** reachable by
+  the agent and is not needed for any of the steps below.
+
+---
+
+## Reading mail (IMAP)
+
+- Darbaan serves the mailbox as a single **`INBOX`** — a synced, recency-bounded
+  view of received mail. Select it and use plain IMAP (`SEARCH`, `FETCH`).
+- **Standard IMAP only.** Do not rely on provider-specific extensions (Gmail raw
+  search, All-Mail folders, etc.); they are not available through the gate.
+- **Listing is cheap.** Envelopes and headers are synced eagerly; a message
+  **body is fetched on first read** and then cached. Listing the inbox downloads
+  no bodies.
+- The synced **store is canonical** — treat the face as read-only for content.
+- **Tracking what you have already processed:** keep your *own* marker. The
+  reliable pattern is a **UID high-water-mark** (remember the highest UID you
+  have handled; next run, process only `UID > high-water`), or a local record of
+  handled `Message-ID`s. Do not depend on server-side flags/keywords persisting
+  as your processed-state.
+
+A typical fetch loop: `SELECT INBOX` → `UID SEARCH ALL` → process the UIDs above
+your high-water → `UID FETCH <n> (RFC822)` → advance the high-water.
+
+---
+
+## Labeling mail
+
+- Apply a label with a **standard IMAP keyword**: `UID STORE <n> +FLAGS (mylabel)`
+  (remove with `-FLAGS`).
+- On a **Gmail-backed** deployment these keywords map to real **Gmail labels** —
+  searchable in Gmail as `label:mylabel`. The local store is canonical; the
+  provider label is an eventually-consistent replica.
+- Use labels for triage/organization you want reflected in the real mailbox
+  (e.g. marking something handled, flagging it for a human). Keep your own
+  processed-state separately (see above) rather than reading labels back as
+  control state.
+
+---
+
+## Sending mail (and the approval gate)
+
+Submitting is ordinary SMTP — `STARTTLS`, authenticate, then `MAIL FROM` /
+`RCPT TO` / `DATA` (or your SMTP client's `send_message`). **But:**
+
+1. **Every submission is held, not sent.** Darbaan is default-deny: a successful
+   submit means the message is **queued pending approval**, NOT delivered. Treat
+   a send as *asynchronous*.
+2. **A human operator approves or rejects** each held message out-of-band (e.g. a
+   queue CLI, or a phone approval client). Your agent does not approve its own
+   mail — that is the whole point of the gate.
+3. **Outcome:**
+   - **Approved** → Darbaan delivers via the upstream provider (and signs it).
+   - **Rejected** → you receive a **bounce** (next section). Nothing was sent.
+
+Design senders accordingly: submit, then expect *either* silent delivery (on
+approval) *or* a bounce (on rejection) — never assume immediate delivery, and do
+not retry blindly on "no confirmation".
+
+> Some deployments run the upstream sender in **stub** mode (it delivers nothing
+> even after approval) until real delivery is deliberately switched on. If
+> approved mail is not arriving, check whether the deployment has enabled real
+> sending.
+
+---
+
+## Bounces (handling rejections)
+
+When a held message is **rejected** (or otherwise can't be delivered), Darbaan
+emits a **DSN bounce** — a standard delivery-status-notification message — and
+you **read it back over IMAP**, in your inbox, like any other mail.
+
+- **The bounce is DKIM-signed by Darbaan** (its own signing selector + domain).
+  This is what makes a bounce *trustworthy*: **verify the DKIM signature** against
+  Darbaan's signing identity before acting on it. A bounce is a security-relevant
+  message (it tells you a send failed); a forged or unsigned "bounce" that does
+  not verify against Darbaan's key should **not** be trusted or acted on.
+- **Match it to your sent message.** The DSN echoes the original message's
+  headers (e.g. `Message-ID`), so you can tie the bounce back to the specific
+  submission it concerns.
+- **Read the reason.** The DSN carries the status/reason for the failure. Use it
+  to decide what to do — surface to a human, fix and resubmit, or drop — rather
+  than silently re-sending the same message (which will just be held again).
+
+---
+
+## Quick reference
+
+| Goal | How |
+|---|---|
+| Read new mail | IMAP `1143` → `SELECT INBOX` → fetch `UID > high-water` |
+| Label mail | IMAP `UID STORE <n> +FLAGS (label)` |
+| Send mail | SMTP `1465` → submit → **held for approval** |
+| Confirm a send | it's async: delivery is silent; a **signed bounce** means rejected |
+| Trust a bounce | verify its **DKIM signature** against Darbaan's identity first |
+
+Never hardcode the agent credential — load it from your deployment's
+configuration/secret store.

--- a/USAGE.md
+++ b/USAGE.md
@@ -38,6 +38,11 @@ mailbox credentials):
 
 - Darbaan serves the mailbox as a single **`INBOX`** — a synced, recency-bounded
   view of received mail. Select it and use plain IMAP (`SEARCH`, `FETCH`).
+- **It can be a filtered view.** The operator may configure rules that hide some
+  messages, or hold them back pending review, before they ever reach you. So your
+  `INBOX` can intentionally contain *fewer* messages than the underlying mailbox —
+  that is by design (gated), not lost mail. Don't treat a smaller-than-expected
+  inbox as an error.
 - **Standard IMAP only.** Do not rely on provider-specific extensions (Gmail raw
   search, All-Mail folders, etc.); they are not available through the gate.
 - **Listing is cheap.** Envelopes and headers are synced eagerly; a message


### PR DESCRIPTION
Makes the user-facing docs public-quality and standalone so they can ship with the app.

- **README.md** — rewritten as a public project intro; the per-section ADR links are gone, replaced by a single optional design-notes pointer to adr/.
- **INSTALL.md** (new) — full Docker run-through: prerequisites, generating TLS + DKIM keys, .env, switching on delivery and inbound sync, the approval clients, an end-to-end smoke test, and troubleshooting.
- **USAGE.md** (new) — standalone usage guide: connecting over IMAP/SMTP, reading, labeling, sending through the default-deny approval flow, and validating DKIM-signed bounces.

No internal references, no ADR-link clutter. For your review + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)