### PR TITLE
feat(inboxcfg): EnvPrefix mangle + secret-env collision guard (ADR 0023, 3c-i)

### DIFF
--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -83,6 +83,7 @@ func Validate(inboxes []Inbox) error {
 		return fmt.Errorf("inboxcfg: no inboxes configured")
 	}
 	seen := make(map[string]bool, len(inboxes))
+	envSeen := make(map[string]string, len(inboxes)) // EnvPrefix → first inbox name
 	for i, in := range inboxes {
 		name := strings.TrimSpace(in.Name)
 		if name == "" {
@@ -92,11 +93,39 @@ func Validate(inboxes []Inbox) error {
 			return fmt.Errorf("inboxcfg: duplicate inbox name %q", name)
 		}
 		seen[name] = true
+		// The per-inbox secret env binding is many-to-one (e.g. "work-1" and
+		// "work.1" both mangle to WORK_1), so a collision would silently share
+		// secrets — reject it at load (ADR 0023).
+		ep := EnvPrefix(name)
+		if other, dup := envSeen[ep]; dup {
+			return fmt.Errorf("inboxcfg: inboxes %q and %q map to the same secret env prefix %q", other, name, ep)
+		}
+		envSeen[ep] = name
 		if _, err := in.Filter(); err != nil {
 			return fmt.Errorf("inboxcfg: inbox %q: %w", name, err)
 		}
 	}
 	return nil
+}
+
+// EnvPrefix mangles an inbox name into the infix of its per-inbox secret env vars
+// (ADR 0012/0023): uppercased, with every rune outside [A-Z0-9] replaced by '_'
+// (e.g. "work" → "WORK", "team-1" → "TEAM_1"). It is the SINGLE source of truth
+// for the mangle — both the runtime secret lookup
+// (DARBAAN_INBOX_<EnvPrefix>_IMAP_PASSWORD / _SMTP_PASSWORD) and Validate's
+// collision guard call it, so they can never diverge. The mangle is many-to-one,
+// which is why Validate rejects names that collide on it.
+func EnvPrefix(name string) string {
+	var b strings.Builder
+	b.Grow(len(name))
+	for _, r := range strings.ToUpper(name) {
+		if (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+		} else {
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
 }
 
 // Filter compiles the inbox's filter (ADR 0021/0022): from the filter_file path

--- a/internal/inboxcfg/inboxcfg_test.go
+++ b/internal/inboxcfg/inboxcfg_test.go
@@ -14,6 +14,30 @@ import (
 	"github.com/yaad-index/darbaan/internal/inboxcfg"
 )
 
+func TestEnvPrefix(t *testing.T) {
+	cases := map[string]string{
+		"work":     "WORK",
+		"Work":     "WORK", // case-folded
+		"personal": "PERSONAL",
+		"team-1":   "TEAM_1", // hyphen → _
+		"team.1":   "TEAM_1", // dot → _ (collides with team-1; Validate rejects)
+		"a b":      "A_B",    // space → _
+		"café":     "CAF_",   // non-ASCII rune → _
+		"default":  "DEFAULT",
+		"":         "",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, inboxcfg.EnvPrefix(in), in)
+	}
+}
+
+func TestValidateEnvPrefixCollision(t *testing.T) {
+	// Distinct names that mangle to the same env prefix are rejected (get-it-right-once).
+	require.Error(t, inboxcfg.Validate([]inboxcfg.Inbox{{Name: "work-1"}, {Name: "work.1"}}))
+	// Distinct prefixes are fine.
+	require.NoError(t, inboxcfg.Validate([]inboxcfg.Inbox{{Name: "work"}, {Name: "personal"}}))
+}
+
 func TestInboxFilterFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "f.yaml")
 	require.NoError(t, os.WriteFile(path,


### PR DESCRIPTION
Multi-inbox slice 3c-i of 5 (ADR 0023) — the per-inbox secret-env mangle + collision guard. Split out of 3c so the "get it right once" env binding lands as its own small, well-tested unit before the N-syncers wiring uses it.

## What
- `inboxcfg.EnvPrefix(name) string`: the single canonical mangle for per-inbox secret env vars — uppercased, every rune outside `[A-Z0-9]` → `_` (e.g. `work` → `WORK`, `team-1` → `TEAM_1`). One source of truth: the runtime secret lookup (`DARBAAN_INBOX_<EnvPrefix>_IMAP_PASSWORD` / `_SMTP_PASSWORD`, lands with the N-syncers wiring) and the load-time collision guard both call it, so they can't diverge.
- `Validate` now rejects a config whose inbox names collide on `EnvPrefix` (the mangle is many-to-one, so distinct names like `work-1` / `work.1` would silently share secrets) — fail-fast at load.

## Tests
Mangle table (case-fold, space, hyphen, dot, non-ASCII, `default`, empty) + the collision-pair rejection. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Next: 3c-ii (N syncers built from inbox backends, per-inbox secret lookup via EnvPrefix with legacy fallback for the default inbox, content-fetch/keyword dispatch, N poll loops) + held-list aggregation. Builds on 1/2a/2b/3a/3b (merged).
