### PR TITLE
feat(signer): Verify for the inbound bounce-spoof trust check (ADR 0024)

### DIFF
--- a/internal/signer/signer.go
+++ b/internal/signer/signer.go
@@ -78,3 +78,36 @@ func (s *Signer) Sign(raw []byte) ([]byte, error) {
 func (s *Signer) PublicKeyTXT() string {
 	return "v=DKIM1; k=ed25519; p=" + base64.StdEncoding.EncodeToString(s.pubKey)
 }
+
+// Verify reports whether raw carries a valid DKIM signature from Darbaan's own
+// bounce selector/domain — the trust check for the inbound bounce-spoof guard
+// (ADR 0024, realizing ADR 0007's quarantine). Darbaan signs its own bounces, so
+// it can verify them: the key may be pinned out-of-band rather than published in
+// DNS, so the lookup is injected and resolves ONLY Darbaan's own
+// `<selector>._domainkey.<domain>` against the in-memory public key. A signature
+// from any other domain/selector has no key to check against and does not count,
+// and a forged `d=<our domain>` signature fails because it wasn't made with our
+// key. Returns true only if some signature with d=<our domain> verifies; an
+// unsigned message returns false. err is non-nil only on malformed input, never
+// for an unverified message (that is a clean false).
+func (s *Signer) Verify(raw []byte) (bool, error) {
+	want := s.opts.Selector + "._domainkey." + s.opts.Domain
+	record := s.PublicKeyTXT()
+	vs, err := dkim.VerifyWithOptions(bytes.NewReader(raw), &dkim.VerifyOptions{
+		LookupTXT: func(domain string) ([]string, error) {
+			if domain == want {
+				return []string{record}, nil
+			}
+			return nil, nil // foreign selector/domain: no key, so its signature can't verify
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("signer: dkim verify: %w", err)
+	}
+	for _, v := range vs {
+		if v.Err == nil && v.Domain == s.opts.Domain {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/signer/signer_test.go
+++ b/internal/signer/signer_test.go
@@ -73,6 +73,44 @@ func TestVerifyFailsOnTamper(t *testing.T) {
 	assert.Error(t, vs[0].Err) // body changed → signature no longer verifies
 }
 
+func TestVerifyOwnSignature(t *testing.T) {
+	s, err := signer.New(writeEd25519(t), "darbaan", "darbaan.test")
+	require.NoError(t, err)
+	signed, err := s.Sign([]byte("From: MAILER-DAEMON@darbaan.test\r\nSubject: x\r\n\r\nbody\r\n"))
+	require.NoError(t, err)
+
+	ok, err := s.Verify(signed)
+	require.NoError(t, err)
+	assert.True(t, ok) // our own signature verifies against our pinned key
+}
+
+func TestVerifyRejectsUnsignedTamperedAndForeign(t *testing.T) {
+	s, err := signer.New(writeEd25519(t), "darbaan", "darbaan.test")
+	require.NoError(t, err)
+
+	// unsigned: no DKIM-Signature → not trusted
+	ok, err := s.Verify([]byte("From: spoof@evil.test\r\nSubject: Returned mail\r\n\r\nfake bounce\r\n"))
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// tampered after signing → signature no longer verifies
+	signed, err := s.Sign([]byte("From: m@darbaan.test\r\nSubject: x\r\n\r\nbody\r\n"))
+	require.NoError(t, err)
+	tampered := bytes.Replace(signed, []byte("body"), []byte("evil"), 1)
+	ok, err = s.Verify(tampered)
+	require.NoError(t, err)
+	assert.False(t, ok)
+
+	// signed by a DIFFERENT domain's key (d= not ours) → no key to check, not trusted
+	other, err := signer.New(writeEd25519(t), "darbaan", "other.test")
+	require.NoError(t, err)
+	foreign, err := other.Sign([]byte("From: m@other.test\r\nSubject: x\r\n\r\nbody\r\n"))
+	require.NoError(t, err)
+	ok, err = s.Verify(foreign)
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
 func TestPublicKeyTXTFormat(t *testing.T) {
 	s, err := signer.New(writeEd25519(t), "sel", "dom")
 	require.NoError(t, err)


### PR DESCRIPTION
First of the ADR 0024 (bounce-spoof guard) implementation split — the trust-check primitive.

## What
Adds `Signer.Verify(raw) (bool, error)`: reports whether a message carries a valid DKIM signature from Darbaan's **own** bounce selector/domain (ADR 0024, realizing ADR 0007's quarantine). Darbaan signs its own bounces, so it can verify them.

- The key lookup is **injected** and resolves only `<selector>._domainkey.<domain>` against the in-memory public key — the bounce key may be pinned out-of-band rather than published in DNS.
- A signature from any other domain/selector has no key to check against; a forged `d=<our domain>` signature fails because it wasn't made with our key; an unsigned message returns a clean `false`.
- `err` is non-nil only on malformed input, never for an unverified message.

Single internal signing key (the existing global DKIM config), consistent with the bounce-guard's trust anchor — no per-inbox selectors.

## Scope
`internal/signer` only — the prerequisite primitive. The bounce-shape detection + guard logic (B) and the read-face wiring + config (C) follow as separate PRs.

## Tests
Own-signature verifies; unsigned, tampered, and foreign-domain-signed all rejected. Reuses `go-msgauth/dkim` (already in deps). Gate green: build, vet, gofmt, `go test -race`, golangci-lint v2.11.4 (0 issues).

Builds toward ADR 0024 (merged).
