### PR TITLE
feat(filter): per-inbox default_visibility (ADR 0022)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -96,6 +96,7 @@ type CLI struct {
 	Serve      ServeCmd      `cmd:"" help:"Run the SMTP + IMAP faces and the admin API."`
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
 	Holds      HoldsCmd      `cmd:"" help:"Inspect and decide inbound messages held for a human (ADR 0021)."`
+	Filter     FilterCmd     `cmd:"" help:"Inspect the inbound filter without starting serve (ADR 0021/0022)."`
 	Telegram   TelegramCmd   `cmd:"" help:"Run the Telegram approval client (a separate admin-API client process)."`
 	DkimPubkey DkimPubkeyCmd `cmd:"" name:"dkim-pubkey" help:"Print the DKIM public-key record to pin to the agent."`
 	Version    VersionCmd    `cmd:"" help:"Print version and exit."`
@@ -293,6 +294,63 @@ func (*DkimPubkeyCmd) Run(cli *CLI) error {
 	}
 	fmt.Println(s.PublicKeyTXT())
 	return nil
+}
+
+// FilterCmd groups inbound-filter inspection subcommands (no serve, no stores).
+type FilterCmd struct {
+	Explain FilterExplainCmd `cmd:"" help:"Resolve and print the filter: the default disposition and each rule's resolved action (bare rules show the action implied by default_visibility)."`
+}
+
+// FilterExplainCmd compiles the inbound filter and prints its resolved shape — a
+// dry-run that surfaces what a bare (action-less) rule resolves to under the
+// configured default visibility (ADR 0022), so the disposition is auditable
+// without reading mail or starting serve.
+type FilterExplainCmd struct {
+	Path string `arg:"" optional:"" help:"Filter YAML path (defaults to --inbound-filter)." type:"path"`
+}
+
+func (c *FilterExplainCmd) Run(cli *CLI) error {
+	path := c.Path
+	if path == "" {
+		path = cli.InboundFilter
+	}
+	if path == "" {
+		return errors.New("no filter path: pass an argument or set --inbound-filter")
+	}
+	flt, err := filter.Load(path)
+	if err != nil {
+		return err
+	}
+	def := flt.Default()
+	fmt.Printf("filter: %s\n", path)
+	fmt.Printf("default: %s  (no match → %s)\n", def, visibilityWord(def))
+	rules := flt.Rules()
+	if len(rules) == 0 {
+		fmt.Println("rules: (none)")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "#\tMATCH\tACTION\tSOURCE")
+	for i, r := range rules {
+		source := "explicit"
+		if r.Implied {
+			source = "implied by default_visibility"
+		}
+		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\n", i+1, r.Match, r.Action, source)
+	}
+	return w.Flush()
+}
+
+// visibilityWord renders a no-match action as its operator-facing disposition.
+func visibilityWord(a filter.Action) string {
+	switch a {
+	case filter.Hide:
+		return "hidden"
+	case filter.Hold:
+		return "held for human"
+	default:
+		return "visible"
+	}
 }
 
 // VersionCmd prints the build version.

--- a/internal/filter/doc.go
+++ b/internal/filter/doc.go
@@ -1,6 +1,9 @@
 // Package filter applies the inbound rules: declarative YAML matched top-down,
