### PR TITLE
feat(imapsync): sync writes per-inbox (ADR 0023, 2b/5)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -176,7 +176,7 @@ func (cli *CLI) newSyncer(inbox inbound.InboundStore) (*imapsync.Syncer, func(),
 	}
 	pass := os.Getenv("DARBAAN_INBOUND_IMAP_PASSWORD")
 	dial := imapsync.Dialer(cli.InboundIMAPHost, cli.InboundIMAPUsername, pass)
-	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbox, state, maxAge)
+	syncer := imapsync.New(dial, cli.InboundIMAPMailbox, cli.AgentUsername, inbound.DefaultInbox, inbox, state, maxAge)
 	// Gmail label write-through (ADR 0020 20c): capability-gated, so harmless on a
 	// non-Gmail backend (reports not-supported → WriteKeywords uses plain keywords).
 	syncer.SetLabelStore(imapsync.RawGmailLabelStore(cli.InboundIMAPHost, cli.InboundIMAPUsername, pass, cli.InboundIMAPMailbox))

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -25,6 +25,7 @@ type Syncer struct {
 	dial       DialFunc
 	mailbox    string
 	owner      string // the agent whose mailbox this is
+	inbox      string // the named inbox this syncer feeds (ADR 0023); "" = DefaultInbox
 	store      inbound.InboundStore
 	state      StateStore
 	maxAge     time.Duration  // recency cutoff; 0 = no cutoff (ADR 0008)
@@ -36,10 +37,11 @@ type Syncer struct {
 // (capability-gated) and falls back to plain keywords elsewhere.
 func (s *Syncer) SetLabelStore(fn LabelStoreFunc) { s.labelStore = fn }
 
-// New builds a Syncer. owner is the agent the synced mail belongs to. maxAge is
+// New builds a Syncer. owner is the agent the synced mail belongs to; inbox is the
+// named inbox this syncer feeds (ADR 0023; empty reads as DefaultInbox). maxAge is
 // the recency cutoff for the initial/full sync (0 = pull everything).
-func New(dial DialFunc, mailbox, owner string, store inbound.InboundStore, state StateStore, maxAge time.Duration) *Syncer {
-	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, store: store, state: state, maxAge: maxAge}
+func New(dial DialFunc, mailbox, owner, inbox string, store inbound.InboundStore, state StateStore, maxAge time.Duration) *Syncer {
+	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, inbox: inbox, store: store, state: state, maxAge: maxAge}
 }
 
 // Dialer is the production DialFunc: TLS-connect to addr and log in with the
@@ -147,7 +149,7 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 		if uid <= last {
 			continue // dynamic "N:*" past-the-end guard
 		}
-		d := deliveryOf(s.owner, m)
+		d := deliveryOf(s.owner, s.inbox, m)
 		d.UpstreamUID = uid
 		d.UIDValidity = uidValidity
 		// Store headers-only (pending); the body is fetched on demand. Idempotent
@@ -252,7 +254,7 @@ func uidSetOf(uids []imap.UID) imap.UIDSet {
 // stale) or the message is gone upstream, so the read face can surface a
 // transient error rather than empty content.
 func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
-	m, err := s.store.Get(owner, inbound.DefaultInbox, id)
+	m, err := s.store.Get(owner, s.inbox, id)
 	if err != nil {
 		return inbound.Message{}, err
 	}
@@ -301,7 +303,7 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 	if raw == nil {
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found", id, m.UpstreamUID)
 	}
-	return s.store.SetContent(owner, inbound.DefaultInbox, id, raw)
+	return s.store.SetContent(owner, s.inbox, id, raw)
 }
 
 // WriteKeywords replicates a message's keyword set to the upstream backend over a
@@ -314,7 +316,7 @@ func (s *Syncer) WriteKeywords(owner, id string, add, remove []string) error {
 	if len(add) == 0 && len(remove) == 0 {
 		return nil
 	}
-	m, err := s.store.Get(owner, inbound.DefaultInbox, id)
+	m, err := s.store.Get(owner, s.inbox, id)
 	if err != nil {
 		return err
 	}
@@ -364,7 +366,7 @@ func (s *Syncer) WriteKeywords(owner, id string, add, remove []string) error {
 // write whose immediate upstream replicate failed is retried here on the next sync
 // (ADR 0020). Best-effort: failures are logged, never fatal to the sync.
 func (s *Syncer) reconcileKeywords() {
-	dirty, err := s.store.DirtyKeywords(s.owner, inbound.DefaultInbox)
+	dirty, err := s.store.DirtyKeywords(s.owner, s.inbox)
 	if err != nil {
 		log.Printf("darbaan: keyword reconcile list: %v", err)
 		return
@@ -378,7 +380,7 @@ func (s *Syncer) reconcileKeywords() {
 			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
 			continue
 		}
-		if err := s.store.ClearKeywordsDirty(s.owner, inbound.DefaultInbox, m.ID); err != nil {
+		if err := s.store.ClearKeywordsDirty(s.owner, s.inbox, m.ID); err != nil {
 			log.Printf("darbaan: keyword reconcile clear %s: %v", m.ID, err)
 		}
 	}
@@ -392,8 +394,8 @@ func toFlags(kw []string) []imap.Flag {
 	return f
 }
 
-func deliveryOf(owner string, m *imapclient.FetchMessageBuffer) inbound.Delivery {
-	d := inbound.Delivery{Owner: owner, Raw: rawBody(m), Size: m.RFC822Size, Keywords: keywordsOf(m.Flags)}
+func deliveryOf(owner, inbox string, m *imapclient.FetchMessageBuffer) inbound.Delivery {
+	d := inbound.Delivery{Owner: owner, Inbox: inbox, Raw: rawBody(m), Size: m.RFC822Size, Keywords: keywordsOf(m.Flags)}
 	if m.Envelope != nil {
 		d.Subject = m.Envelope.Subject
 		d.From = firstAddr(m.Envelope.From)

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -100,7 +100,7 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	appendMsg(t, user, "From: bob@x.test\r\nTo: agent@d.test\r\nSubject: two\r\n\r\nbody two")
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
@@ -141,6 +141,28 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	assert.Len(t, msgs, 3)
 }
 
+func TestSyncTagsInbox(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: w\r\n\r\nbody")
+
+	store := newInbound(t)
+	// A syncer feeding the "work" inbox tags every record it writes (ADR 0023 2b).
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", "work", store, newState(t), 0)
+	n, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, n)
+
+	w, err := store.List("agent", "work")
+	require.NoError(t, err)
+	require.Len(t, w, 1)
+	assert.Equal(t, "work", w[0].Inbox)
+
+	// It is not visible in a different inbox.
+	d, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.Empty(t, d)
+}
+
 // Streaming pulls every message (no Collect-all into memory), and the concrete
 // UIDNEXT bound makes a no-new sync return 0 (not via the "N:*" quirk).
 func TestSyncStreamsManyMessages(t *testing.T) {
@@ -150,7 +172,7 @@ func TestSyncStreamsManyMessages(t *testing.T) {
 		appendMsg(t, user, fmt.Sprintf("Subject: m%d\r\n\r\nbody %d", i, i))
 	}
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 
 	got, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
@@ -174,7 +196,7 @@ func TestFetchContentFillsPending(t *testing.T) {
 	appendMsg(t, user, "Subject: real\r\n\r\nreal body") // upstream UID 1, UIDVALIDITY 1
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "real", UpstreamUID: 1, UIDValidity: 1})
 	require.NoError(t, err)
@@ -203,7 +225,7 @@ func TestFetchContentStaleUIDValidity(t *testing.T) {
 	appendMsg(t, user, "Subject: x\r\n\r\ny")
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 999})
 	require.NoError(t, err)
 
@@ -220,12 +242,12 @@ func TestSyncDedupsOnCursorReset(t *testing.T) {
 
 	store := newInbound(t) // shared across both syncers
 
-	n, err := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0).Sync(context.Background())
+	n, err := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0).Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 2, n)
 
 	// A second syncer with a FRESH cursor re-fetches both, but dedups: 0 new.
-	n, err = imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0).Sync(context.Background())
+	n, err = imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0).Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 0, n)
 
