### PR TITLE
docs(adr): 0025 approval-gate full-body fidelity for long messages

### DIFF
--- a/adr/0025-approval-gate-long-body-fidelity.md
+++ b/adr/0025-approval-gate-long-body-fidelity.md
@@ -1,0 +1,85 @@
+# ADR 0025: Approval gate — full-body fidelity for long messages (.txt attachment)
+
+**Status:** Proposed (2026-06-29)
+
+## Context
+
+The Telegram approval client (`internal/telegram`) renders a held message for the
+operator to review before release: headers (From / To / Cc), hidden-recipient
+warnings, the attachment list (each uploaded for inspection), and the decoded
+**text body** inline (`body.go: bodyText`). The decision keyboard (Approve /
+Reject) acts on that view (ADR 0004/0017).
+
+Telegram caps a text message at **4096 UTF-16 units** (and a media caption at
+1024). A long email body (a deep reply chain, a newsletter) **overflows that cap**,
+so the inline body is truncated by Telegram. The capture is **not** the problem —
+the sluice stores the full raw message and `bodyText` decodes all of it — the
+problem is **review fidelity**: the operator can be shown a truncated body and
+approve it believing they saw the whole thing. The full thread must be reviewable
+at the gate.
+
+## Decision
+
+When the body is too long to render inline, the Telegram client **attaches the
+full body as a `.txt` document to the same approval message**, and the inline
+preview is explicitly marked as truncated.
+
+### Specifics
+
+- **Threshold:** if the rendered body would push the notification over Telegram's
+  per-message limit, the body is **moved to an attached `.txt`** rather than
+  truncated silently. (Implementation picks the exact rune budget, leaving room for
+  the header/attachment-list block that shares the message.)
+- **Body only, not the `.eml`.** The attachment is the **decoded text body**
+  (`bodyText` output) — the headers and metadata are already shown in the message,
+  so the operator does not need the full raw `.eml`. (Operator confirmed: body
+  only, `.txt`, no PDF — PDF would need a rendering dependency.)
+- **Clearly the original message, not an email attachment.** `body.go` already
+  uploads the email's *own* attachments (the exfiltration-vector list). The
+  full-body `.txt` must be unmistakably distinct from those: a fixed, descriptive
+  filename (e.g. `original-message-body.txt`) and a caption that says it is the
+  **full text of the message under review**, not a file the message carried. It is
+  attached to / replied onto the **same** approval message so the operator sees it
+  in context with the Approve / Reject buttons.
+- **Truncation is never silent.** When the body is offloaded, the inline preview
+  ends with an explicit marker (e.g. `… [truncated — full body attached as
+  original-message-body.txt]`) so the operator knows the inline text is partial and
+  the decision should be made against the attachment.
+
+### Why the client, not the store
+
+The held payload is already complete (sluice stores `Raw`; `bodyText` decodes the
+whole body). This is purely a **delivery-fidelity** fix in the approval client
+(ADR 0017: interfaces are clients over the local API) — no store, admin-API, or
+filter change.
+
+## Boundaries / non-goals
+
+- **No PDF / rich rendering** (would add a dependency); plain `.txt` of the text
+  body is the deliverable.
+- **No raw `.eml` export** here — headers/metadata are already in the message; a
+  full-raw export is a separate need if it ever arises.
+- **HTML-only bodies:** when a message has no `text/plain` part, `bodyText` already
+  falls back to nested text; if it yields nothing, the `.txt` is empty/absent and
+  the existing attachment list still lets the operator open the raw parts. A
+  dedicated HTML-to-text path for the offloaded body is a possible follow-up, not
+  required here.
+
+## Consequences
+
+- The operator can always review the **complete** message body at the gate,
+  regardless of length, and is never silently shown a truncated view.
+- The full-body `.txt` is visually distinct from the email's own attachments, so it
+  cannot be mistaken for message-carried content.
+- Scope stays inside `internal/telegram`; the contract with the admin API and store
+  is unchanged.
+
+## Follow-ups
+
+- HTML-only → text extraction for the offloaded body, if HTML-only mail proves
+  common at the gate.
+- The sender-override at the approval gate (Approve / **Change** sender) is a
+  **separate** approval-client change tracked with the multi-inbox ADR (it needs
+  the configured per-inbox identity set); it is intentionally not in this ADR.
+
+Relates to ADR 0004, 0017.


### PR DESCRIPTION
## What

Adds **ADR 0025**: when a held message body is too long for Telegram's 4096-char limit, the approval client attaches the **full decoded body as `original-message-body.txt`** to the same approval message, and marks the inline preview as truncated.

## Why

The Telegram gate renders the body inline for review (`internal/telegram/body.go`). A long body (deep reply chain, newsletter) overflows Telegram's cap and is truncated — so the operator can approve believing they saw the whole message. Capture is fine (sluice stores the full `Raw`, `bodyText` decodes all of it); the gap is **review fidelity**.

## How

- Over the threshold -> body moves to an attached `.txt` instead of silent truncation.
- **Body only**, not the `.eml` (headers/metadata are already in the message). Plain `.txt`, no PDF (avoids a rendering dependency).
- **Clearly the message under review, not an email attachment**: fixed descriptive filename + caption, attached to the same approval message in context with the Approve/Reject buttons. Distinct from the email's own attachments that `body.go` already uploads.
- **Never silent**: inline preview ends with `… [truncated — full body attached as original-message-body.txt]`.

Client-only change (`internal/telegram`, ADR 0017); store/admin-API/filter untouched.

## Scope

The sender-override at the gate (Approve / **Change** sender) is a separate approval-client change tracked with the multi-inbox ADR — it needs the configured per-inbox identity set, so it's intentionally not here.

## Review asks
- forge-rubigd: read the shared PR skill, then review + implement (threshold split + sendDocument of the body .txt + truncation marker + HTML-only edge note).
- sora-rubigd: review the "distinct from email attachments" labeling — is the filename+caption enough that an operator can't confuse the body .txt with message-carried content.

Relates to ADR 0004, 0017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)