-// first match wins, with actions hide | allow | hold-for-human and a
-// configurable no-match default. It controls read-time noise and attack
+// first match wins, with actions hide | allow | hold-for-human. A per-inbox
+// default_visibility (visible|hidden, ADR 0022) fixes the no-match default and
+// what a bare (action-less) rule does — a match flips visibility — so the common
+// allowlist/denylist inbox is a one-liner; an explicit action always wins and
+// hold-for-human is never implied. It controls read-time noise and attack
 // surface; it does not stop an injection from an allowed sender — the outbound
 // sluice does (ADR 0008).
 package filter

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -1,6 +1,7 @@
 package filter
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -53,8 +54,9 @@ type Filter struct {
 }
 
 type rule struct {
-	conds  []cond
-	action Action
+	conds   []cond
+	action  Action
+	implied bool // action came from the default disposition (a bare rule, ADR 0022)
 }
 
 type cond struct {
@@ -86,6 +88,48 @@ func (f *Filter) Default() Action {
 		return Allow
 	}
 	return f.def
+}
+
+// RuleView is a human-readable view of one compiled rule for the `filter
+// explain` dry-run (ADR 0022): the resolved action plus whether it was implied
+// by the default disposition (a bare rule) or written explicitly.
+type RuleView struct {
+	Match   string // the AND-ed conditions, rendered
+	Action  Action
+	Implied bool
+}
+
+// Rules returns the compiled rules in evaluation order as RuleViews, so the CLI
+// can show what each rule resolved to without re-parsing the YAML.
+func (f *Filter) Rules() []RuleView {
+	if f == nil {
+		return nil
+	}
+	out := make([]RuleView, 0, len(f.rules))
+	for _, r := range f.rules {
+		out = append(out, RuleView{Match: r.describe(), Action: r.action, Implied: r.implied})
+	}
+	return out
+}
+
+// describe renders a rule's AND-ed conditions for explain output.
+func (r rule) describe() string {
+	parts := make([]string, 0, len(r.conds))
+	for _, c := range r.conds {
+		parts = append(parts, c.describe())
+	}
+	return strings.Join(parts, " AND ")
+}
+
+func (c cond) describe() string {
+	field := c.field
+	if c.field == fieldHeader {
+		field = "header:" + c.header
+	}
+	if c.field == fieldAge {
+		return fmt.Sprintf("%s %s %s", field, c.op, c.dur)
+	}
+	return fmt.Sprintf("%s %s %q", field, c.op, c.value)
 }
 
 func (r rule) matches(m inbound.Message, now time.Time) bool {

--- a/internal/filter/load.go
+++ b/internal/filter/load.go
@@ -11,11 +11,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// YAML shapes. A filter is `default: <action>` plus an ordered `rules:` list;
-// each rule is `match:` (AND-ed conditions) + one `action:`.
+// YAML shapes. A filter is a per-inbox default disposition plus an ordered
+// `rules:` list; each rule is `match:` (AND-ed conditions) + an optional
+// `action:`. The disposition is `default_visibility: visible|hidden` (ADR 0022)
+// and fixes both the no-match default and what a bare (action-less) rule does.
+// The legacy `default: <action>` (ADR 0008/0021) is still honored for back-compat.
 type fileConfig struct {
-	Default string       `yaml:"default"`
-	Rules   []ruleConfig `yaml:"rules"`
+	DefaultVisibility string       `yaml:"default_visibility"`
+	Default           string       `yaml:"default"`
+	Rules             []ruleConfig `yaml:"rules"`
 }
 
 type ruleConfig struct {
@@ -55,25 +59,35 @@ func Compile(data []byte) (*Filter, error) {
 		return nil, fmt.Errorf("parse: %w", err)
 	}
 
-	def := Allow
-	if fc.Default != "" {
-		a, err := parseAction(fc.Default)
-		if err != nil {
-			return nil, fmt.Errorf("default: %w", err)
-		}
-		def = a
+	def, flip, flipSet, err := resolveDefault(fc)
+	if err != nil {
+		return nil, err
 	}
 
 	f := &Filter{def: def}
 	for i, rc := range fc.Rules {
-		action, err := parseAction(rc.Action)
-		if err != nil {
-			return nil, fmt.Errorf("rule %d: %w", i+1, err)
+		// A bare rule (no action:) takes the inverse of the default disposition
+		// — a match flips visibility (ADR 0022). An explicit action wins and is
+		// parsed as today; hold-for-human is therefore never implied by the mode.
+		var (
+			action  Action
+			implied bool
+		)
+		if rc.Action == "" {
+			if !flipSet {
+				return nil, fmt.Errorf("rule %d: no action and no default disposition to imply one (set default_visibility, or give the rule an explicit action)", i+1)
+			}
+			action, implied = flip, true
+		} else {
+			action, err = parseAction(rc.Action)
+			if err != nil {
+				return nil, fmt.Errorf("rule %d: %w", i+1, err)
+			}
 		}
 		if len(rc.Match) == 0 {
 			return nil, fmt.Errorf("rule %d: no match conditions", i+1)
 		}
-		r := rule{action: action}
+		r := rule{action: action, implied: implied}
 		for j, cc := range rc.Match {
 			c, err := compileCond(cc)
 			if err != nil {
@@ -84,6 +98,83 @@ func Compile(data []byte) (*Filter, error) {
 		f.rules = append(f.rules, r)
 	}
 	return f, nil
+}
+
+// visibility dispositions (ADR 0022).
+const (
+	visVisible = "visible"
+	visHidden  = "hidden"
+)
+
+// resolveDefault reconciles the first-class default_visibility/mode disposition
+// with the legacy default: action into the no-match action (def) and the action
+// a bare rule resolves to (flip; flipSet is false when no disposition implies
+// one — legacy default: hold-for-human, which has no visibility inverse).
+//
+// Precedence: an explicit default_visibility (or mode alias) sets the
+// disposition; a legacy default:, if also present, must agree. With only a
+// legacy default:, honor it (back-compat). With neither, the implicit default is
+// visible (default-allow) — every existing ADR 0021 config keeps working.
+func resolveDefault(fc fileConfig) (def, flip Action, flipSet bool, err error) {
+	vis, err := normVisibility(fc.DefaultVisibility)
+	if err != nil {
+		return "", "", false, err
+	}
+
+	var legacy Action
+	if fc.Default != "" {
+		legacy, err = parseAction(fc.Default)
+		if err != nil {
+			return "", "", false, fmt.Errorf("default: %w", err)
+		}
+	}
+
+	if vis != "" {
+		d := Allow
+		if vis == visHidden {
+			d = Hide
+		}
+		if fc.Default != "" && legacy != d {
+			return "", "", false, fmt.Errorf("default_visibility: %s conflicts with default: %s (use one)", vis, fc.Default)
+		}
+		return d, inverse(d), true, nil
+	}
+
+	if fc.Default != "" {
+		switch legacy {
+		case Allow:
+			return Allow, Hide, true, nil
+		case Hide:
+			return Hide, Allow, true, nil
+		default: // Hold has no visibility inverse: bare rules are not implied.
+			return legacy, "", false, nil
+		}
+	}
+
+	return Allow, Hide, true, nil
+}
+
+// inverse flips a visibility action (allow<->hide). Only called for Allow/Hide.
+func inverse(a Action) Action {
+	if a == Allow {
+		return Hide
+	}
+	return Allow
+}
+
+// normVisibility normalizes default_visibility into "" | visible | hidden.
+// (whitelist=visible / blacklist=hidden is conceptual framing in the ADR/docs,
+// not config surface — ADR 0022.)
+func normVisibility(s string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "":
+		return "", nil
+	case visVisible:
+		return visVisible, nil
+	case visHidden:
+		return visHidden, nil
+	}
+	return "", fmt.Errorf("default_visibility: unknown %q (visible|hidden)", s)
 }
 
 func parseAction(s string) (Action, error) {

--- a/internal/filter/load_test.go
+++ b/internal/filter/load_test.go
@@ -1,0 +1,128 @@
+package filter_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/filter"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// ADR 0022: default_visibility fixes the no-match default AND what a bare
+// (action-less) rule does. visible => no-match SHOW, bare match HIDE.
+func TestDefaultVisibilityVisible(t *testing.T) {
+	f, err := filter.Compile([]byte(`
+default_visibility: visible
+rules:
+  - match: [{field: from, op: domain, value: b.com}]
+`))
+	require.NoError(t, err)
+	now := time.Now()
+	// bare rule under visible flips a match to HIDE
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{Envelope: from("b.com")}, now))
+	// no match => default SHOW
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Envelope: from("other.com")}, now))
+	assert.Equal(t, filter.Allow, f.Default())
+}
+
+// hidden => no-match HIDE, bare match SHOW (the personal-inbox allowlist).
+func TestDefaultVisibilityHidden(t *testing.T) {
+	f, err := filter.Compile([]byte(`
+default_visibility: hidden
+rules:
+  - match: [{field: label, op: equals, value: x}]
+`))
+	require.NoError(t, err)
+	now := time.Now()
+	// bare rule under hidden flips a match to SHOW
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Keywords: []string{"x"}}, now))
+	// no match => default HIDE
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{Keywords: []string{"y"}}, now))
+	assert.Equal(t, filter.Hide, f.Default())
+}
+
+// An explicit action always wins over the mode-implied flip; hold-for-human is
+// never implied and stays explicit in either mode.
+func TestExplicitActionWinsOverFlip(t *testing.T) {
+	f, err := filter.Compile([]byte(`
+default_visibility: hidden
+rules:
+  - match: [{field: label, op: equals, value: review}]
+    action: hold-for-human
+  - match: [{field: from, op: domain, value: spam.example}]
+    action: hide
+  - match: [{field: label, op: equals, value: keep}]
+`))
+	require.NoError(t, err)
+	now := time.Now()
+	assert.Equal(t, filter.Hold, f.Decide(inbound.Message{Keywords: []string{"review"}}, now))
+	assert.Equal(t, filter.Hide, f.Decide(inbound.Message{Envelope: from("spam.example")}, now))
+	assert.Equal(t, filter.Allow, f.Decide(inbound.Message{Keywords: []string{"keep"}}, now)) // bare => flip to show
+}
+
+// Absent key behaves as today (default-allow); legacy default: + explicit
+// actions keep working untouched (back-compat is a hard requirement).
+func TestBackCompatLegacyDefault(t *testing.T) {
+	// absent disposition => visible/default-allow
+	f, err := filter.Compile([]byte(`
+rules:
+  - match: [{field: from, op: domain, value: spam.example}]
+    action: hide
+`))
+	require.NoError(t, err)
+	assert.Equal(t, filter.Allow, f.Default())
+
+	// legacy default: hide still honored; a bare rule flips to allow
+	g, err := filter.Compile([]byte(`
+default: hide
+rules:
+  - match: [{field: from, op: domain, value: trusted.example}]
+`))
+	require.NoError(t, err)
+	now := time.Now()
+	assert.Equal(t, filter.Hide, g.Default())
+	assert.Equal(t, filter.Allow, g.Decide(inbound.Message{Envelope: from("trusted.example")}, now))
+}
+
+// Synonymous values are accepted; only genuine contradictions are rejected.
+func TestDispositionConflicts(t *testing.T) {
+	// synonymous: visible + default: allow => OK
+	_, err := filter.Compile([]byte("default_visibility: visible\ndefault: allow\nrules: []"))
+	assert.NoError(t, err)
+
+	bad := []string{
+		"default_visibility: visible\ndefault: hide\nrules: []", // contradiction
+		"default_visibility: bogus\nrules: []",                  // unknown disposition
+		// a bare rule under legacy default: hold has no disposition to imply an action
+		"default: hold-for-human\nrules: [{match: [{field: from, op: equals, value: a@b.com}]}]",
+	}
+	for _, y := range bad {
+		_, err := filter.Compile([]byte(y))
+		assert.Error(t, err, y)
+	}
+}
+
+// Rules() exposes each rule's resolved action + whether it was implied, for the
+// `filter explain` dry-run.
+func TestRulesViewForExplain(t *testing.T) {
+	f, err := filter.Compile([]byte(`
+default_visibility: hidden
+rules:
+  - match: [{field: label, op: equals, value: x}]
+  - match: [{field: from, op: domain, value: spam.example}]
+    action: hold-for-human
+`))
+	require.NoError(t, err)
+	rules := f.Rules()
+	require.Len(t, rules, 2)
+	// bare rule: implied flip to allow (under hidden)
+	assert.Equal(t, filter.Allow, rules[0].Action)
+	assert.True(t, rules[0].Implied)
+	assert.Contains(t, rules[0].Match, "label")
+	// explicit rule
+	assert.Equal(t, filter.Hold, rules[1].Action)
+	assert.False(t, rules[1].Implied)
+}


