### PR TITLE
feat(guard): wire bounce-spoof guard into read face + held-list + config (ADR 0024)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/bounceguard"
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/imapsync"
 	"github.com/yaad-index/darbaan/internal/inbound"
@@ -84,6 +85,9 @@ type CLI struct {
 	InboundSyncDB           string        `name:"inbound-sync-db" default:"darbaan-sync.db" help:"Path to the inbound sync-state (UIDVALIDITY + last UID) database." type:"path"`
 	InboundMaxAge           string        `name:"inbound-max-age" help:"Recency cutoff for the initial/full sync, e.g. 1y, 30d, 12h (ADR 0008). Empty = no cutoff (pull everything). Forward-only: widening it later needs a re-sync."`
 	InboundFilter           string        `name:"inbound-filter" help:"Path to the inbound filter rules (YAML, ADR 0021): serve-time allow/hide over synced mail. Empty = no filter (allow all)." type:"path"`
+
+	BounceGuardEnabled bool   `name:"bounce-guard-enabled" default:"true" help:"Inbound bounce-spoof guard (ADR 0024): hide mail posing as a delivery-status bounce that lacks a valid Darbaan signature. On by default; false is an explicit opt-out."`
+	BounceGuardOnSpoof string `name:"bounce-guard-on-spoof" default:"hide" enum:"hide,hold-for-human" help:"What to do with a spoof candidate: hide it from the agent (default), or hold-for-human (route to the inbound approval queue)."`
 
 	AgentUsername string `name:"agent-username" help:"The agent's Darbaan SMTP username. The password is supplied out-of-band via DARBAAN_AGENT_PASS, never inlined in config (ADR 0012)."`
 
@@ -440,14 +444,26 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
-	// The admin hold-for-human queue and the read face share one filter + owner
-	// (ADR 0021): the read face hides held mail, the admin surface decides it.
-	svc.SetInboundHolds(flt, cli.AgentUsername)
+	// The inbound bounce-spoof guard (ADR 0024) runs ahead of the user filter on
+	// both faces, verifying with the bounce signer's own key. On by default; an
+	// explicit opt-out is logged. on_spoof=hold-for-human routes spoofs to the
+	// inbound approval queue instead of hiding them.
+	var guard *bounceguard.Guard
+	if cli.BounceGuardEnabled {
+		guard = bounceguard.New(sgn.Verify)
+	} else {
+		fmt.Fprintln(os.Stderr, "darbaan: bounce-spoof guard DISABLED (bounce-guard-enabled=false)")
+	}
+	holdSpoof := cli.BounceGuardOnSpoof == "hold-for-human"
+	// The admin hold-for-human queue and the read face share one filter + owner +
+	// guard (ADR 0021/0024): the read face hides held/spoof mail, the admin surface
+	// decides it.
+	svc.SetInboundHolds(flt, cli.AgentUsername, guard, holdSpoof)
 	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer), flt)
+	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer), flt, guard, holdSpoof)
 	if err != nil {
 		return err
 	}

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -95,7 +95,7 @@ func TestHoldsRoundtrip(t *testing.T) {
 	svc := admin.NewService(q, inbox, fakeSender{nil}, testSigner(t), strictRouter(), "darbaan.test")
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(flt, "agent")
+	svc.SetInboundHolds(flt, "agent", nil, false)
 	_, held, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "review me", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
 	require.NoError(t, err)
 

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -88,15 +88,14 @@ func (s *Service) guardHoldsSpoof(m inbound.Message) bool {
 	if s.guard == nil || !s.holdSpoof {
 		return false
 	}
-	spoof, err := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
+	// Verdict is fail-CLOSED for a candidate it can't fetch/verify (ADR 0024), so
+	// a spoof the read face hides is also surfaced here for an operator decision —
+	// the two stay consistent. The error rides along with spoof=true; the read
+	// face logs it.
+	spoof, _ := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
 		fm, e := s.inbox.Get(s.owner, m.ID)
 		return fm.Raw, e
 	})
