### PR TITLE
feat(serve): consume inboxcfg → per-inbox filter map + filter_file (ADR 0023, 3a/5)

### DIFF
--- a/cmd/darbaan/inboxes_test.go
+++ b/cmd/darbaan/inboxes_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+func TestResolveInboxesImplicitDefault(t *testing.T) {
+	// No inboxes: config → one implicit "default" inbox built from the flat flags,
+	// carrying the legacy --inbound-filter as its filter_file (ADR 0023 back-compat).
+	rules := filepath.Join(t.TempDir(), "rules.yaml")
+	require.NoError(t, os.WriteFile(rules, []byte("default_visibility: visible\n"), 0o600))
+	cli := parseCLI(t, []string{
+		"--inbound-filter", rules,
+		"--inbound-imap-host", "imap.example:993",
+		"version",
+	})
+	inboxes, err := cli.resolveInboxes()
+	require.NoError(t, err)
+	require.Len(t, inboxes, 1)
+	assert.Equal(t, inbound.DefaultInbox, inboxes[0].Name)
+	assert.Equal(t, rules, inboxes[0].FilterFile)
+	assert.Equal(t, "imap.example:993", inboxes[0].Backend.IMAPHost)
+	// The implicit default's filter compiles from the legacy path.
+	flt, err := inboxes[0].Filter()
+	require.NoError(t, err)
+	require.NotNil(t, flt)
+}
+
+func TestResolveInboxesFromConfig(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfg, []byte(
+		"inboxes:\n"+
+			"  - name: work\n    identity: agent@company.example\n"+
+			"  - name: personal\n    default_visibility: hidden\n"), 0o600))
+
+	cli := parseCLI(t, []string{"--config", cfg, "version"})
+	inboxes, err := cli.resolveInboxes()
+	require.NoError(t, err)
+	require.Len(t, inboxes, 2)
+	assert.Equal(t, "work", inboxes[0].Name)
+	assert.Equal(t, "agent@company.example", inboxes[0].Identity)
+	assert.Equal(t, "personal", inboxes[1].Name)
+	assert.Equal(t, "hidden", inboxes[1].DefaultVisibility)
+}

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/imapsync"
 	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/inboxcfg"
 	"github.com/yaad-index/darbaan/internal/listener"
 	"github.com/yaad-index/darbaan/internal/policy"
 	"github.com/yaad-index/darbaan/internal/signer"
@@ -134,6 +135,67 @@ func (c *CLI) openStore() (sluice.MessageStore, func(), error) {
 		return nil, nil, err
 	}
 	return ms, func() { _ = ms.Close(); _ = al.Close() }, nil
+}
+
+// configBytes returns the bytes of the resolved config file (the same path kong
+// loaded — --config / DARBAAN_CONFIG / a default), or nil if none. The inboxes:
+// list (ADR 0023) is read from it directly, since kong's flat flags don't model
+// a list of inbox objects.
+func (c *CLI) configBytes() ([]byte, error) {
+	path := c.Config
+	if path == "" {
+		for _, p := range defaultConfigPaths {
+			if _, err := os.Stat(p); err == nil {
+				path = p
+				break
+			}
+		}
+	}
+	if path == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read config %s: %w", path, err)
+	}
+	return data, nil
+}
+
+// resolveInboxes resolves the configured inboxes (ADR 0023), or a single implicit
+// "default" inbox built from the legacy top-level flags when no inboxes: is
+// configured — so an existing single-inbox config is unchanged. Each inbox's
+// filter is validated (compiles) by Validate.
+func (c *CLI) resolveInboxes() ([]inboxcfg.Inbox, error) {
+	data, err := c.configBytes()
+	if err != nil {
+		return nil, err
+	}
+	parsed, err := inboxcfg.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	implicit := inboxcfg.Inbox{
+		Name:       inbound.DefaultInbox,
+		Identity:   c.SMTPUsername,
+		FilterFile: c.InboundFilter,
+		Backend: inboxcfg.Backend{
+			IMAPHost:     c.InboundIMAPHost,
+			IMAPUsername: c.InboundIMAPUsername,
+			IMAPMailbox:  c.InboundIMAPMailbox,
+			MaxAge:       c.InboundMaxAge,
+			SenderType:   c.SenderType,
+			SMTPHost:     c.SMTPHost,
+			SMTPUsername: c.SMTPUsername,
+		},
+	}
+	inboxes := inboxcfg.Resolve(parsed, implicit)
+	if err := inboxcfg.Validate(inboxes); err != nil {
+		return nil, err
+	}
+	return inboxes, nil
 }
 
 // openInbound opens the inbound (served mailbox) store per config.
@@ -440,10 +502,25 @@ func (*ServeCmd) Run(cli *CLI) error {
 	}
 	defer stopSync()
 
-	flt, err := filter.Load(cli.InboundFilter)
+	// Resolve the configured inboxes (ADR 0023): a config with no inboxes: is one
+	// implicit "default" inbox built from the legacy top-level flags, so a
+	// single-inbox deployment is unchanged. Each inbox's filter is compiled up
+	// front (fail-fast on a bad rule set). 3a wires the resolution + per-inbox
+	// filter map; the read face still serves the default inbox here — N mailboxes
+	// land in 3b.
+	inboxes, err := cli.resolveInboxes()
 	if err != nil {
 		return err
 	}