### PR DESCRIPTION
Implements ADR 0022 (#114): a per-inbox default disposition for the inbound filter.

## What
- `default_visibility: visible | hidden` (single canonical key, no alias).
  - `visible` (default-allow): no match → show; a bare (action-less) rule → hide.
  - `hidden` (default-deny): no match → hide; a bare rule → show.
- Bare rules become match-only; the disposition decides what a match means. An explicit `action:` always wins, and `hold-for-human` is never implied by the disposition.
- `filter explain <path>` dry-run prints the resolved default disposition and each rule's resolved action, flagging whether it was implied by the disposition or written explicitly — so the bare-rule semantics are auditable without serving mail.

## Engine impact
Compile/load only (`internal/filter/load.go`). `Filter.Decide` (first-match action, else default) is unchanged.

## Back-compat (hard requirement)
- Absent key ⇒ `visible` (today's behavior); existing filter configs keep working untouched.
- Legacy `default: <action>` still honored. Specifying both is accepted when synonymous (`default: allow` + `default_visibility: visible`), and rejected only on a genuine contradiction.

## Tests
Both dispositions, the bare-rule flip, explicit-action-wins, back-compat (absent key + legacy `default:`), conflict rejection, and the explain view. Local gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Gated on ADR 0022 (#114) landing.