-	if err != nil {
-		// fail-open: a transient fetch error must not surface non-bounces; logged
-		// at the read face where the same verdict runs.
-		return false
-	}
 	return spoof
 }
 

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -16,6 +16,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/approver"
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/bounce"
+	"github.com/yaad-index/darbaan/internal/bounceguard"
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/policy"
@@ -29,14 +30,16 @@ type Signer interface {
 
 // Service runs the approval orchestration against the stores serve owns.
 type Service struct {
-	store  sluice.MessageStore
-	inbox  inbound.InboundStore
-	sender backend.Sender
-	signer Signer
-	router *policy.Router
-	domain string
-	filter *filter.Filter // inbound filter, for the hold-for-human queue (ADR 0021)
-	owner  string         // the agent whose inbound mailbox the holds belong to
+	store     sluice.MessageStore
+	inbox     inbound.InboundStore
+	sender    backend.Sender
+	signer    Signer
+	router    *policy.Router
+	domain    string
+	filter    *filter.Filter     // inbound filter, for the hold-for-human queue (ADR 0021)
+	owner     string             // the agent whose inbound mailbox the holds belong to
+	guard     *bounceguard.Guard // inbound bounce-spoof guard (ADR 0024; nil = off)
+	holdSpoof bool               // on_spoof=hold-for-human → spoofs join the held queue
 }
 
 // NewService wires the approval service. inbox and signer may be nil only when
@@ -47,15 +50,16 @@ func NewService(store sluice.MessageStore, inbox inbound.InboundStore, sender ba
 }
 
 // SetInboundHolds wires the inbound hold-for-human queue (ADR 0021): the filter
-// that decides which synced messages are held, and the agent (owner) they belong
-// to. Without it, HeldList is empty.
-func (s *Service) SetInboundHolds(flt *filter.Filter, owner string) {
-	s.filter, s.owner = flt, owner
+// that decides which synced messages are held, the agent (owner) they belong to,
+// and the bounce-spoof guard (ADR 0024). When the guard is set with holdSpoof,
+// spoof candidates also join the held queue. Without it, HeldList is empty.
+func (s *Service) SetInboundHolds(flt *filter.Filter, owner string, guard *bounceguard.Guard, holdSpoof bool) {
+	s.filter, s.owner, s.guard, s.holdSpoof = flt, owner, guard, holdSpoof
 }
 
-// HeldList returns the inbound messages held for a human decision (a hold-rule
-// match with no decision yet, ADR 0021) — the inbound mirror of the outbound
-// List.
+// HeldList returns the inbound messages held for a human decision with no
+// decision yet — a hold-rule match (ADR 0021) or, under on_spoof=hold-for-human,
+// a bounce-spoof candidate (ADR 0024). The inbound mirror of the outbound List.
 func (s *Service) HeldList() ([]inbound.Message, error) {
 	if s.inbox == nil {
 		return nil, nil
@@ -67,11 +71,46 @@ func (s *Service) HeldList() ([]inbound.Message, error) {
 	now := time.Now()
 	var held []inbound.Message
 	for _, m := range msgs {
-		if s.filter.Decide(m, now) == filter.Hold && m.HoldDecision == "" {
+		if m.HoldDecision != "" {
+			continue // already decided
+		}
+		if s.filter.Decide(m, now) == filter.Hold || s.guardHoldsSpoof(m) {
 			held = append(held, m)
 		}
 	}
 	return held, nil
+}
+
+// guardHoldsSpoof reports whether m is a bounce-spoof candidate routed to the
+// held queue (on_spoof=hold-for-human, ADR 0024). False when the guard is off or
+// on_spoof=hide (hidden spoofs aren't a human-decision queue item).
+func (s *Service) guardHoldsSpoof(m inbound.Message) bool {
+	if s.guard == nil || !s.holdSpoof {
+		return false
+	}
+	spoof, err := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
+		fm, e := s.inbox.Get(s.owner, m.ID)
+		return fm.Raw, e
+	})
+	if err != nil {
+		// fail-open: a transient fetch error must not surface non-bounces; logged
+		// at the read face where the same verdict runs.
+		return false
+	}
+	return spoof
+}
+
+// envelopeFromLocals returns the local-parts of a message's envelope From
+// addresses — the metadata-cheap input to the guard's From-precheck (ADR 0024).
+func envelopeFromLocals(m inbound.Message) []string {
+	if m.Envelope == nil {
+		return nil
+	}
+	out := make([]string, 0, len(m.Envelope.From))
+	for _, a := range m.Envelope.From {
+		out = append(out, a.Mailbox)
+	}
+	return out
 }
 
 // ExposeHeld approves a held message for the agent to see (ADR 0021).

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/bounceguard"
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/policy"
@@ -223,7 +224,7 @@ func TestInboundHoldQueue(t *testing.T) {
 	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(flt, "agent")
+	svc.SetInboundHolds(flt, "agent", nil, false)
 
 	_, _, err = inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1}) // allowed
 	require.NoError(t, err)
@@ -246,6 +247,47 @@ func TestInboundHoldQueue(t *testing.T) {
 	_, held2, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 3, UIDValidity: 1, Keywords: []string{"review"}})
 	require.NoError(t, err)
 	_, err = svc.DropHeld(held2.ID)
+	require.NoError(t, err)
+	list, err = svc.HeldList()
+	require.NoError(t, err)
+	assert.Empty(t, list)
+}
+
+// Under on_spoof=hold-for-human, a bounce-spoof candidate joins the held queue
+// (ADR 0024) alongside filter holds; ordinary mail does not.
+func TestInboundBounceGuardHold(t *testing.T) {
+	q, _ := seedStore(t)
+	inbox := newInbound(t)
+	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	passthrough, err := filter.Compile([]byte("")) // default-allow, no rules: only the guard holds
+	require.NoError(t, err)
+	// Verifier says "no valid Darbaan signature" → a bounce-shaped message is a spoof.
+	guard := bounceguard.New(func([]byte) (bool, error) { return false, nil })
+	svc.SetInboundHolds(passthrough, "agent", guard, true /* hold-for-human */)
+
+	// A bounce-shaped message from MAILER-DAEMON (envelope From hits the precheck;
+	// the stored raw is bounce-shaped) → spoof → held.
+	_, spoof, err := inbox.AddSynced(inbound.Delivery{
+		Owner: "agent", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{From: []inbound.Address{{Mailbox: "MAILER-DAEMON", Host: "mail.example"}}},
+		Raw:      []byte("From: MAILER-DAEMON@mail.example\r\nSubject: Returned mail\r\n\r\nbounced\r\n"),
+	})
+	require.NoError(t, err)
+	// Ordinary mail (non-candidate From) → no fetch, not a spoof, not held.
+	_, _, err = inbox.AddSynced(inbound.Delivery{
+		Owner: "agent", UpstreamUID: 2, UIDValidity: 1,
+		Envelope: &inbound.Envelope{From: []inbound.Address{{Mailbox: "alice", Host: "example.com"}}},
+		Raw:      []byte("From: alice@example.com\r\nSubject: lunch?\r\n\r\nhey\r\n"),
+	})
+	require.NoError(t, err)
+
+	list, err := svc.HeldList()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, spoof.ID, list[0].ID)
+
+	// Dropping decides it → off the held list.
+	_, err = svc.DropHeld(spoof.ID)
 	require.NoError(t, err)
 	list, err = svc.HeldList()
 	require.NoError(t, err)

