### PR TITLE
feat(bounceguard): bounce-shape detection + spoof verdict (ADR 0024)

### DIFF
--- a/internal/bounceguard/bounceguard.go
+++ b/internal/bounceguard/bounceguard.go
@@ -1,0 +1,130 @@
+// Package bounceguard implements the inbound bounce-spoof guard (ADR 0024):
+// detect mail that LOOKS like a delivery-status notification (a bounce) but does
+// not carry a valid Darbaan bounce signature, so the read face can hide it ahead
+// of the user filter (ADR 0021/0022). It makes ADR 0007's "quarantine external
+// mail posing as a bounce" concrete: shape detection is deliberately broad and
+// cheap (headers/structure only); the precise gate is the signature check, so a
+// genuine Darbaan-issued bounce (ADR 0006) always passes and only unsigned
+// bounce-shaped mail is caught.
+package bounceguard
+
+import (
+	"bytes"
+	"net/mail"
+	"strings"
+
+	gomessage "github.com/emersion/go-message"
+	_ "github.com/emersion/go-message/charset" // register charsets so non-UTF-8 headers parse
+)
+
+// Verifier reports whether raw carries a valid Darbaan bounce signature (the
+// signer.Verify trust check, ADR 0007). It is injected so this package depends
+// only on the function shape, not on the signer.
+type Verifier func(raw []byte) (bool, error)
+
+// Guard decides whether a bounce-shaped message is a spoof — bounce-shaped but
+// not validly signed by Darbaan.
+type Guard struct{ verify Verifier }
+
+// New builds a Guard that uses verify as its trust check.
+func New(verify Verifier) *Guard { return &Guard{verify: verify} }
+
+// IsSpoof reports whether raw is a bounce-shaped message lacking a valid Darbaan
+// signature — a spoof candidate the read face should hide/hold (ADR 0024).
+// Secure by default:
+//
+//   - not bounce-shaped         → false (ordinary mail; the guard ignores it)
+//   - shaped + valid signature  → false (a genuine Darbaan-issued bounce, ADR 0006)
+//   - shaped + unsigned/invalid → true
+//   - shaped + verify error     → true, with the error (can't confirm ⇒ fail closed)
+//
+// Shape (cheap, header/structure) is checked first; the signature (which reads
+// the body) runs only on a shape hit, so ordinary mail never incurs the verify.
+func (g *Guard) IsSpoof(raw []byte) (bool, error) {
+	if !Shaped(raw) {
+		return false, nil
+	}
+	ok, err := g.verify(raw)
+	if err != nil {
+		return true, err // bounce-shaped and we couldn't confirm a valid signature → fail closed
+	}
+	return !ok, nil
+}
+
+// Shaped reports whether raw looks like a bounce / DSN — header and structure
+// shape only, no signature check (ADR 0024). Deliberately broad: the signature is
+// the precise gate, so a false shape-positive only costs a verify on otherwise
+// ordinary mail. Unparseable input is treated as not-shaped (the user filter
+// still applies).
+func Shaped(raw []byte) bool {
+	ent, err := gomessage.Read(bytes.NewReader(raw))
+	if err != nil || ent == nil {
+		return false
+	}
+	h := ent.Header
+	ct, params, _ := h.ContentType()
+
+	// multipart/report; report-type=delivery-status (RFC 6522)
+	if ct == "multipart/report" && strings.EqualFold(params["report-type"], "delivery-status") {
+		return true
+	}
+	// a message/delivery-status part anywhere in the structure
+	if hasDeliveryStatus(ent) {
+		return true
+	}
+	// null sender (<>) or MAILER-DAEMON / postmaster local-part, on Return-Path or From
+	if bounceSender(h.Get("Return-Path")) || bounceSender(h.Get("From")) {
+		return true
+	}
+	// RFC 3834 auto-reply combined with a delivery-status content type
+	if strings.Contains(strings.ToLower(h.Get("Auto-Submitted")), "auto-replied") &&
+		(ct == "multipart/report" || ct == "message/delivery-status") {
+		return true
+	}
+	return false
+}
+
+// hasDeliveryStatus reports whether the entity or any nested part is a
+// message/delivery-status (the machine-readable DSN part). It walks the in-memory
+// raw — no upstream fetch.
+func hasDeliveryStatus(ent *gomessage.Entity) bool {
+	mr := ent.MultipartReader()
+	if mr == nil {
+		ct, _, _ := ent.Header.ContentType()
+		return ct == "message/delivery-status"
+	}
+	for {
+		p, err := mr.NextPart()
+		if err != nil {
+			return false
+		}
+		if hasDeliveryStatus(p) {
+			return true
+		}
+	}
+}
+
+// bounceSender reports whether an address-header value is the null sender (<>,
+// RFC 5321's empty reverse-path) or has a MAILER-DAEMON / postmaster local-part,
+// case-insensitively — the classic bounce originators.
+func bounceSender(headerValue string) bool {
+	v := strings.TrimSpace(headerValue)
+	switch v {
+	case "":
+		return false
+	case "<>":
+		return true
+	}
+	addr, err := mail.ParseAddress(v)
+	if err != nil {
+		// Unparseable (e.g. a bare "MAILER-DAEMON"): scan the raw value instead.
+		lower := strings.ToLower(v)
+		return strings.Contains(lower, "mailer-daemon") || strings.Contains(lower, "postmaster")
+	}
+	local := addr.Address
+	if i := strings.LastIndex(local, "@"); i >= 0 {
+		local = local[:i]
+	}
+	local = strings.ToLower(local)
+	return local == "mailer-daemon" || local == "postmaster"
+}

