### PR TITLE
feat(inbound): thread (owner,inbox) through the store + synced-index (ADR 0023, 2a/5)

### DIFF
--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -78,7 +78,7 @@ func TestAdminRejectViaClient(t *testing.T) {
 	out, err := admin.NewClient(addr, "tok").Reject(context.Background(), id, "policy", false)
 	require.NoError(t, err)
 	assert.Equal(t, string(sluice.StatusRejected), out.Status)
-	msgs, _ := inbox.List("agent")
+	msgs, _ := inbox.List("agent", inbound.DefaultInbox)
 	require.Len(t, msgs, 1) // bounce delivered server-side
 }
 

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -64,7 +64,7 @@ func (s *Service) HeldList() ([]inbound.Message, error) {
 	if s.inbox == nil {
 		return nil, nil
 	}
-	msgs, err := s.inbox.List(s.owner)
+	msgs, err := s.inbox.List(s.owner, inbound.DefaultInbox)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (s *Service) guardHoldsSpoof(m inbound.Message) bool {
 	// the two stay consistent. The error rides along with spoof=true; the read
 	// face logs it.
 	spoof, _ := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
-		fm, e := s.inbox.Get(s.owner, m.ID)
+		fm, e := s.inbox.Get(s.owner, inbound.DefaultInbox, m.ID)
 		return fm.Raw, e
 	})
 	return spoof
