### PR TITLE
feat(listener): read face serves N mailboxes per inbox (ADR 0023, 3b/5)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -540,7 +540,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer), flt, guard, holdSpoof)
+	}, cred, inbox, imapContentFetch(syncer), imapKeywordWriter(syncer), filters, guard, holdSpoof)
 	if err != nil {
 		return err
 	}

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -253,8 +253,8 @@ func uidSetOf(uids []imap.UID) imap.UIDSet {
 // errors cleanly when the mailbox UIDVALIDITY has changed (the stored UID is
 // stale) or the message is gone upstream, so the read face can surface a
 // transient error rather than empty content.
-func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
-	m, err := s.store.Get(owner, s.inbox, id)
+func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) {
+	m, err := s.store.Get(owner, inbox, id)
 	if err != nil {
 		return inbound.Message{}, err
 	}
@@ -303,7 +303,7 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 	if raw == nil {
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found", id, m.UpstreamUID)
 	}
-	return s.store.SetContent(owner, s.inbox, id, raw)
+	return s.store.SetContent(owner, inbox, id, raw)
 }
 
 // WriteKeywords replicates a message's keyword set to the upstream backend over a
@@ -312,11 +312,11 @@ func (s *Syncer) FetchContent(owner, id string) (inbound.Message, error) {
 // current keywords and applying the +/- delta, so it is idempotent and handles
 // both additions and removals (content + delete stay read-only). The local store
 // is canonical; a failure here is returned so the caller logs + reconciles later.
-func (s *Syncer) WriteKeywords(owner, id string, add, remove []string) error {
+func (s *Syncer) WriteKeywords(owner, inbox, id string, add, remove []string) error {
 	if len(add) == 0 && len(remove) == 0 {
 		return nil
 	}
-	m, err := s.store.Get(owner, s.inbox, id)
+	m, err := s.store.Get(owner, inbox, id)
 	if err != nil {
 		return err
 	}
@@ -376,7 +376,7 @@ func (s *Syncer) reconcileKeywords() {
 		// failed immediate label REMOVE is NOT reconciled (the label lingers
 		// upstream). Deliberate — acceptable for the add-dominated labeling flow;
 		// the deferred convergent read-side / go-imap upstream swap cleans it up.
-		if err := s.WriteKeywords(s.owner, m.ID, m.Keywords, nil); err != nil {
+		if err := s.WriteKeywords(s.owner, s.inbox, m.ID, m.Keywords, nil); err != nil {
 			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
 			continue
 		}

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -127,7 +127,7 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	assert.Equal(t, 0, n)
 
 	// The body is fetched on demand.
-	filled, err := syncer.FetchContent("agent", msgs[0].ID)
+	filled, err := syncer.FetchContent("agent", inbound.DefaultInbox, msgs[0].ID)
 	require.NoError(t, err)
 	assert.False(t, filled.Pending)
 	assert.Contains(t, string(filled.Raw), "body")
@@ -202,7 +202,7 @@ func TestFetchContentFillsPending(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, m.Pending)
 
-	filled, err := syncer.FetchContent("agent", m.ID)
+	filled, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.False(t, filled.Pending)
 	assert.Contains(t, string(filled.Raw), "real body")
@@ -213,7 +213,7 @@ func TestFetchContentFillsPending(t *testing.T) {
 	assert.Contains(t, string(got.Raw), "real body")
 
 	// Present message → no upstream contact, returned as-is.
-	again, err := syncer.FetchContent("agent", m.ID)
+	again, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
 	require.NoError(t, err)
 	assert.False(t, again.Pending)
 }
@@ -229,7 +229,7 @@ func TestFetchContentStaleUIDValidity(t *testing.T) {
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 999})
 	require.NoError(t, err)
 
-	_, err = syncer.FetchContent("agent", m.ID)
+	_, err = syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
 	require.Error(t, err)
 }
 
@@ -310,11 +310,11 @@ func TestWriteKeywordsToUpstream(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 
-	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, []string{"useless", "handled"}, nil))
+	require.NoError(t, syncer.WriteKeywords("agent", inbound.DefaultInbox, msgs[0].ID, []string{"useless", "handled"}, nil))
 	assert.ElementsMatch(t, []string{"useless", "handled"}, upstreamKeywords(t, addr, 1))
 
 	// Removing one via the delta.
-	require.NoError(t, syncer.WriteKeywords("agent", msgs[0].ID, nil, []string{"useless"}))
+	require.NoError(t, syncer.WriteKeywords("agent", inbound.DefaultInbox, msgs[0].ID, nil, []string{"useless"}))
 	assert.ElementsMatch(t, []string{"handled"}, upstreamKeywords(t, addr, 1))
 }
 
@@ -335,14 +335,14 @@ func TestWriteKeywordsRoutesToLabelStore(t *testing.T) {
 	var gotUID uint32
 	var gotAdd []string
 	syncer.SetLabelStore(func(uid, _ uint32, add, remove []string) error { gotUID, gotAdd = uid, add; return nil })
-	require.NoError(t, syncer.WriteKeywords("agent", id, []string{"useless"}, nil))
+	require.NoError(t, syncer.WriteKeywords("agent", inbound.DefaultInbox, id, []string{"useless"}, nil))
 	assert.Equal(t, uint32(1), gotUID)
 	assert.Equal(t, []string{"useless"}, gotAdd)
 	assert.Empty(t, upstreamKeywords(t, addr, 1)) // went the label path, not keywords
 
 	// ErrNotXGM → fall back to a plain keyword STORE.
 	syncer.SetLabelStore(func(uid, _ uint32, add, remove []string) error { return imapsync.ErrNotXGM })
-	require.NoError(t, syncer.WriteKeywords("agent", id, []string{"plainkw"}, nil))
+	require.NoError(t, syncer.WriteKeywords("agent", inbound.DefaultInbox, id, []string{"plainkw"}, nil))
 	assert.ElementsMatch(t, []string{"plainkw"}, upstreamKeywords(t, addr, 1))
 }
 

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -39,14 +39,14 @@ type IMAPServerConfig struct {
 // ContentFetch resolves a message's full content (Raw) on demand: for a present
 // record from its blob, for a pending record by fetching the body from upstream
 // (lazy, ADR 0019). It is called per-FETCH, never at SELECT.
-type ContentFetch func(owner, id string) (inbound.Message, error)
+type ContentFetch func(owner, inbox, id string) (inbound.Message, error)
 
 // KeywordWriter replicates a keyword change to the upstream backend as an
 // add/remove delta (the label write-through, ADR 0020). The local store is
 // canonical; a returned error means the upstream replicate failed and is
 // reconciled later. nil disables write-through (local-only labels — e.g. sync
 // disabled).
-type KeywordWriter func(owner, id string, add, remove []string) error
+type KeywordWriter func(owner, inbox, id string, add, remove []string) error
 
 // IMAPServer serves the agent's mailbox (the InboundStore) over IMAP as a
 // translation adapter (ADR 0016): the store is canonical. SELECT snapshots
@@ -60,16 +60,23 @@ type IMAPServer struct {
 // content on demand; if nil it defaults to reading straight from the store
 // (no upstream — bounce-only / sync-disabled deployments have no pending
 // records).
-func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, flt *filter.Filter, guard *bounceguard.Guard, holdSpoof bool) (*IMAPServer, error) {
+// filters maps each inbox name to its compiled serve-time filter (ADR 0021/0022).
+// The keys are the configured inboxes (ADR 0023); each is exposed as an IMAP
+// mailbox (the default inbox as INBOX). A single-inbox deploy passes one entry
+// keyed DefaultInbox.
+func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
+	if len(filters) == 0 {
+		filters = map[string]*filter.Filter{inbound.DefaultInbox: nil} // no filter = allow-all default inbox
+	}
 	if fetch == nil {
-		fetch = func(owner, id string) (inbound.Message, error) { return store.Get(owner, inbound.DefaultInbox, id) }
+		fetch = func(owner, inbox, id string) (inbound.Message, error) { return store.Get(owner, inbox, id) }
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords, filter: flt, guard: guard, holdSpoof: holdSpoof}, nil, nil
+			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -92,14 +99,45 @@ func (s *IMAPServer) Close() error { return s.imap.Close() }
 type imapSession struct {
 	cred          Credential
 	store         inbound.InboundStore
-	fetch         ContentFetch       // resolves message content on demand (per-FETCH)
-	writeKeywords KeywordWriter      // replicates a keyword change upstream (nil = local-only)
-	filter        *filter.Filter     // serve-time inbound filter (nil = allow all; ADR 0021)
-	guard         *bounceguard.Guard // inbound bounce-spoof guard, ahead of the filter (nil = off; ADR 0024)
-	holdSpoof     bool               // on_spoof=hold-for-human → held-semantics; false = hide
+	fetch         ContentFetch              // resolves message content on demand (per-FETCH)
+	writeKeywords KeywordWriter             // replicates a keyword change upstream (nil = local-only)
+	filters       map[string]*filter.Filter // per-inbox serve-time filter (ADR 0021/0022/0023)
+	guard         *bounceguard.Guard        // inbound bounce-spoof guard, ahead of the filter (nil = off; ADR 0024)
+	holdSpoof     bool                      // on_spoof=hold-for-human → held-semantics; false = hide
 	owner         string
+	selectedInbox string // the inbox name of the SELECTed mailbox (ADR 0023)
 	authed        bool
 	selected      []inbound.Message // metadata snapshot taken at Select (no content)
+}
+
+// mailboxName maps an inbox name to its IMAP mailbox name: the default inbox is
+// exposed as INBOX (back-compat), every other inbox by its own name (ADR 0023).
+func mailboxName(inbox string) string {
+	if inbox == inbound.DefaultInbox {
+		return imapMailbox
+	}
+	return inbox
+}
+
+// resolveMailbox maps an IMAP mailbox name back to a configured inbox name,
+// reporting whether it exists.
+func (s *imapSession) resolveMailbox(mailbox string) (string, bool) {
+	for inbox := range s.filters {
+		if mailboxName(inbox) == mailbox {
+			return inbox, true
+		}
+	}
+	return "", false
+}
+
+// mailboxNames returns the exposed IMAP mailbox names, sorted for stable LIST.
+func (s *imapSession) mailboxNames() []string {
+	names := make([]string, 0, len(s.filters))
+	for inbox := range s.filters {
+		names = append(names, mailboxName(inbox))
+	}
+	sort.Strings(names)
+	return names
 }
 
 // listAndFilter returns the owner's full message list and the filtered-visible
@@ -108,26 +146,27 @@ type imapSession struct {
 // when the highest-UID messages are hidden, breaking client sync. allow is
 // visible; hide and undecided/rejected hold are omitted. Evaluated fresh each
 // call (no cache).
-func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err error) {
-	full, err = s.store.List(s.owner, inbound.DefaultInbox)
+func (s *imapSession) listAndFilter(inbox string) (full, visible []inbound.Message, err error) {
+	full, err = s.store.List(s.owner, inbox)
 	if err != nil {
 		return nil, nil, err
 	}
+	flt := s.filters[inbox] // per-inbox filter (ADR 0023); nil = allow-all
 	now := time.Now()
 	for _, m := range full { // new backing slice — leave full intact for UIDNEXT
 		// The bounce-spoof guard runs AHEAD of the user filter (ADR 0024): it is a
 		// security floor, so a spoof can't be surfaced by a permissive default or a
 		// broad allow rule.
 		if s.guard != nil {
-			if s.guardHides(m) {
+			if s.guardHides(m, inbox) {
 				continue
 			}
 		}
-		if s.filter == nil {
+		if flt == nil {
 			visible = append(visible, m)
 			continue
 		}
-		switch s.filter.Decide(m, now) {
+		switch flt.Decide(m, now) {
 		case filter.Allow:
 			visible = append(visible, m)
 		case filter.Hold:
@@ -148,9 +187,9 @@ func (s *imapSession) listAndFilter() (full, visible []inbound.Message, err erro
 // (the user filter then applies). A guard error is fail-CLOSED (Verdict returns
 // spoof=true for a bounce-shaped candidate it couldn't fetch/verify, ADR 0024);
 // it is logged and the message is hidden.
-func (s *imapSession) guardHides(m inbound.Message) bool {
+func (s *imapSession) guardHides(m inbound.Message, inbox string) bool {
 	spoof, err := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
-		fm, e := s.fetch(s.owner, m.ID)
+		fm, e := s.fetch(s.owner, inbox, m.ID)
 		return fm.Raw, e
 	})
 	if err != nil {
@@ -202,10 +241,12 @@ func (s *imapSession) Login(username, password string) error {
 }
 
 func (s *imapSession) Select(mailbox string, _ *imap.SelectOptions) (*imap.SelectData, error) {
-	if mailbox != imapMailbox {
+	inbox, ok := s.resolveMailbox(mailbox)
+	if !ok {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
 	}
-	full, visible, err := s.listAndFilter()
+	s.selectedInbox = inbox
+	full, visible, err := s.listAndFilter(inbox)
 	if err != nil {
 		return nil, err
 	}
@@ -245,10 +286,11 @@ func (s *imapSession) Unselect() error {
 }
 
 func (s *imapSession) Status(mailbox string, options *imap.StatusOptions) (*imap.StatusData, error) {
-	if mailbox != imapMailbox {
+	inbox, ok := s.resolveMailbox(mailbox)
+	if !ok {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
 	}
-	full, visible, err := s.listAndFilter()
+	full, visible, err := s.listAndFilter(inbox) // a query, not a selection — selectedInbox unchanged
 	if err != nil {
 		return nil, err
 	}
@@ -279,10 +321,14 @@ func (s *imapSession) List(w *imapserver.ListWriter, _ string, patterns []string
 	if len(patterns) == 0 {
 		return nil // LIST "" "" is a delimiter query; nothing to enumerate
 	}
-	return w.WriteList(&imap.ListData{
-		Mailbox: imapMailbox,
-		Delim:   '/',
-	})
+	// Advertise every configured inbox as a mailbox (the default inbox as INBOX),
+	// in stable order (ADR 0023).
+	for _, name := range s.mailboxNames() {
+		if err := w.WriteList(&imap.ListData{Mailbox: name, Delim: '/'}); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error {
@@ -300,7 +346,7 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 			return
 		}
 		if markSeen && !m.Seen {
-			if err := s.store.SetSeen(s.owner, inbound.DefaultInbox, m.ID, true); err != nil {
+			if err := s.store.SetSeen(s.owner, s.selectedInbox, m.ID, true); err != nil {
 				ferr = err
 				return
 			}
@@ -333,7 +379,7 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 		if !done {
 			done = true
 			var full inbound.Message
-			if full, err = s.fetch(s.owner, m.ID); err == nil {
+			if full, err = s.fetch(s.owner, s.selectedInbox, m.ID); err == nil {
 				raw = full.Raw
 			}
 		}
@@ -352,7 +398,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 			return
 		}
 		if touchesSeen && m.Seen != seen {
-			if err := s.store.SetSeen(s.owner, inbound.DefaultInbox, m.ID, seen); err != nil {
+			if err := s.store.SetSeen(s.owner, s.selectedInbox, m.ID, seen); err != nil {
 				serr = err
 				return
 			}
@@ -363,7 +409,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 		if flags.Op == imap.StoreFlagsSet || len(kw) > 0 {
 			next, added, removed := applyKeywordOp(m.Keywords, flags.Op, kw)
 			if len(added) > 0 || len(removed) > 0 {
-				if _, err := s.store.SetKeywords(s.owner, inbound.DefaultInbox, m.ID, next); err != nil {
+				if _, err := s.store.SetKeywords(s.owner, s.selectedInbox, m.ID, next); err != nil {
 					serr = err
 					return
 				}
@@ -373,10 +419,10 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 				// Skip records with no upstream (locally-generated, e.g. bounces) —
 				// their labels are local-only, nothing to replicate.
 				if s.writeKeywords != nil && m.UpstreamUID != 0 {
-					if err := s.writeKeywords(s.owner, m.ID, added, removed); err != nil {
+					if err := s.writeKeywords(s.owner, s.selectedInbox, m.ID, added, removed); err != nil {
 						log.Printf("darbaan: imap keyword write-through for %s deferred: %v", m.ID, err)
 					} else {
-						_ = s.store.ClearKeywordsDirty(s.owner, inbound.DefaultInbox, m.ID)
+						_ = s.store.ClearKeywordsDirty(s.owner, s.selectedInbox, m.ID)
 					}
 				}
 			}

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -45,11 +45,63 @@ func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk, flt, nil, false)
+		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
 	return l.Addr().String()
+}
+
+func startIMAPMulti(t *testing.T, store inbound.InboundStore, filters map[string]*filter.Filter) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
+		listener.Credential{Username: "agent", Password: "pw"}, store, nil, nil, filters, nil, false)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+// ADR 0023: each configured inbox is a named IMAP mailbox (the default inbox as
+// INBOX); SELECT serves that inbox's records, isolated from the others.
+func TestIMAPMultiInbox(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	_, err = store.Add(inbound.Delivery{Owner: "agent", Subject: "d", Raw: []byte("Subject: d\r\n\r\nd")})
+	require.NoError(t, err)
+	_, err = store.Add(inbound.Delivery{Owner: "agent", Inbox: "work", Subject: "w", Raw: []byte("Subject: w\r\n\r\nw")})
+	require.NoError(t, err)
+
+	addr := startIMAPMulti(t, store, map[string]*filter.Filter{inbound.DefaultInbox: nil, "work": nil})
+	c, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+
+	// LIST advertises the default inbox as INBOX plus the named "work" mailbox.
+	boxes, err := c.List("", "*", nil).Collect()
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, b := range boxes {
+		names[b.Mailbox] = true
+	}
+	assert.True(t, names["INBOX"], "LIST shows INBOX (default inbox)")
+	assert.True(t, names["work"], "LIST shows the work mailbox")
+
+	// Each mailbox serves only its own inbox's records.
+	selWork, err := c.Select("work", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), selWork.NumMessages)
+	selInbox, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), selInbox.NumMessages)
+
+	// A mailbox that isn't configured does not exist.
+	_, err = c.Select("nope", nil).Wait()
+	require.Error(t, err)
 }
 
 // A body FETCH of a pending (headers-only) record resolves its content on demand
@@ -62,7 +114,7 @@ func TestIMAPFetchResolvesPendingOnDemand(t *testing.T) {
 	require.NoError(t, err) // pending record at seq 2
 
 	var fetchCalls int
-	fetch := func(owner, id string) (inbound.Message, error) {
+	fetch := func(owner, inbox, id string) (inbound.Message, error) {
 		fetchCalls++
 		if id == m.ID { // simulate the on-demand upstream fill
 			return store.SetContent(owner, inbound.DefaultInbox, id, []byte("Subject: lazy\r\n\r\nlazy-body"))
@@ -231,7 +283,7 @@ func TestIMAPEnvelopeAndHeaderSearchFromMetadata(t *testing.T) {
 	require.NoError(t, err)
 
 	var fetchCalls int
-	fetch := func(owner, id string) (inbound.Message, error) {
+	fetch := func(owner, inbox, id string) (inbound.Message, error) {
 		fetchCalls++
 		return store.Get(owner, inbound.DefaultInbox, id)
 	}
@@ -324,7 +376,7 @@ func TestIMAPStoreKeywordWritesThrough(t *testing.T) {
 
 	var wroteID string
 	var wroteAdd []string
-	wk := func(owner, id string, add, remove []string) error { wroteID, wroteAdd = id, add; return nil }
+	wk := func(owner, inbox, id string, add, remove []string) error { wroteID, wroteAdd = id, add; return nil }
 
 	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk, nil), nil)
 	require.NoError(t, err)
@@ -355,7 +407,7 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1})
 	require.NoError(t, err)
 
-	wk := func(owner, id string, add, remove []string) error { return errors.New("upstream down") }
+	wk := func(owner, inbox, id string, add, remove []string) error { return errors.New("upstream down") }
 
 	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk, nil), nil)
 	require.NoError(t, err)
@@ -382,7 +434,7 @@ func TestIMAPStoreKeywordWriteFailureStaysDirty(t *testing.T) {
 func TestIMAPStoreKeywordLocalOnlyNoUpstream(t *testing.T) {
 	store := seedInbound(t) // a bounce: Add → no UpstreamUID, seq 1
 	called := false
-	wk := func(owner, id string, add, remove []string) error { called = true; return nil }
+	wk := func(owner, inbox, id string, add, remove []string) error { called = true; return nil }
 
 	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, wk, nil), nil)
 	require.NoError(t, err)


### PR DESCRIPTION
Multi-inbox slice 3b of 5 (ADR 0023) — the read face serves N mailboxes.

## What
- Each configured inbox is exposed as an IMAP mailbox: LIST advertises them (the default inbox as `INBOX` for back-compat, others by name, stable-sorted), SELECT/STATUS resolve a mailbox name to its inbox, and the session serves that inbox's records via its own filter (the per-inbox filter map from 3a) + the bounce guard.
- The session tracks the SELECTed inbox and threads it through every read-face store op (List/Get/SetSeen/SetKeywords/ClearKeywordsDirty) and the on-demand content fetch.
- `ContentFetch` and `KeywordWriter` gain an `inbox` parameter so FETCH/STORE on a selected mailbox resolve content / replicate keywords for the right inbox. The syncer's `FetchContent`/`WriteKeywords` use the passed inbox; its sync-write + reconcile use its own configured inbox.

## N=1 byte-for-byte
One inbox (default) is served as `INBOX` exactly as before — all existing read-face/sync tests pass unchanged.

## Cross-package
listener (the read-face change) + imapsync (FetchContent/WriteKeywords signatures) + cmd (passes the per-inbox filter map to NewIMAPServer). No new logic in the callers.

## Follow-ups for N>1 (noted; not reached until a multi-inbox config deploys)
- Per-inbox content-fetch routing across N syncers, and aggregating the admin held-list across inboxes — both land with the N-syncers wiring (3c).

## Tests
New `TestIMAPMultiInbox`: with default + `work` inboxes, LIST shows `INBOX` + `work`, SELECT each serves only its inbox's records, an unconfigured mailbox errors. All existing tests pass. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Next: 3c (N syncers + per-inbox fetch routing + held-list aggregation). Builds on 1/2a/2b/3a (merged).