--- a/internal/bounceguard/bounceguard_test.go
+++ b/internal/bounceguard/bounceguard_test.go
@@ -1,0 +1,72 @@
+package bounceguard_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/bounceguard"
+)
+
+const dsnReport = "Content-Type: multipart/report; report-type=\"delivery-status\"; boundary=\"b\"\r\n" +
+	"From: MAILER-DAEMON@mail.example\r\nSubject: Returned mail\r\n\r\n" +
+	"--b\r\nContent-Type: text/plain\r\n\r\nyour message bounced\r\n" +
+	"--b\r\nContent-Type: message/delivery-status\r\n\r\nFinal-Recipient: rfc822;x@y.test\r\nAction: failed\r\n" +
+	"--b--\r\n"
+
+func TestShaped(t *testing.T) {
+	shaped := map[string]string{
+		"multipart/report dsn":         dsnReport,
+		"message/delivery-status leaf": "Content-Type: message/delivery-status\r\nFrom: x@y.test\r\n\r\nstatus\r\n",
+		"mailer-daemon From":           "From: Mail Delivery Subsystem <MAILER-DAEMON@mail.example>\r\nSubject: x\r\n\r\nb\r\n",
+		"postmaster From":              "From: postmaster@mail.example\r\nSubject: x\r\n\r\nb\r\n",
+		"null sender Return-Path":      "Return-Path: <>\r\nFrom: whoever@x.test\r\nSubject: x\r\n\r\nb\r\n",
+		"auto-replied + dsn ct":        "Content-Type: message/delivery-status\r\nAuto-Submitted: auto-replied\r\nFrom: a@b.test\r\n\r\ns\r\n",
+	}
+	for name, raw := range shaped {
+		assert.True(t, bounceguard.Shaped([]byte(raw)), name)
+	}
+
+	notShaped := map[string]string{
+		"ordinary mail":      "From: alice@example.com\r\nTo: bob@example.com\r\nSubject: lunch?\r\n\r\nhey\r\n",
+		"plain auto-reply":   "From: a@b.test\r\nAuto-Submitted: auto-replied\r\nSubject: OOO\r\n\r\naway\r\n", // auto-reply without DSN content type
+		"postmaster in body": "From: alice@example.com\r\nSubject: hi\r\n\r\nemail postmaster@x for help\r\n",
+		"unparseable":        "\x00\x01 not a message",
+		"empty":              "",
+	}
+	for name, raw := range notShaped {
+		assert.False(t, bounceguard.Shaped([]byte(raw)), name)
+	}
+}
+
+func TestIsSpoofShapeFirstThenVerify(t *testing.T) {
+	ordinary := []byte("From: alice@example.com\r\nSubject: lunch?\r\n\r\nhey\r\n")
+
+	// Ordinary mail is not bounce-shaped → verify is never called (cheap-first).
+	called := false
+	g := bounceguard.New(func([]byte) (bool, error) { called = true; return false, nil })
+	spoof, err := g.IsSpoof(ordinary)
+	assert.NoError(t, err)
+	assert.False(t, spoof)
+	assert.False(t, called, "verify must not run on non-bounce-shaped mail")
+
+	// Bounce-shaped + valid signature → genuine bounce, not a spoof.
+	g = bounceguard.New(func([]byte) (bool, error) { return true, nil })
+	spoof, err = g.IsSpoof([]byte(dsnReport))
+	assert.NoError(t, err)
+	assert.False(t, spoof)
+
+	// Bounce-shaped + unsigned/invalid → spoof.
+	g = bounceguard.New(func([]byte) (bool, error) { return false, nil })
+	spoof, err = g.IsSpoof([]byte(dsnReport))
+	assert.NoError(t, err)
+	assert.True(t, spoof)
+
+	// Bounce-shaped + verify error → fail closed (spoof), surfacing the error.
+	boom := errors.New("malformed")
+	g = bounceguard.New(func([]byte) (bool, error) { return false, boom })
+	spoof, err = g.IsSpoof([]byte(dsnReport))
+	assert.ErrorIs(t, err, boom)
+	assert.True(t, spoof)
+}


### PR DESCRIPTION
Second of the ADR 0024 (bounce-spoof guard) split — the detection + verdict logic.

## What
New `internal/bounceguard`: decides whether a message is a **spoof candidate** — bounce-shaped but not validly signed by Darbaan.

- `Shaped(raw)` — cheap header/structure shape match (no signature): `multipart/report; report-type=delivery-status`, a `message/delivery-status` part anywhere, null-sender `<>` / `MAILER-DAEMON` / `postmaster` local-part (case-insensitive, on Return-Path or From), or RFC 3834 `Auto-Submitted: auto-replied` combined with a delivery-status content type. Deliberately broad; unparseable input → not shaped.
- `Guard.IsSpoof(raw)` — **shape-first, then verify-on-hit**: not shaped → false (ordinary mail never incurs the verify); shaped + valid signature → false (genuine bounce, ADR 0006); shaped + unsigned/invalid → true; shaped + verify error → true with the error (**fail closed** — can't confirm ⇒ treat as spoof).

The `Verifier` is an **injected func type**, so this package doesn't import `signer` — it composes with `signer.Verify` (PR #122) at the wiring step (C) without a hard dependency.

## Scope
`internal/bounceguard` only — pure logic + tests. Wiring it ahead of the user filter in the read face + `bounce_guard.{enabled,on_spoof}` config is the next PR (C), which depends on this + #122 being on main.

## Tests
All shape signals (positive + negatives incl. body-mention false-positive guard, plain auto-reply, unparseable), and the four IsSpoof outcomes including verify-not-called-on-ordinary-mail and fail-closed-on-error. Gate green: build, vet, gofmt, `go test -race`, golangci-lint v2.11.4 (0 issues).

Builds toward ADR 0024 (merged). Pairs with #122.