--- a/internal/bounceguard/bounceguard.go
+++ b/internal/bounceguard/bounceguard.go
@@ -73,9 +73,14 @@ func Candidate(fromLocalParts []string) bool {
 // available. If rawInHand is non-empty it is checked directly (covers ALL shape
 // signals, no fetch). Otherwise, only a From-precheck Candidate triggers getRaw
 // (the bounded on-demand fetch) and a full check; a non-candidate passes without
-// a fetch. A getRaw failure is fail-OPEN (returns false with the error to log) —
-// a transient fetch error must not hide legitimate mail; the signature check
-// inside IsSpoof remains fail-closed.
+// a fetch.
+//
+// A getRaw failure on a Candidate is fail-CLOSED (returns true with the error):
+// Candidate reads the same From header bounceSender does, so a Candidate IS
+// bounce-shaped, and "bounce-shaped + unverifiable" is a spoof per ADR 0024 — a
+// transient fetch error must not surface a possibly-forged MAILER-DAEMON. A
+// non-candidate never fetches, so legitimate mail is never hidden on a fetch
+// error. The signature check inside IsSpoof is likewise fail-closed.
 func (g *Guard) Verdict(fromLocalParts []string, rawInHand []byte, getRaw func() ([]byte, error)) (bool, error) {
 	if len(rawInHand) > 0 {
 		return g.IsSpoof(rawInHand)
@@ -85,7 +90,7 @@ func (g *Guard) Verdict(fromLocalParts []string, rawInHand []byte, getRaw func()
 	}
 	raw, err := getRaw()
 	if err != nil {
-		return false, err
+		return true, err
 	}
 	return g.IsSpoof(raw)
 }

--- a/internal/bounceguard/bounceguard.go
+++ b/internal/bounceguard/bounceguard.go
@@ -51,6 +51,45 @@ func (g *Guard) IsSpoof(raw []byte) (bool, error) {
 	return !ok, nil
 }
 
+// Candidate reports whether any of a message's envelope From local-parts looks
+// like a bounce sender (mailer-daemon / postmaster, case-insensitive) — the
+// cheap, metadata-only pre-check that bounds the on-demand raw fetch at the lazy
+// read face (ADR 0024 v1; ADR 0019 keeps SELECT metadata-only). The null sender
+// <> is not in the stored envelope (it is the SMTP reverse-path, not the From
+// header), so it is caught only by the full Shaped() check once raw is in hand,
+// and by the follow-up shape-flag work — not by this pre-check.
+func Candidate(fromLocalParts []string) bool {
+	for _, lp := range fromLocalParts {
+		switch strings.ToLower(strings.TrimSpace(lp)) {
+		case "mailer-daemon", "postmaster":
+			return true
+		}
+	}
+	return false
+}
+
+// Verdict decides spoof for one message while honoring the lazy read face: the
+// full Shaped()+verify needs raw, so it is reached only when raw is cheaply
+// available. If rawInHand is non-empty it is checked directly (covers ALL shape
+// signals, no fetch). Otherwise, only a From-precheck Candidate triggers getRaw
+// (the bounded on-demand fetch) and a full check; a non-candidate passes without
+// a fetch. A getRaw failure is fail-OPEN (returns false with the error to log) —
+// a transient fetch error must not hide legitimate mail; the signature check
+// inside IsSpoof remains fail-closed.
+func (g *Guard) Verdict(fromLocalParts []string, rawInHand []byte, getRaw func() ([]byte, error)) (bool, error) {
+	if len(rawInHand) > 0 {
+		return g.IsSpoof(rawInHand)
+	}
+	if !Candidate(fromLocalParts) {
+		return false, nil
+	}
+	raw, err := getRaw()
+	if err != nil {
+		return false, err
+	}
+	return g.IsSpoof(raw)
+}
+
 // Shaped reports whether raw looks like a bounce / DSN — header and structure
 // shape only, no signature check (ADR 0024). Deliberately broad: the signature is
 // the precise gate, so a false shape-positive only costs a verify on otherwise

--- a/internal/bounceguard/bounceguard_test.go
+++ b/internal/bounceguard/bounceguard_test.go
@@ -71,11 +71,12 @@ func TestVerdict(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, v)
 
-	// candidate but fetch fails → fail-open (false) with the error surfaced
+	// candidate but fetch fails → fail-CLOSED (true): a candidate is bounce-shaped,
+	// and shaped+unverifiable is a spoof (ADR 0024); the error is surfaced for logging.
 	boom := errors.New("fetch failed")
 	v, err = unsigned.Verdict([]string{"postmaster"}, nil, func() ([]byte, error) { return nil, boom })
 	assert.ErrorIs(t, err, boom)
-	assert.False(t, v)
+	assert.True(t, v)
 }
 
 func TestIsSpoofShapeFirstThenVerify(t *testing.T) {

--- a/internal/bounceguard/bounceguard_test.go
+++ b/internal/bounceguard/bounceguard_test.go
@@ -40,6 +40,44 @@ func TestShaped(t *testing.T) {
 	}
 }
 
+func TestCandidate(t *testing.T) {
+	assert.True(t, bounceguard.Candidate([]string{"MAILER-DAEMON"}))
+	assert.True(t, bounceguard.Candidate([]string{"alice", "Postmaster"}))
+	assert.False(t, bounceguard.Candidate([]string{"alice", "bob"}))
+	assert.False(t, bounceguard.Candidate(nil))
+}
+
+func TestVerdict(t *testing.T) {
+	spoofRaw := []byte(dsnReport) // shaped, and our verifier says unsigned → spoof
+	unsigned := bounceguard.New(func([]byte) (bool, error) { return false, nil })
+
+	// raw in hand → full check, no fetch needed (fetch must NOT be called)
+	v, err := unsigned.Verdict(nil, spoofRaw, func() ([]byte, error) {
+		t.Fatal("getRaw must not be called when raw is in hand")
+		return nil, nil
+	})
+	assert.NoError(t, err)
+	assert.True(t, v)
+
+	// no raw, non-candidate From → pass without fetching
+	fetched := false
+	v, err = unsigned.Verdict([]string{"alice"}, nil, func() ([]byte, error) { fetched = true; return spoofRaw, nil })
+	assert.NoError(t, err)
+	assert.False(t, v)
+	assert.False(t, fetched, "non-candidate must not trigger a fetch")
+
+	// no raw, candidate From → fetch + full check → spoof
+	v, err = unsigned.Verdict([]string{"MAILER-DAEMON"}, nil, func() ([]byte, error) { return spoofRaw, nil })
+	assert.NoError(t, err)
+	assert.True(t, v)
+
+	// candidate but fetch fails → fail-open (false) with the error surfaced
+	boom := errors.New("fetch failed")
+	v, err = unsigned.Verdict([]string{"postmaster"}, nil, func() ([]byte, error) { return nil, boom })
+	assert.ErrorIs(t, err, boom)
+	assert.False(t, v)
+}
+
 func TestIsSpoofShapeFirstThenVerify(t *testing.T) {
 	ordinary := []byte("From: alice@example.com\r\nSubject: lunch?\r\n\r\nhey\r\n")
 

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -17,6 +17,7 @@ import (
 	"github.com/emersion/go-imap/v2/imapserver"
 	"github.com/emersion/go-message/textproto"
 
+	"github.com/yaad-index/darbaan/internal/bounceguard"
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 )
@@ -59,7 +60,7 @@ type IMAPServer struct {
 // content on demand; if nil it defaults to reading straight from the store
 // (no upstream — bounce-only / sync-disabled deployments have no pending
 // records).
-func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, flt *filter.Filter) (*IMAPServer, error) {
+func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, flt *filter.Filter, guard *bounceguard.Guard, holdSpoof bool) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -68,7 +69,7 @@ func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundS
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords, filter: flt}, nil, nil
+			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords, filter: flt, guard: guard, holdSpoof: holdSpoof}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -91,9 +92,11 @@ func (s *IMAPServer) Close() error { return s.imap.Close() }
 type imapSession struct {
 	cred          Credential
 	store         inbound.InboundStore
-	fetch         ContentFetch   // resolves message content on demand (per-FETCH)
-	writeKeywords KeywordWriter  // replicates a keyword change upstream (nil = local-only)
-	filter        *filter.Filter // serve-time inbound filter (nil = allow all; ADR 0021)
+	fetch         ContentFetch       // resolves message content on demand (per-FETCH)
+	writeKeywords KeywordWriter      // replicates a keyword change upstream (nil = local-only)
+	filter        *filter.Filter     // serve-time inbound filter (nil = allow all; ADR 0021)
+	guard         *bounceguard.Guard // inbound bounce-spoof guard, ahead of the filter (nil = off; ADR 0024)
+	holdSpoof     bool               // on_spoof=hold-for-human → held-semantics; false = hide
 	owner         string
 	authed        bool
 	selected      []inbound.Message // metadata snapshot taken at Select (no content)
@@ -110,11 +113,20 @@ func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err erro
 	if err != nil {
 		return nil, nil, err
 	}
-	if s.filter == nil {
-		return full, full, nil
-	}
 	now := time.Now()
 	for _, m := range full { // new backing slice — leave full intact for UIDNEXT
+		// The bounce-spoof guard runs AHEAD of the user filter (ADR 0024): it is a
+		// security floor, so a spoof can't be surfaced by a permissive default or a
+		// broad allow rule.
+		if s.guard != nil {
+			if s.guardHides(m) {
+				continue
+			}
+		}
+		if s.filter == nil {
+			visible = append(visible, m)
+			continue
+		}
 		switch s.filter.Decide(m, now) {
 		case filter.Allow:
 			visible = append(visible, m)
@@ -127,6 +139,42 @@ func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err erro
 		}
 	}
 	return full, visible, nil
+}
+
+// guardHides reports whether the bounce-spoof guard omits m from the read face.
+// A spoof under on_spoof=hide is always omitted; under on_spoof=hold-for-human it
+// is omitted until an operator exposes it (held-semantics, like a filter Hold),
+// and surfaced for decision via the admin held-list. A non-spoof returns false
+// (the user filter then applies). A guard error is logged and treated as
+// not-hiding (fail-open at the read face — the verify inside stays fail-closed).
+func (s *imapSession) guardHides(m inbound.Message) bool {
+	spoof, err := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
+		fm, e := s.fetch(s.owner, m.ID)
+		return fm.Raw, e
+	})
+	if err != nil {
+		log.Printf("darbaan imap: bounce-guard %s: %v", m.ID, err)
+	}
+	if !spoof {
+		return false
+	}
+	if s.holdSpoof && m.HoldDecision == inbound.HoldApproved {
+		return false // operator exposed it
+	}
+	return true
+}
+
+// envelopeFromLocals returns the local-parts of a message's envelope From
+// addresses (the metadata-cheap input to the guard's From-precheck, ADR 0024).
+func envelopeFromLocals(m inbound.Message) []string {
+	if m.Envelope == nil {
+		return nil
+	}
+	out := make([]string, 0, len(m.Envelope.From))
+	for _, a := range m.Envelope.From {
+		out = append(out, a.Mailbox)
+	}
+	return out
 }
 
 // uidNext returns the next UID, derived from the highest UID across ALL stored

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -145,8 +145,9 @@ func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err erro
 // A spoof under on_spoof=hide is always omitted; under on_spoof=hold-for-human it
 // is omitted until an operator exposes it (held-semantics, like a filter Hold),
 // and surfaced for decision via the admin held-list. A non-spoof returns false