@@ -114,12 +114,12 @@ func envelopeFromLocals(m inbound.Message) []string {
 
 // ExposeHeld approves a held message for the agent to see (ADR 0021).
 func (s *Service) ExposeHeld(id string) (inbound.Message, error) {
-	return s.inbox.SetHoldDecision(s.owner, id, inbound.HoldApproved)
+	return s.inbox.SetHoldDecision(s.owner, inbound.DefaultInbox, id, inbound.HoldApproved)
 }
 
 // DropHeld rejects a held message — it stays hidden from the agent (ADR 0021).
 func (s *Service) DropHeld(id string) (inbound.Message, error) {
-	return s.inbox.SetHoldDecision(s.owner, id, inbound.HoldRejected)
+	return s.inbox.SetHoldDecision(s.owner, inbound.DefaultInbox, id, inbound.HoldRejected)
 }
 
 // Outcome is the result of an approve/reject action. Status is the committed

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -79,25 +79,25 @@ func (failingInbound) AddSynced(inbound.Delivery) (bool, inbound.Message, error)
 func (failingInbound) AddSyncedPending(inbound.Delivery) (bool, inbound.Message, error) {
 	return false, inbound.Message{}, errors.New("inbound store down")
 }
-func (failingInbound) SetContent(string, string, []byte) (inbound.Message, error) {
+func (failingInbound) SetContent(string, string, string, []byte) (inbound.Message, error) {
 	return inbound.Message{}, errors.New("inbound store down")
 }
-func (failingInbound) SetKeywords(string, string, []string) (inbound.Message, error) {
+func (failingInbound) SetKeywords(string, string, string, []string) (inbound.Message, error) {
 	return inbound.Message{}, errors.New("inbound store down")
 }
-func (failingInbound) ClearKeywordsDirty(string, string) error { return nil }
-func (failingInbound) DirtyKeywords(string) ([]inbound.Message, error) {
+func (failingInbound) ClearKeywordsDirty(string, string, string) error { return nil }
+func (failingInbound) DirtyKeywords(string, string) ([]inbound.Message, error) {
 	return nil, nil
 }
-func (failingInbound) SetHoldDecision(string, string, string) (inbound.Message, error) {
+func (failingInbound) SetHoldDecision(string, string, string, string) (inbound.Message, error) {
 	return inbound.Message{}, errors.New("inbound store down")
 }
-func (failingInbound) List(string) ([]inbound.Message, error) { return nil, nil }
-func (failingInbound) Get(string, string) (inbound.Message, error) {
+func (failingInbound) List(string, string) ([]inbound.Message, error) { return nil, nil }
+func (failingInbound) Get(string, string, string) (inbound.Message, error) {
 	return inbound.Message{}, inbound.ErrNotFound
 }
-func (failingInbound) SetSeen(string, string, bool) error { return nil }
-func (failingInbound) Close() error                       { return nil }
+func (failingInbound) SetSeen(string, string, string, bool) error { return nil }
+func (failingInbound) Close() error                               { return nil }
 
 func TestApproveStubHoldsDefaultDeny(t *testing.T) {
 	q, id := seedStore(t)
@@ -130,10 +130,10 @@ func TestApprovePermanentFailureBounces(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, out.Warn) // surfaced as a warning, not a failed verdict
 
-	msgs, err := inbox.List("agent")
+	msgs, err := inbox.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
-	bounce, err := inbox.Get("agent", msgs[0].ID) // List is metadata-only; content via Get
+	bounce, err := inbox.Get("agent", inbound.DefaultInbox, msgs[0].ID) // List is metadata-only; content via Get
 	require.NoError(t, err)
 	assert.Contains(t, string(bounce.Raw), "upstream delivery failed permanently")
 	assert.NotContains(t, string(bounce.Raw), "mailbox unavailable") // never echo upstream body
@@ -152,7 +152,7 @@ func TestApproveTransientStaysApproved(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, out.Warn, "transient")
 
-	msgs, _ := inbox.List("agent")
+	msgs, _ := inbox.List("agent", inbound.DefaultInbox)
 	assert.Empty(t, msgs) // no bounce on transient
 	got, _ := q.Get(id)
 	assert.Equal(t, sluice.StatusApproved, got.Status)
@@ -168,11 +168,11 @@ func TestRejectDeliversSignedBounce(t *testing.T) {
 	assert.Equal(t, string(sluice.StatusRejected), out.Status)
 	assert.Empty(t, out.Warn)
 
-	msgs, err := inbox.List("agent")
+	msgs, err := inbox.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "MAILER-DAEMON@darbaan.test", msgs[0].From)
-	bounce, err := inbox.Get("agent", msgs[0].ID) // List is metadata-only; content via Get
+	bounce, err := inbox.Get("agent", inbound.DefaultInbox, msgs[0].ID) // List is metadata-only; content via Get
 	require.NoError(t, err)
 	assert.Contains(t, string(bounce.Raw), "smells like exfiltration")
 	assert.Contains(t, string(bounce.Raw), "5.7.1")

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -252,7 +252,7 @@ func uidSetOf(uids []imap.UID) imap.UIDSet {
 // stale) or the message is gone upstream, so the read face can surface a
 // transient error rather than empty content.
 func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
-	m, err := s.store.Get(owner, id)
+	m, err := s.store.Get(owner, inbound.DefaultInbox, id)
 	if err != nil {
 		return inbound.Message{}, err
 	}
@@ -301,7 +301,7 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 	if raw == nil {
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found", id, m.UpstreamUID)
 	}
-	return s.store.SetContent(owner, id, raw)
+	return s.store.SetContent(owner, inbound.DefaultInbox, id, raw)
 }
 
 // WriteKeywords replicates a message's keyword set to the upstream backend over a
@@ -314,7 +314,7 @@ func (s *Syncer) WriteKeywords(owner, id string, add, remove []string) error {
 	if len(add) == 0 && len(remove) == 0 {
 		return nil
 	}
-	m, err := s.store.Get(owner, id)
+	m, err := s.store.Get(owner, inbound.DefaultInbox, id)
 	if err != nil {
 		return err
 	}
@@ -364,7 +364,7 @@ func (s *Syncer) WriteKeywords(owner, id string, add, remove []string) error {
 // write whose immediate upstream replicate failed is retried here on the next sync
 // (ADR 0020). Best-effort: failures are logged, never fatal to the sync.
 func (s *Syncer) reconcileKeywords() {
-	dirty, err := s.store.DirtyKeywords(s.owner)
+	dirty, err := s.store.DirtyKeywords(s.owner, inbound.DefaultInbox)
 	if err != nil {
 		log.Printf("darbaan: keyword reconcile list: %v", err)
 		return
@@ -378,7 +378,7 @@ func (s *Syncer) reconcileKeywords() {
 			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
 			continue
 		}
-		if err := s.store.ClearKeywordsDirty(s.owner, m.ID); err != nil {
+		if err := s.store.ClearKeywordsDirty(s.owner, inbound.DefaultInbox, m.ID); err != nil {
 			log.Printf("darbaan: keyword reconcile clear %s: %v", m.ID, err)
 		}
 	}

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -106,7 +106,7 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 2, n)
 
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 	// Headers-only sync: metadata from the envelope, bodies pending (lazy).
@@ -137,7 +137,7 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	n, err = syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
-	msgs, _ = store.List("agent")
+	msgs, _ = store.List("agent", inbound.DefaultInbox)
 	assert.Len(t, msgs, 3)
 }
 
@@ -155,7 +155,7 @@ func TestSyncStreamsManyMessages(t *testing.T) {
 	got, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, n, got)
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Len(t, msgs, n)
 	for _, m := range msgs {
@@ -185,7 +185,7 @@ func TestFetchContentFillsPending(t *testing.T) {
 	assert.False(t, filled.Pending)
 	assert.Contains(t, string(filled.Raw), "real body")
 
-	got, err := store.Get("agent", m.ID)
+	got, err := store.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.False(t, got.Pending)
 	assert.Contains(t, string(got.Raw), "real body")
@@ -229,7 +229,7 @@ func TestSyncDedupsOnCursorReset(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Len(t, msgs, 2) // no duplicates
 }
@@ -246,7 +246,7 @@ func TestSyncPullsKeywords(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
 
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	assert.ElementsMatch(t, []string{"useless", "$Important"}, msgs[0].Keywords)
@@ -284,7 +284,7 @@ func TestWriteKeywordsToUpstream(t *testing.T) {
 	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 
@@ -305,7 +305,7 @@ func TestWriteKeywordsRoutesToLabelStore(t *testing.T) {
 	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	id := msgs[0].ID
 
@@ -333,20 +333,20 @@ func TestSyncReconcilesDirtyKeywords(t *testing.T) {
 	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
 	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 
 	// Mark dirty locally (as if the immediate upstream write had failed).
-	_, err = store.SetKeywords("agent", msgs[0].ID, []string{"useless"})
+	_, err = store.SetKeywords("agent", inbound.DefaultInbox, msgs[0].ID, []string{"useless"})
 	require.NoError(t, err)
-	dirty, err := store.DirtyKeywords("agent")
+	dirty, err := store.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, dirty, 1)
 
 	// Next sync reconciles it upstream and clears dirty.
 	_, err = syncer.Sync(context.Background())
 	require.NoError(t, err)
-	dirty, err = store.DirtyKeywords("agent")
+	dirty, err = store.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Empty(t, dirty)
 	assert.ElementsMatch(t, []string{"useless"}, upstreamKeywords(t, addr, 1))
@@ -365,7 +365,7 @@ func TestSyncRecencyCutoff(t *testing.T) {
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, n) // only the fresh message, ancient one skipped
-	msgs, err := store.List("agent")
+	msgs, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 	assert.Equal(t, "fresh", msgs[0].Subject)
@@ -391,6 +391,6 @@ func TestSyncResetsOnUIDValidityMismatch(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 1, n) // mismatch → cursor reset to 0 → message re-pulled despite LastUID=99
 
-	msgs, _ := store.List("agent")
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
 	require.Len(t, msgs, 1)
 }

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -148,7 +148,7 @@ func (s *bboltStore) addSynced(d Delivery, pending bool) (bool, Message, error) 
 	if d.UpstreamUID == 0 {
 		return false, Message{}, fmt.Errorf("inbound: AddSynced requires a non-zero upstream UID")
 	}
-	idxKey := syncedKey(d.Owner, d.UIDValidity, d.UpstreamUID)
+	idxKey := syncedKey(d.Owner, d.Inbox, d.UIDValidity, d.UpstreamUID)
 	var (
 		added bool
 		msg   Message
@@ -180,14 +180,14 @@ func (s *bboltStore) addSynced(d Delivery, pending bool) (bool, Message, error) 
 
 // SetContent fills a pending message's body: write the content blob and mark the
 // record present. Owner-scoped; returns the now-complete message.
-func (s *bboltStore) SetContent(owner, id string, raw []byte) (Message, error) {
+func (s *bboltStore) SetContent(owner, inbox, id string, raw []byte) (Message, error) {
 	var msg Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
-		if rec.Owner != owner {
+		if !recScoped(rec, owner, inbox) {
 			return ErrNotFound
 		}
 		// Content blob first, then the metadata flip (same ordering as Add).
@@ -218,6 +218,7 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byt
 	msg := Message{
 		ID:          strconv.FormatUint(seq, 10),
 		Owner:       d.Owner,
+		Inbox:       NormInbox(d.Inbox),
 		From:        d.From,
 		To:          d.To,
 		Subject:     d.Subject,
@@ -245,19 +246,31 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byt
 	return msg, key, nil
 }
 
-// syncedKey is the dedup index key for an upstream message: owner + UIDVALIDITY
-// + UID. UIDVALIDITY is included because UIDs are only unique within it.
-func syncedKey(owner string, uidValidity, uid uint32) []byte {
-	k := make([]byte, 0, len(owner)+1+8)
+// syncedKey is the dedup index key for an upstream message: owner + inbox +
+// UIDVALIDITY + UID. The inbox is included because each inbox is an independent
+// upstream UID space (ADR 0023) — two inboxes (esp. on different accounts) can
+// carry the same (UIDVALIDITY, UID), and must not collide in the dedup index.
+// UIDVALIDITY is included because UIDs are only unique within it.
+func syncedKey(owner, inbox string, uidValidity, uid uint32) []byte {
+	inbox = NormInbox(inbox)
+	k := make([]byte, 0, len(owner)+1+len(inbox)+1+8)
 	k = append(k, owner...)
 	k = append(k, 0) // separator (an owner name has no NUL)
+	k = append(k, inbox...)
+	k = append(k, 0)
 	var n [8]byte
 	binary.BigEndian.PutUint32(n[0:4], uidValidity)
 	binary.BigEndian.PutUint32(n[4:8], uid)
 	return append(k, n[:]...)
 }
 
-func (s *bboltStore) List(owner string) ([]Message, error) {
+// recScoped reports whether a stored record belongs to (owner, inbox), treating a
+// record with no Inbox (written before multi-inbox) as DefaultInbox.
+func recScoped(rec stored, owner, inbox string) bool {
+	return rec.Owner == owner && NormInbox(rec.Inbox) == NormInbox(inbox)
+}
+
+func (s *bboltStore) List(owner, inbox string) ([]Message, error) {
 	var recs []stored
 	err := s.db.View(func(tx *bbolt.Tx) error {
 		return tx.Bucket(bucketInbound).ForEach(func(_, v []byte) error {
@@ -265,7 +278,7 @@ func (s *bboltStore) List(owner string) ([]Message, error) {
 			if err := json.Unmarshal(v, &rec); err != nil {
 				return err
 			}
-			if rec.Owner == owner {
+			if recScoped(rec, owner, inbox) {
 				recs = append(recs, rec)
 			}
 			return nil
@@ -286,14 +299,14 @@ func (s *bboltStore) List(owner string) ([]Message, error) {
 	return out, nil
 }
 
-func (s *bboltStore) SetSeen(owner, id string, seen bool) error {
+func (s *bboltStore) SetSeen(owner, inbox, id string, seen bool) error {
 	return s.db.Update(func(tx *bbolt.Tx) error {
 		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
-		if rec.Owner != owner {
-			return ErrNotFound // do not touch another owner's message
+		if !recScoped(rec, owner, inbox) {
+			return ErrNotFound // do not touch another owner's/inbox's message
 		}
 		if rec.Seen == seen {
 			return nil
@@ -306,14 +319,14 @@ func (s *bboltStore) SetSeen(owner, id string, seen bool) error {
 // SetKeywords replaces the owner's message's keyword set (ADR 0020) and marks it
 // dirty for upstream reconcile. The local store is canonical; the returned
 // message carries the new keywords (without content). Metadata-only write.
-func (s *bboltStore) SetKeywords(owner, id string, keywords []string) (Message, error) {
+func (s *bboltStore) SetKeywords(owner, inbox, id string, keywords []string) (Message, error) {
 	var msg Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
-		if rec.Owner != owner {
+		if !recScoped(rec, owner, inbox) {
 			return ErrNotFound
 		}
 		rec.Keywords = keywords
@@ -332,13 +345,13 @@ func (s *bboltStore) SetKeywords(owner, id string, keywords []string) (Message, 
 }
 
 // ClearKeywordsDirty clears the dirty flag after a successful upstream replicate.
-func (s *bboltStore) ClearKeywordsDirty(owner, id string) error {
+func (s *bboltStore) ClearKeywordsDirty(owner, inbox, id string) error {
 	return s.db.Update(func(tx *bbolt.Tx) error {
 		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
-		if rec.Owner != owner {
+		if !recScoped(rec, owner, inbox) {
 			return ErrNotFound
 		}
 		if !rec.KeywordsDirty {
@@ -351,14 +364,14 @@ func (s *bboltStore) ClearKeywordsDirty(owner, id string) error {
 
 // SetHoldDecision persists the human's hold-for-human decision (ADR 0021) on the
 // owner's message (metadata only; the blob is untouched) and returns it.
-func (s *bboltStore) SetHoldDecision(owner, id, decision string) (Message, error) {
+func (s *bboltStore) SetHoldDecision(owner, inbox, id, decision string) (Message, error) {
 	var msg Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
 		}
-		if rec.Owner != owner {
+		if !recScoped(rec, owner, inbox) {
 			return ErrNotFound
 		}
 		rec.HoldDecision = decision
@@ -373,7 +386,7 @@ func (s *bboltStore) SetHoldDecision(owner, id, decision string) (Message, error
 
 // DirtyKeywords returns the owner's messages whose keywords await upstream
 // replication (metadata only), for the sync to reconcile.
-func (s *bboltStore) DirtyKeywords(owner string) ([]Message, error) {
+func (s *bboltStore) DirtyKeywords(owner, inbox string) ([]Message, error) {
 	var out []Message
 	err := s.db.View(func(tx *bbolt.Tx) error {
 		return tx.Bucket(bucketInbound).ForEach(func(_, v []byte) error {
@@ -381,7 +394,7 @@ func (s *bboltStore) DirtyKeywords(owner string) ([]Message, error) {
 			if err := json.Unmarshal(v, &rec); err != nil {
 				return err
 			}
-			if rec.KeywordsDirty && rec.Owner == owner {
+			if rec.KeywordsDirty && recScoped(rec, owner, inbox) {
 				out = append(out, rec.Message)
 			}
 			return nil
@@ -393,15 +406,15 @@ func (s *bboltStore) DirtyKeywords(owner string) ([]Message, error) {
 	return out, nil
 }
 
-func (s *bboltStore) Get(owner, id string) (Message, error) {
+func (s *bboltStore) Get(owner, inbox, id string) (Message, error) {
 	var rec stored
 	err := s.db.View(func(tx *bbolt.Tx) error {
 		r, _, e := loadStored(tx, id)
 		if e != nil {
 			return e
 		}
-		if r.Owner != owner {
-			return ErrNotFound // do not leak another owner's message
+		if !recScoped(r, owner, inbox) {
+			return ErrNotFound // do not leak another owner's/inbox's message
 		}
 		rec = r
 		return nil

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -46,6 +46,7 @@ type Envelope struct {
 // Delivery is a new inbound message to store.
 type Delivery struct {
 	Owner   string // the agent whose mailbox this is (whose send was rejected)
+	Inbox   string // the named inbox this delivery belongs to (ADR 0023); "" = DefaultInbox
 	From    string // e.g. MAILER-DAEMON@<domain>
 	To      string // the original submitter
 	Subject string
@@ -73,6 +74,7 @@ type Delivery struct {
 type Message struct {
 	ID         string    `json:"id"`
 	Owner      string    `json:"owner"`
+	Inbox      string    `json:"inbox,omitempty"` // named inbox (ADR 0023); "" reads as DefaultInbox
 	From       string    `json:"from"`
 	To         string    `json:"to"`
 	Subject    string    `json:"subject"`
@@ -115,6 +117,20 @@ const (
 	HoldRejected = "rejected"
 )
 
+// DefaultInbox is the implicit single inbox (ADR 0023). A record stored before
+// multi-inbox carries no Inbox and reads as DefaultInbox, and a single-inbox
+// deployment addresses everything as DefaultInbox — so N=1 is unchanged.
+const DefaultInbox = "default"
+
+// NormInbox resolves an empty inbox name to DefaultInbox, so stored records
+// written before multi-inbox (Inbox == "") match the default inbox.
+func NormInbox(inbox string) string {
+	if inbox == "" {
+		return DefaultInbox
+	}
+	return inbox
+}
+
 // InboundStore is the agent's served mailbox. Implementations are selected by
 // config (inbound-type) and constructed through New.
 type InboundStore interface {
@@ -130,26 +146,28 @@ type InboundStore interface {
 	// Delivery's Raw is ignored. SetContent fills the body later.
 	AddSyncedPending(Delivery) (added bool, m Message, err error)
 	// SetContent fills a pending message's body (write the content blob, mark it
-	// present) and returns the now-complete message. Owner-scoped.
-	SetContent(owner, id string, raw []byte) (Message, error)
+	// present) and returns the now-complete message. Scoped to (owner, inbox).
+	SetContent(owner, inbox, id string, raw []byte) (Message, error)
 	// SetKeywords replaces a message's keyword set (ADR 0020) and marks it dirty
-	// for upstream reconcile. Local store is canonical. Owner-scoped.
-	SetKeywords(owner, id string, keywords []string) (Message, error)
+	// for upstream reconcile. Local store is canonical. Scoped to (owner, inbox).
+	SetKeywords(owner, inbox, id string, keywords []string) (Message, error)
 	// ClearKeywordsDirty clears the dirty flag after upstream replication succeeds.
-	ClearKeywordsDirty(owner, id string) error
-	// DirtyKeywords returns messages whose keywords await upstream replication.
-	DirtyKeywords(owner string) ([]Message, error)
+	ClearKeywordsDirty(owner, inbox, id string) error
+	// DirtyKeywords returns the inbox's messages whose keywords await upstream
+	// replication — per inbox, since each inbox reconciles against its own backend.
+	DirtyKeywords(owner, inbox string) ([]Message, error)
 	// SetHoldDecision persists the human's hold-for-human decision (ADR 0021):
-	// "approved" exposes the message, "rejected" keeps it hidden. Owner-scoped.
-	SetHoldDecision(owner, id, decision string) (Message, error)
-	// List returns the owner's messages' metadata (no content/Raw) in receive
-	// order; a body is fetched per-message via Get / the content fetcher.
-	List(owner string) ([]Message, error)
-	// Get returns one of the owner's messages with content, or ErrNotFound.
-	Get(owner, id string) (Message, error)
-	// SetSeen sets or clears the \Seen flag on the owner's message — the only
-	// mutable flag the v1 IMAP face persists. Owner-scoped like Get.
-	SetSeen(owner, id string, seen bool) error
+	// "approved" exposes the message, "rejected" keeps it hidden. (owner, inbox)-scoped.
+	SetHoldDecision(owner, inbox, id, decision string) (Message, error)
+	// List returns the inbox's messages' metadata (no content/Raw) in receive
+	// order; a body is fetched per-message via Get / the content fetcher. Each
+	// inbox is an independent mailbox (ADR 0023).
+	List(owner, inbox string) ([]Message, error)
+	// Get returns one of the inbox's messages with content, or ErrNotFound.
+	Get(owner, inbox, id string) (Message, error)
+	// SetSeen sets or clears the \Seen flag on the inbox's message — the only
+	// mutable flag the v1 IMAP face persists. (owner, inbox)-scoped like Get.
+	SetSeen(owner, inbox, id string, seen bool) error
 	// Close releases the underlying resources.
 	Close() error
 }

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -18,6 +18,49 @@ func newStore(t *testing.T) inbound.InboundStore {
 	return s
 }
 
+func TestInboxIsolation(t *testing.T) {
+	s := newStore(t)
+
+	// The SAME upstream (UIDVALIDITY, UID) in two different inboxes must NOT
+	// collide in the dedup index — each inbox is an independent UID space (ADR 0023).
+	_, work, err := s.AddSynced(inbound.Delivery{Owner: "agent", Inbox: "work", UpstreamUID: 5, UIDValidity: 1, Raw: []byte("From: a@x\r\n\r\nw")})
+	require.NoError(t, err)
+	added, personal, err := s.AddSynced(inbound.Delivery{Owner: "agent", Inbox: "personal", UpstreamUID: 5, UIDValidity: 1, Raw: []byte("From: b@y\r\n\r\np")})
+	require.NoError(t, err)
+	assert.True(t, added, "same (uid,uidvalidity) in a different inbox is not a duplicate")
+	assert.NotEqual(t, work.ID, personal.ID)
+
+	// List is per-inbox.
+	w, err := s.List("agent", "work")
+	require.NoError(t, err)
+	require.Len(t, w, 1)
+	assert.Equal(t, work.ID, w[0].ID)
+	assert.Equal(t, "work", w[0].Inbox)
+	p, err := s.List("agent", "personal")
+	require.NoError(t, err)
+	require.Len(t, p, 1)
+	assert.Equal(t, personal.ID, p[0].ID)
+
+	// Get is inbox-scoped: work's id is not reachable under personal.
+	_, err = s.Get("agent", "personal", work.ID)
+	require.ErrorIs(t, err, inbound.ErrNotFound)
+	_, err = s.Get("agent", "work", work.ID)
+	require.NoError(t, err)
+
+	// Re-adding the same (work, uid 5) is still an idempotent no-op.
+	again, _, err := s.AddSynced(inbound.Delivery{Owner: "agent", Inbox: "work", UpstreamUID: 5, UIDValidity: 1, Raw: []byte("x")})
+	require.NoError(t, err)
+	assert.False(t, again)
+
+	// A record stored with no Inbox reads as DefaultInbox (back-compat).
+	def, err := s.Add(inbound.Delivery{Owner: "agent", Raw: []byte("From: c@z\r\n\r\nd")})
+	require.NoError(t, err)
+	d, err := s.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.Len(t, d, 1)
+	assert.Equal(t, def.ID, d[0].ID)
+}
+
 func TestAddSyncedDedup(t *testing.T) {
 	s := newStore(t)
 	d := inbound.Delivery{Owner: "agent", Subject: "hi", Raw: []byte("Subject: hi\r\n\r\nx"), UpstreamUID: 5, UIDValidity: 1}
@@ -31,7 +74,7 @@ func TestAddSyncedDedup(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, added)
 	assert.Equal(t, m1.ID, m2.ID)
-	msgs, _ := s.List("agent")
+	msgs, _ := s.List("agent", inbound.DefaultInbox)
 	assert.Len(t, msgs, 1)
 
 	// A different UID is a new message.
@@ -46,7 +89,7 @@ func TestAddSyncedDedup(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, added)
 
-	msgs, _ = s.List("agent")
+	msgs, _ = s.List("agent", inbound.DefaultInbox)
 	assert.Len(t, msgs, 3)
 
 	// AddSynced requires upstream coordinates.
@@ -63,21 +106,21 @@ func TestSetKeywordsDirtyOnlyWithUpstream(t *testing.T) {
 	// Local-only record (Add → no UpstreamUID): keywords set, not dirty.
 	local, err := s.Add(inbound.Delivery{Owner: "agent", Subject: "bounce"})
 	require.NoError(t, err)
-	_, err = s.SetKeywords("agent", local.ID, []string{"x"})
+	_, err = s.SetKeywords("agent", inbound.DefaultInbox, local.ID, []string{"x"})
 	require.NoError(t, err)
-	got, err := s.Get("agent", local.ID)
+	got, err := s.Get("agent", inbound.DefaultInbox, local.ID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"x"}, got.Keywords)
-	dirty, err := s.DirtyKeywords("agent")
+	dirty, err := s.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Empty(t, dirty)
 
 	// Synced record (has UpstreamUID): keyword change IS dirty.
 	_, synced, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 5, UIDValidity: 1})
 	require.NoError(t, err)
-	_, err = s.SetKeywords("agent", synced.ID, []string{"y"})
+	_, err = s.SetKeywords("agent", inbound.DefaultInbox, synced.ID, []string{"y"})
 	require.NoError(t, err)
-	dirty, err = s.DirtyKeywords("agent")
+	dirty, err = s.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, dirty, 1)
 	assert.Equal(t, synced.ID, dirty[0].ID)
@@ -91,12 +134,12 @@ func TestPendingThenSetContent(t *testing.T) {
 	assert.True(t, m.Pending)
 
 	// A pending record exposes its metadata but no content yet.
-	got, err := s.Get("agent", m.ID)
+	got, err := s.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.True(t, got.Pending)
 	assert.Empty(t, got.Raw)
 	assert.Equal(t, "hi", got.Subject)
-	list, err := s.List("agent")
+	list, err := s.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.True(t, list[0].Pending)
@@ -104,12 +147,12 @@ func TestPendingThenSetContent(t *testing.T) {
 
 	// SetContent fills the body and marks it present.
 	raw := []byte("Subject: hi\r\n\r\nbody")
-	filled, err := s.SetContent("agent", m.ID, raw)
+	filled, err := s.SetContent("agent", inbound.DefaultInbox, m.ID, raw)
 	require.NoError(t, err)
 	assert.False(t, filled.Pending)
 	assert.Equal(t, raw, filled.Raw)
 
-	got, err = s.Get("agent", m.ID)
+	got, err = s.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.False(t, got.Pending)
 	assert.Equal(t, raw, got.Raw)
@@ -123,12 +166,12 @@ func TestAddListGet(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, m.Seen) // lands unseen
 
-	list, err := s.List("agent")
+	list, err := s.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.Equal(t, "Bounce", list[0].Subject)
 
-	got, err := s.Get("agent", m.ID)
+	got, err := s.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.Equal(t, []byte("raw"), got.Raw)
 }
@@ -138,19 +181,19 @@ func TestOwnerIsolation(t *testing.T) {
 	m, err := s.Add(inbound.Delivery{Owner: "alice", Raw: []byte("x")})
 	require.NoError(t, err)
 
-	list, err := s.List("bob")
+	list, err := s.List("bob", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Empty(t, list)
 
-	_, err = s.Get("bob", m.ID) // must not leak another owner's message
+	_, err = s.Get("bob", inbound.DefaultInbox, m.ID) // must not leak another owner's message
 	require.ErrorIs(t, err, inbound.ErrNotFound)
 }
 
 func TestGetNotFound(t *testing.T) {
 	s := newStore(t)
-	_, err := s.Get("agent", "999")
+	_, err := s.Get("agent", inbound.DefaultInbox, "999")
 	require.ErrorIs(t, err, inbound.ErrNotFound)
-	_, err = s.Get("agent", "not-a-number")
+	_, err = s.Get("agent", inbound.DefaultInbox, "not-a-number")
 	require.ErrorIs(t, err, inbound.ErrNotFound)
 }
 
@@ -165,17 +208,17 @@ func TestSetSeen(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, m.Seen)
 
-	require.NoError(t, s.SetSeen("agent", m.ID, true))
-	got, err := s.Get("agent", m.ID)
+	require.NoError(t, s.SetSeen("agent", inbound.DefaultInbox, m.ID, true))
+	got, err := s.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.True(t, got.Seen)
 
-	require.NoError(t, s.SetSeen("agent", m.ID, false))
-	got, err = s.Get("agent", m.ID)
+	require.NoError(t, s.SetSeen("agent", inbound.DefaultInbox, m.ID, false))
+	got, err = s.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.False(t, got.Seen)
 
 	// owner-scoped + not-found
-	require.ErrorIs(t, s.SetSeen("other", m.ID, true), inbound.ErrNotFound)
-	require.ErrorIs(t, s.SetSeen("agent", "999", true), inbound.ErrNotFound)
+	require.ErrorIs(t, s.SetSeen("other", inbound.DefaultInbox, m.ID, true), inbound.ErrNotFound)
+	require.ErrorIs(t, s.SetSeen("agent", inbound.DefaultInbox, "999", true), inbound.ErrNotFound)
 }

--- a/internal/inbound/tiering_internal_test.go
+++ b/internal/inbound/tiering_internal_test.go
@@ -39,12 +39,12 @@ func TestAddTiersContent(t *testing.T) {
 	assert.Nil(t, rec.Raw, "raw must not be stored in bbolt")
 	assert.Equal(t, "bounce", rec.Subject) // subject is already metadata
 
-	got, err := s.Get("agent", m.ID)
+	got, err := s.Get("agent", DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.Equal(t, m.Raw, got.Raw) // reassembled from the blob
 
 	// List is metadata-only (no blob reads): content comes per-FETCH via Get.
-	list, err := s.List("agent")
+	list, err := s.List("agent", DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.Equal(t, "bounce", list[0].Subject)
@@ -60,7 +60,7 @@ func TestSweepOrphans(t *testing.T) {
 
 	require.NoError(t, s.sweepOrphans())
 
-	got, err := s.Get("agent", m.ID) // referenced blob survived
+	got, err := s.Get("agent", DefaultInbox, m.ID) // referenced blob survived
 	require.NoError(t, err)
 	assert.NotEmpty(t, got.Raw)
 	_, err = s.blobs.Get("9999") // orphan reclaimed
@@ -81,26 +81,26 @@ func TestLegacyInlineFallback(t *testing.T) {
 		return tx.Bucket(bucketInbound).Put(seqkey.Encode(1), enc)
 	}))
 
-	got, err := s.Get("agent", "1")
+	got, err := s.Get("agent", DefaultInbox, "1")
 	require.NoError(t, err)
 	assert.Equal(t, legacy.Raw, got.Raw) // inline raw, no blob read
 
 	// List is metadata-only now (content fetched per-FETCH): metadata present,
 	// Raw empty even for a legacy inline record.
-	list, err := s.List("agent")
+	list, err := s.List("agent", DefaultInbox)
 	require.NoError(t, err)
 	require.Len(t, list, 1)
 	assert.Equal(t, "old", list[0].Subject)
 	assert.Empty(t, list[0].Raw)
 
 	// SetSeen mutates metadata and keeps the inline raw readable.
-	require.NoError(t, s.SetSeen("agent", "1", true))
-	got, err = s.Get("agent", "1")
+	require.NoError(t, s.SetSeen("agent", DefaultInbox, "1", true))
+	got, err = s.Get("agent", DefaultInbox, "1")
 	require.NoError(t, err)
 	assert.True(t, got.Seen)
 	assert.Equal(t, legacy.Raw, got.Raw)
 
 	// Owner isolation is preserved.
-	_, err = s.Get("other", "1")
+	_, err = s.Get("other", DefaultInbox, "1")
 	assert.ErrorIs(t, err, ErrNotFound)
 }

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -65,7 +65,7 @@ func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundS
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
 	if fetch == nil {
-		fetch = func(owner, id string) (inbound.Message, error) { return store.Get(owner, id) }
+		fetch = func(owner, id string) (inbound.Message, error) { return store.Get(owner, inbound.DefaultInbox, id) }
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
@@ -109,7 +109,7 @@ type imapSession struct {
 // visible; hide and undecided/rejected hold are omitted. Evaluated fresh each
 // call (no cache).
 func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err error) {
-	full, err = s.store.List(s.owner)
+	full, err = s.store.List(s.owner, inbound.DefaultInbox)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -300,7 +300,7 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 			return
 		}
 		if markSeen && !m.Seen {
-			if err := s.store.SetSeen(s.owner, m.ID, true); err != nil {
+			if err := s.store.SetSeen(s.owner, inbound.DefaultInbox, m.ID, true); err != nil {
 				ferr = err
 				return
 			}
@@ -352,7 +352,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 			return
 		}
 		if touchesSeen && m.Seen != seen {
-			if err := s.store.SetSeen(s.owner, m.ID, seen); err != nil {
+			if err := s.store.SetSeen(s.owner, inbound.DefaultInbox, m.ID, seen); err != nil {
 				serr = err
 				return
 			}
@@ -363,7 +363,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 		if flags.Op == imap.StoreFlagsSet || len(kw) > 0 {
 			next, added, removed := applyKeywordOp(m.Keywords, flags.Op, kw)
 			if len(added) > 0 || len(removed) > 0 {
-				if _, err := s.store.SetKeywords(s.owner, m.ID, next); err != nil {
+				if _, err := s.store.SetKeywords(s.owner, inbound.DefaultInbox, m.ID, next); err != nil {
 					serr = err
 					return
 				}
@@ -376,7 +376,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 					if err := s.writeKeywords(s.owner, m.ID, added, removed); err != nil {
 						log.Printf("darbaan: imap keyword write-through for %s deferred: %v", m.ID, err)
 					} else {
-						_ = s.store.ClearKeywordsDirty(s.owner, m.ID)
+						_ = s.store.ClearKeywordsDirty(s.owner, inbound.DefaultInbox, m.ID)
 					}
 				}
 			}

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -65,9 +65,9 @@ func TestIMAPFetchResolvesPendingOnDemand(t *testing.T) {
 	fetch := func(owner, id string) (inbound.Message, error) {
 		fetchCalls++
 		if id == m.ID { // simulate the on-demand upstream fill
-			return store.SetContent(owner, id, []byte("Subject: lazy\r\n\r\nlazy-body"))
+			return store.SetContent(owner, inbound.DefaultInbox, id, []byte("Subject: lazy\r\n\r\nlazy-body"))
 		}
-		return store.Get(owner, id)
+		return store.Get(owner, inbound.DefaultInbox, id)
 	}
 
 	c, err := imapclient.DialInsecure(startIMAPWithFetch(t, store, fetch), nil)
@@ -92,7 +92,7 @@ func TestIMAPFetchResolvesPendingOnDemand(t *testing.T) {
 	assert.Contains(t, string(msgs[0].FindBodySection(&imap.FetchItemBodySection{})), "lazy-body")
 	assert.GreaterOrEqual(t, fetchCalls, 1)
 
-	got, err := store.Get("agent", m.ID)
+	got, err := store.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.False(t, got.Pending) // cached present after the on-demand fetch
 }
@@ -119,14 +119,14 @@ func TestIMAPFetchMarksSeenAndPersists(t *testing.T) {
 	require.Len(t, msgs, 1)
 	assert.Contains(t, string(msgs[0].FindBodySection(&imap.FetchItemBodySection{})), "refused-marker")
 
-	got, err := store.Get("agent", "1")
+	got, err := store.Get("agent", inbound.DefaultInbox, "1")
 	require.NoError(t, err)
 	assert.True(t, got.Seen) // \Seen persisted across the fetch
 }
 
 func TestIMAPStoreUnsetSeenPersists(t *testing.T) {
 	store := seedInbound(t)
-	require.NoError(t, store.SetSeen("agent", "1", true))
+	require.NoError(t, store.SetSeen("agent", inbound.DefaultInbox, "1", true))
 
 	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)
 	require.NoError(t, err)
@@ -139,7 +139,7 @@ func TestIMAPStoreUnsetSeenPersists(t *testing.T) {
 		&imap.StoreFlags{Op: imap.StoreFlagsDel, Flags: []imap.Flag{imap.FlagSeen}}, nil).Collect()
 	require.NoError(t, err)
 
-	got, err := store.Get("agent", "1")
+	got, err := store.Get("agent", inbound.DefaultInbox, "1")
 	require.NoError(t, err)
 	assert.False(t, got.Seen) // \Seen cleared and persisted
 }
@@ -233,7 +233,7 @@ func TestIMAPEnvelopeAndHeaderSearchFromMetadata(t *testing.T) {
 	var fetchCalls int
 	fetch := func(owner, id string) (inbound.Message, error) {
 		fetchCalls++
-		return store.Get(owner, id)
+		return store.Get(owner, inbound.DefaultInbox, id)
 	}
 	c, err := imapclient.DialInsecure(startIMAPWithFetch(t, store, fetch), nil)
 	require.NoError(t, err)
@@ -336,12 +336,12 @@ func TestIMAPStoreKeywordWritesThrough(t *testing.T) {
 	require.NoError(t, c.Store(imap.SeqSetNum(1),
 		&imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{"useless"}}, nil).Close())
 
-	got, err := store.Get("agent", m.ID)
+	got, err := store.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"useless"}, got.Keywords) // local store is canonical
 	assert.Equal(t, m.ID, wroteID)
 	assert.Equal(t, []string{"useless"}, wroteAdd) // replicated the add delta upstream
-	dirty, err := store.DirtyKeywords("agent")
+	dirty, err := store.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Empty(t, dirty) // cleared on successful replicate
 }
@@ -368,10 +368,10 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 	require.NoError(t, c.Store(imap.SeqSetNum(1),
 		&imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{"useless"}}, nil).Close())
 
-	got, err := store.Get("agent", m.ID)
+	got, err := store.Get("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"useless"}, got.Keywords) // committed locally
-	dirty, err := store.DirtyKeywords("agent")
+	dirty, err := store.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Len(t, dirty, 1) // stays dirty for reconcile
 }
@@ -394,11 +394,11 @@ func TestIMAPStoreKeywordLocalOnlyNoUpstream(t *testing.T) {
 	require.NoError(t, c.Store(imap.SeqSetNum(1),
 		&imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{"useless"}}, nil).Close())
 
-	got, err := store.Get("agent", "1")
+	got, err := store.Get("agent", inbound.DefaultInbox, "1")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"useless"}, got.Keywords) // local label still set
 	assert.False(t, called, "no upstream write for a local-only record")
-	dirty, err := store.DirtyKeywords("agent")
+	dirty, err := store.DirtyKeywords("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Empty(t, dirty) // not dirty → never enters reconcile
 }
@@ -469,7 +469,7 @@ func TestIMAPHoldForHuman(t *testing.T) {
 	assert.Equal(t, uint32(1), sel.NumMessages) // held one hidden pending decision
 
 	// A human approves exposure → it becomes visible on the next select.
-	_, err = store.SetHoldDecision("agent", held.ID, inbound.HoldApproved)
+	_, err = store.SetHoldDecision("agent", inbound.DefaultInbox, held.ID, inbound.HoldApproved)
 	require.NoError(t, err)
 	c2, err := imapclient.DialInsecure(addr, nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Multi-inbox slice **2a** of 5 (ADR 0023) — thread the inbox dimension through the store. Behavior-preserving foundation for per-inbox sync (2b) and the N-mailbox read face (3).

## ⚠️ Migration — one-time re-sync per DEPLOYED instance
The synced-index dedup key now includes the inbox, so **existing index entries are orphaned**: on first deploy of this change, each running instance does a **one-time re-sync that re-pulls its mailbox** (forward-only, idempotent — the new per-inbox index re-populates and dedups thereafter). darbaan runs two live instances, so this is a real per-instance event at deploy time, not just the test box. No data loss; stored records are untouched (they read as `DefaultInbox`).

## What
- `Message`/`Delivery` gain `Inbox`; `DefaultInbox = "default"` + `NormInbox()`. A record written before multi-inbox (empty `Inbox`) **reads as** `DefaultInbox`, so **no record migration** — only the synced-index re-keys (above).
- `InboundStore` is threaded `(owner, inbox)` on every scoped method (`List`, `Get`, `SetContent`, `SetSeen`, `SetKeywords`, `ClearKeywordsDirty`, `DirtyKeywords`, `SetHoldDecision`); writes carry `Delivery.Inbox`.
- `syncedKey` now includes the inbox — closes the cross-inbox UID collision (two inboxes, esp. on different accounts, sharing a `(UIDVALIDITY, UID)`).
- **N=1 byte-for-byte unchanged**: all callers (listener, admin, imapsync) pass `DefaultInbox`; the per-inbox *wiring* of the read face / sync is deferred to 2b/3, so this slice changes no behavior.

## Cross-package touch
Mechanical threading across `inbound` (the change) + `imapsync`, `listener`, `admin` (callers pass `DefaultInbox`). No new logic in the callers.

## Tests
New `TestInboxIsolation`: per-inbox `List`/`Get` scoping, same-`(uid,uidvalidity)`-different-inbox is **not** a dedup hit, idempotent re-add still no-ops, and an `Inbox`-less record reads as `DefaultInbox`. All existing store/read-face/sync/admin tests updated for the new signatures and pass unchanged in behavior. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Next: 2b (sync writes per-inbox). Builds toward ADR 0023 (merged). CHANGELOG is release-please-managed, so the migration note rides this commit body + this PR.