@@ -241,7 +263,7 @@ func TestSyncPullsKeywords(t *testing.T) {
 	appendMsgKw(t, user, "Subject: tagged\r\n\r\nx", []imap.Flag{"useless", "$Important", imap.FlagSeen})
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, n)
@@ -281,7 +303,7 @@ func TestWriteKeywordsToUpstream(t *testing.T) {
 	addr, user := startUpstream(t)
 	appendMsg(t, user, "Subject: x\r\n\r\ny") // upstream UID 1
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	msgs, err := store.List("agent", inbound.DefaultInbox)
@@ -302,7 +324,7 @@ func TestWriteKeywordsRoutesToLabelStore(t *testing.T) {
 	addr, user := startUpstream(t)
 	appendMsg(t, user, "Subject: x\r\n\r\ny")
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	msgs, err := store.List("agent", inbound.DefaultInbox)
@@ -330,7 +352,7 @@ func TestSyncReconcilesDirtyKeywords(t *testing.T) {
 	addr, user := startUpstream(t)
 	appendMsg(t, user, "Subject: x\r\n\r\ny")
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	msgs, err := store.List("agent", inbound.DefaultInbox)
@@ -360,7 +382,7 @@ func TestSyncRecencyCutoff(t *testing.T) {
 	appendMsgAt(t, user, "Subject: fresh\r\n\r\ny", time.Now())
 
 	store := newInbound(t)
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, newState(t), 365*24*time.Hour) // 1y
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 365*24*time.Hour) // 1y
 
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
@@ -386,7 +408,7 @@ func TestSyncResetsOnUIDValidityMismatch(t *testing.T) {
 	state := newState(t)
 	require.NoError(t, state.Save("INBOX", imapsync.State{UIDValidity: 424242, LastUID: 99}))
 
-	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", store, state, 0)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, state, 0)
 	n, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, 1, n) // mismatch → cursor reset to 0 → message re-pulled despite LastUID=99


### PR DESCRIPTION
Multi-inbox slice **2b** of 5 (ADR 0023) — the sync side writes per-inbox. **Stacked on #129 (2a)** — base is the 2a branch, so this diff is only 2b; I'll retarget to `main` once #129 merges.

## What
- `Syncer` gains an `inbox` name field. It tags every `Delivery` it writes with that inbox (`deliveryOf`) and scopes its store reads — `FetchContent`, and the keyword reconcile (`DirtyKeywords` / `ClearKeywordsDirty`) — to it. So a syncer feeding one inbox never reads, fills, or dedups against another's records.
- Replaces the `DefaultInbox` literals 2a placed at the syncer's call sites with `s.inbox`.

## N=1 unchanged
`cmd` constructs the single syncer with `inbound.DefaultInbox`, so its records, on-demand fetches, and reconcile all resolve to the default inbox exactly as before. (Per-inbox *construction* of N syncers comes with the read-face/config wiring in slice 3.)

## Tests
New `TestSyncTagsInbox`: a syncer feeding `work` tags its synced records `work` (visible under `List(owner, "work")`, absent under the default inbox). All existing sync tests updated for the new `New(...)` signature and pass unchanged. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Next: 3 (read face serves N mailboxes). Builds on #129 (2a).