+	filters := make(map[string]*filter.Filter, len(inboxes))
+	for _, in := range inboxes {
+		f, ferr := in.Filter()
+		if ferr != nil {
+			return fmt.Errorf("inbox %q: %w", in.Name, ferr)
+		}
+		filters[in.Name] = f
+	}
+	flt := filters[inbound.DefaultInbox]
 	// The inbound bounce-spoof guard (ADR 0024) runs ahead of the user filter on
 	// both faces, verifying with the bounce signer's own key. On by default; an
 	// explicit opt-out is logged. on_spoof=hold-for-human routes spoofs to the

--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -25,10 +25,15 @@ type Inbox struct {
 	Identity string  `yaml:"identity"` // the From/envelope identity Darbaan sends as for this inbox
 	Backend  Backend `yaml:"backend"`
 
-	// The per-inbox filter policy unit (ADR 0021/0022). Captured as raw YAML so it
-	// compiles through the existing filter engine without re-exporting its config.
+	// The per-inbox filter policy unit (ADR 0021/0022): EITHER inline
+	// default_visibility + rules (captured as raw YAML so it compiles through the
+	// existing filter engine without re-exporting its config), OR a filter_file
+	// path to a YAML rules file. The two are mutually exclusive (a fail-fast config
+	// error if both are set). filter_file eases collapsing an existing path-based
+	// deployment into an inboxes: entry (ADR 0023).
 	DefaultVisibility string    `yaml:"default_visibility"`
 	Rules             yaml.Node `yaml:"rules"`
+	FilterFile        string    `yaml:"filter_file"`
 }
 
 // Backend is an inbox's upstream account coordinates (ADR 0009). Secrets
@@ -94,8 +99,9 @@ func Validate(inboxes []Inbox) error {
 	return nil
 }
 
-// Filter compiles the inbox's {default_visibility, rules} policy unit (ADR
-// 0021/0022) via the shared filter engine. An inbox with neither key yields a
+// Filter compiles the inbox's filter (ADR 0021/0022): from the filter_file path
+// if set, else from the inline {default_visibility, rules}. The two are mutually
+// exclusive — both set is a config error. An inbox with neither yields a
 // pass-through (default-allow) filter.
 func (in Inbox) Filter() (*filter.Filter, error) {
 	doc := map[string]any{}
@@ -104,6 +110,12 @@ func (in Inbox) Filter() (*filter.Filter, error) {
 	}
 	if !in.Rules.IsZero() {
 		doc["rules"] = &in.Rules
+	}
+	if in.FilterFile != "" {
+		if len(doc) > 0 {
+			return nil, fmt.Errorf("filter_file and inline default_visibility/rules are mutually exclusive")
+		}
+		return filter.Load(in.FilterFile)
 	}
 	if len(doc) == 0 {
 		return filter.Compile(nil)

--- a/internal/inboxcfg/inboxcfg_test.go
+++ b/internal/inboxcfg/inboxcfg_test.go
@@ -1,6 +1,8 @@
 package inboxcfg_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,6 +13,23 @@ import (
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/inboxcfg"
 )
+
+func TestInboxFilterFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f.yaml")
+	require.NoError(t, os.WriteFile(path,
+		[]byte("default_visibility: hidden\nrules:\n  - match: [{field: label, op: equals, value: x}]\n"), 0o600))
+
+	// filter_file loads the filter from the path.
+	flt, err := inboxcfg.Inbox{Name: "p", FilterFile: path}.Filter()
+	require.NoError(t, err)
+	assert.Equal(t, filter.Hide, flt.Default())
+
+	// filter_file AND inline together is a config error (Filter + Validate).
+	both := inboxcfg.Inbox{Name: "p", FilterFile: path, DefaultVisibility: "visible"}
+	_, err = both.Filter()
+	require.Error(t, err)
+	require.Error(t, inboxcfg.Validate([]inboxcfg.Inbox{both}))
+}
 
 const twoInboxes = `
 inboxes:


### PR DESCRIPTION
Multi-inbox slice 3a of 5 (ADR 0023) — serve consumes inboxcfg. Foundation for the N-mailbox read face (3b); behavior-preserving at N=1.

## What
- ServeCmd resolves the configured inboxes: it re-reads the SAME config file kong loaded (`--config` / `DARBAAN_CONFIG` / default) for the `inboxes:` list, or builds a single implicit `default` inbox from the legacy top-level flags when none is configured.
- Compiles each inbox's filter up front into a per-inbox map (fail-fast on a bad rule set), and serves the default inbox's filter. N mailboxes land in 3b.

## inboxcfg extension (per the review note)
Adds an optional `filter_file` path to `inboxcfg.Inbox` (a small extension to the merged inboxcfg model): an inbox's filter is **either** inline `default_visibility`+`rules` **or** a `filter_file` path — both set is a fail-fast config error. This lets an existing path-based deployment migrate cleanly into an `inboxes:` entry, and lets the implicit default carry the legacy `--inbound-filter` path so **N=1 is byte-for-byte unchanged**.

## N=1 unchanged
No `inboxes:` → one `default` inbox whose `filter_file` is `--inbound-filter`; serve compiles + serves exactly today's filter. A missing filter path still fails at startup, as today.

## Tests
inboxcfg: `filter_file` loads from a path; `filter_file`+inline together errors (Filter + Validate). cmd: `resolveInboxes` returns the implicit default (name `default`, `filter_file`=`--inbound-filter`, backend from flat flags) with no config, and the configured inboxes from a config file. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Next: 3b (read face serves N mailboxes). Builds on 1/2a/2b (merged).