-// (the user filter then applies). A guard error is logged and treated as
-// not-hiding (fail-open at the read face — the verify inside stays fail-closed).
+// (the user filter then applies). A guard error is fail-CLOSED (Verdict returns
+// spoof=true for a bounce-shaped candidate it couldn't fetch/verify, ADR 0024);
+// it is logged and the message is hidden.
 func (s *imapSession) guardHides(m inbound.Message) bool {
 	spoof, err := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
 		fm, e := s.fetch(s.owner, m.ID)

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -45,7 +45,7 @@ func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk, flt)
+		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk, flt, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -513,6 +513,6 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil, nil, nil)
+		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil, nil, nil, nil, false)
 	require.Error(t, err)
 }


### PR DESCRIPTION
Final piece of the ADR 0024 (bounce-spoof guard) split — wiring + config. Completes the guard against the lazy read-face decision in #125.

## What
The guard now runs **ahead of the user filter** on both inbound surfaces, verifying with the bounce signer's own key (`signer.Verify`, #122) via the `bounceguard` brain (#124):

- **Read face** (`listener`): in `listAndFilter`, the guard runs before the filter. A spoof under `on_spoof=hide` is omitted; under `on_spoof=hold-for-human` it's held-semantics (hidden until an operator exposes it).
- **Admin held-list** (`admin`): under `on_spoof=hold-for-human`, spoof candidates join the held queue (`HeldList`) alongside filter holds, so the operator can expose/drop them.
- **Lazy-safe verdict** (`bounceguard.Verdict`, added here): cheap envelope-From precheck (`MAILER-DAEMON`/`postmaster`) bounds an on-demand raw fetch → full `Shaped()`+verify on a hit; non-candidate From passes with no fetch; full guard runs opportunistically when `Raw` is already in hand. Matches #125 exactly (SELECT stays metadata-only, ADR 0019). Fetch error is fail-open at the read face; the signature check stays fail-closed.
- **Config**: `bounce-guard-enabled` (default true; explicit opt-out is logged) and `bounce-guard-on-spoof` (`hide` default | `hold-for-human`). On by default, secure by default.

## Cross-package touch (integration wiring)
This is the guard's integration PR, so it spans four packages: `bounceguard` (the shared `Candidate`/`Verdict` brain), `listener` (read-face hide), `admin` (held-list surface), `cmd` (config + wiring). No new feature logic is duplicated — the verdict lives once in `bounceguard`; the two surfaces call it with their own raw-fetcher.

## Known gap (v1, per ADR 0024 / #125)
A `multipart/report` DSN from a non-daemon From isn't caught at the read face (it doesn't impersonate the mailer daemon — the named ADR 0007 attack — and the From precheck is the only metadata-cheap signal). Deferred to the sync-time shape-flag follow-up (filed separately).

## Tests
`bounceguard`: `Candidate` + `Verdict` (raw-in-hand skips fetch, non-candidate skips fetch, candidate fetches+detects, fetch-error fail-open). `admin`: a spoof joins the held queue under hold-for-human and ordinary mail doesn't; drop decides it off. Existing read-face/admin tests updated for the new params (guard nil = unchanged behavior). Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Completes ADR 0024. Builds on #122 + #124 (merged).
