### PR TITLE
feat(inboxcfg): inbox config schema + implicit-default resolve (ADR 0023, 1/5)

### DIFF
--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -1,0 +1,116 @@
+// Package inboxcfg is the configuration schema for ADR 0023 multi-inbox: a named
+// list of inboxes, each with its own backend (ADR 0009), send identity, and
+// {default_visibility, rules} policy unit (ADR 0022). It parses the `inboxes:`
+// section and resolves the back-compat default — a config with no `inboxes:` is
+// one implicit "default" inbox built from the legacy top-level fields, so an
+// existing single-inbox deployment is unchanged.
+//
+// This increment is schema + validation only; wiring per-inbox sync / store /
+// filter / outbound routing onto these definitions lands in the later
+// increments. The single agent (ADR 0010) addresses each inbox by name.
+package inboxcfg
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/yaad-index/darbaan/internal/filter"
+)
+
+// Inbox is one configured mailbox the single agent addresses by name (ADR 0023).
+type Inbox struct {
+	Name     string  `yaml:"name"`
+	Identity string  `yaml:"identity"` // the From/envelope identity Darbaan sends as for this inbox
+	Backend  Backend `yaml:"backend"`
+
+	// The per-inbox filter policy unit (ADR 0021/0022). Captured as raw YAML so it
+	// compiles through the existing filter engine without re-exporting its config.
+	DefaultVisibility string    `yaml:"default_visibility"`
+	Rules             yaml.Node `yaml:"rules"`
+}
+
+// Backend is an inbox's upstream account coordinates (ADR 0009). Secrets
+// (passwords) are supplied out-of-band via env/secret, never in config
+// (ADR 0012), so they are not fields here.
+type Backend struct {
+	IMAPHost     string `yaml:"imap_host"`
+	IMAPUsername string `yaml:"imap_username"`
+	IMAPMailbox  string `yaml:"imap_mailbox"`
+	MaxAge       string `yaml:"max_age"`
+	SenderType   string `yaml:"sender_type"`
+	SMTPHost     string `yaml:"smtp_host"`
+	SMTPUsername string `yaml:"smtp_username"`
+}
+
+type fileConfig struct {
+	Inboxes []Inbox `yaml:"inboxes"`
+}
+
+// Parse reads the `inboxes:` list from a config document. An absent or empty
+// `inboxes:` yields nil — the caller substitutes the implicit default via
+// Resolve.
+func Parse(data []byte) ([]Inbox, error) {
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("inboxcfg: parse: %w", err)
+	}
+	return fc.Inboxes, nil
+}
+
+// Resolve returns the configured inboxes, or a single implicit inbox when none
+// are configured — the back-compat path so a legacy single-inbox config keeps
+// working unchanged (ADR 0023). implicit is built by the caller from the legacy
+// top-level fields.
+func Resolve(parsed []Inbox, implicit Inbox) []Inbox {
+	if len(parsed) == 0 {
+		return []Inbox{implicit}
+	}
+	return parsed
+}
+
+// Validate checks an inbox list: at least one inbox, unique non-empty names, and
+// each inbox's filter compiles. Identity is not required here — an inbox may be
+// receive-only; outbound identity matching is enforced where mail is sent.
+func Validate(inboxes []Inbox) error {
+	if len(inboxes) == 0 {
+		return fmt.Errorf("inboxcfg: no inboxes configured")
+	}
+	seen := make(map[string]bool, len(inboxes))
+	for i, in := range inboxes {
+		name := strings.TrimSpace(in.Name)
+		if name == "" {
+			return fmt.Errorf("inboxcfg: inbox %d: name is required", i+1)
+		}
+		if seen[name] {
+			return fmt.Errorf("inboxcfg: duplicate inbox name %q", name)
+		}
+		seen[name] = true
+		if _, err := in.Filter(); err != nil {
+			return fmt.Errorf("inboxcfg: inbox %q: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// Filter compiles the inbox's {default_visibility, rules} policy unit (ADR
+// 0021/0022) via the shared filter engine. An inbox with neither key yields a
+// pass-through (default-allow) filter.
+func (in Inbox) Filter() (*filter.Filter, error) {
+	doc := map[string]any{}
+	if in.DefaultVisibility != "" {
+		doc["default_visibility"] = in.DefaultVisibility
+	}
+	if !in.Rules.IsZero() {
+		doc["rules"] = &in.Rules
+	}
+	if len(doc) == 0 {
+		return filter.Compile(nil)
+	}
+	b, err := yaml.Marshal(doc)
+	if err != nil {
+		return nil, fmt.Errorf("marshal filter: %w", err)
+	}
+	return filter.Compile(b)
+}

--- a/internal/inboxcfg/inboxcfg_test.go
+++ b/internal/inboxcfg/inboxcfg_test.go
@@ -1,0 +1,97 @@
+package inboxcfg_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/filter"
+	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/inboxcfg"
+)
+
+const twoInboxes = `
+inboxes:
+  - name: work
+    identity: agent@company.example
+    backend:
+      imap_host: imap.company.example:993
+      imap_username: agent@company.example
+      sender_type: smtp
+    default_visibility: visible
+    rules:
+      - match: [{field: from, op: domain, value: spam.example}]
+  - name: personal
+    identity: me@personal.example
+    backend:
+      imap_host: imap.personal.example:993
+    default_visibility: hidden
+    rules:
+      - match: [{field: label, op: equals, value: keep}]
+`
+
+func TestParse(t *testing.T) {
+	got, err := inboxcfg.Parse([]byte(twoInboxes))
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+	assert.Equal(t, "work", got[0].Name)
+	assert.Equal(t, "agent@company.example", got[0].Identity)
+	assert.Equal(t, "imap.company.example:993", got[0].Backend.IMAPHost)
+	assert.Equal(t, "smtp", got[0].Backend.SenderType)
+	assert.Equal(t, "personal", got[1].Name)
+	assert.Equal(t, "hidden", got[1].DefaultVisibility)
+
+	// No inboxes: section → nil (caller substitutes the implicit default).
+	none, err := inboxcfg.Parse([]byte("agent_username: agent\n"))
+	require.NoError(t, err)
+	assert.Nil(t, none)
+}
+
+func TestResolveImplicitDefault(t *testing.T) {
+	implicit := inboxcfg.Inbox{Name: "default", Identity: "agent@x.test"}
+	// No configured inboxes → the single implicit default (back-compat).
+	got := inboxcfg.Resolve(nil, implicit)
+	require.Len(t, got, 1)
+	assert.Equal(t, "default", got[0].Name)
+	// Configured inboxes take precedence over the implicit default.
+	parsed, err := inboxcfg.Parse([]byte(twoInboxes))
+	require.NoError(t, err)
+	assert.Len(t, inboxcfg.Resolve(parsed, implicit), 2)
+}
+
+func TestValidate(t *testing.T) {
+	ok, err := inboxcfg.Parse([]byte(twoInboxes))
+	require.NoError(t, err)
+	assert.NoError(t, inboxcfg.Validate(ok))
+
+	assert.Error(t, inboxcfg.Validate(nil)) // no inboxes
+
+	dup := []inboxcfg.Inbox{{Name: "a"}, {Name: "a"}}
+	assert.Error(t, inboxcfg.Validate(dup)) // duplicate name
+
+	noname := []inboxcfg.Inbox{{Name: " "}}
+	assert.Error(t, inboxcfg.Validate(noname)) // empty name
+
+	bad := []inboxcfg.Inbox{{Name: "x", DefaultVisibility: "bogus"}}
+	assert.Error(t, inboxcfg.Validate(bad)) // filter fails to compile
+}
+
+func TestInboxFilter(t *testing.T) {
+	in, err := inboxcfg.Parse([]byte(twoInboxes))
+	require.NoError(t, err)
+	now := time.Now()
+
+	// personal: hidden (default-deny); a bare rule on label=keep flips to SHOW.
+	flt, err := in[1].Filter()
+	require.NoError(t, err)
+	assert.Equal(t, filter.Hide, flt.Default())
+	assert.Equal(t, filter.Allow, flt.Decide(inbound.Message{Keywords: []string{"keep"}}, now))
+	assert.Equal(t, filter.Hide, flt.Decide(inbound.Message{Keywords: []string{"other"}}, now))
+
+	// an inbox with no filter keys → pass-through (default-allow)
+	passthrough, err := inboxcfg.Inbox{Name: "x"}.Filter()
+	require.NoError(t, err)
+	assert.Equal(t, filter.Allow, passthrough.Default())
+}


### PR DESCRIPTION
PR 1 of the ADR 0023 multi-inbox split — the config-schema foundation.

## What
New `internal/inboxcfg`: the schema for a named list of inboxes (ADR 0023), each with its own backend coordinates (ADR 0009), send identity, and `{default_visibility, rules}` policy unit (ADR 0022).

- `Parse(data)` reads the `inboxes:` list; absent/empty → nil.
- `Resolve(parsed, implicit)` returns the configured inboxes, or **one implicit `default` inbox** when none are configured — the back-compat path so a legacy single-inbox config is unchanged.
- `Validate` enforces ≥1 inbox, unique non-empty names, and that each inbox's filter compiles.
- `(Inbox).Filter()` compiles the per-inbox `{default_visibility, rules}` via the existing `filter.Compile` — the policy unit is captured as a raw YAML sub-tree, so **no filter-API change** is needed.
- Secrets (passwords) are out-of-band (env/secret), never config fields (ADR 0012).

## Scope — zero behavior change
Schema + validation only; **not yet consumed by serve**. Wiring per-inbox sync/store/filter (PRs 2–3) and outbound routing + gate Change-sender (PRs 4–5) lands next. The single agent (ADR 0010) is kept.

## Tests
Parse a 2-inbox config; implicit-default resolution; validation (no inboxes / dup name / empty name / bad filter); per-inbox filter compiles and decides (hidden default-deny + bare-rule flip, and pass-through with no filter keys). Gate green: build, vet, gofmt, `go test -race`, golangci-lint v2.11.4 (0 issues).

First of 5; builds toward ADR 0023 (merged).
