### PR TITLE
feat(admin): aggregate held-list across inboxes (ADR 0023, 3c-iii)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -549,7 +549,6 @@ func (*ServeCmd) Run(cli *CLI) error {
 		}
 		filters[in.Name] = f
 	}
-	flt := filters[inbound.DefaultInbox]
 
 	// One inbound syncer per inbox with an upstream (ADR 0019/0023), built before
 	// the read face so per-inbox FetchContent serves pending bodies on demand. An
@@ -573,7 +572,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// The admin hold-for-human queue and the read face share one filter + owner +
 	// guard (ADR 0021/0024): the read face hides held/spoof mail, the admin surface
 	// decides it.
-	svc.SetInboundHolds(flt, cli.AgentUsername, guard, holdSpoof)
+	svc.SetInboundHolds(filters, cli.AgentUsername, guard, holdSpoof)
 	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -95,7 +95,7 @@ func TestHoldsRoundtrip(t *testing.T) {
 	svc := admin.NewService(q, inbox, fakeSender{nil}, testSigner(t), strictRouter(), "darbaan.test")
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(flt, "agent", nil, false)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, "agent", nil, false)
 	_, held, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "review me", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
 	require.NoError(t, err)
 

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/yaad-index/darbaan/internal/approver"
@@ -36,10 +37,10 @@ type Service struct {
 	signer    Signer
 	router    *policy.Router
 	domain    string
-	filter    *filter.Filter     // inbound filter, for the hold-for-human queue (ADR 0021)
-	owner     string             // the agent whose inbound mailbox the holds belong to
-	guard     *bounceguard.Guard // inbound bounce-spoof guard (ADR 0024; nil = off)
-	holdSpoof bool               // on_spoof=hold-for-human → spoofs join the held queue
+	filters   map[string]*filter.Filter // per-inbox filter for the hold-for-human queue (ADR 0021/0023)
+	owner     string                    // the agent whose inbound mailbox the holds belong to
+	guard     *bounceguard.Guard        // inbound bounce-spoof guard (ADR 0024; nil = off)
+	holdSpoof bool                      // on_spoof=hold-for-human → spoofs join the held queue
 }
 
 // NewService wires the approval service. inbox and signer may be nil only when
@@ -49,42 +50,59 @@ func NewService(store sluice.MessageStore, inbox inbound.InboundStore, sender ba
 	return &Service{store: store, inbox: inbox, sender: sender, signer: signer, router: router, domain: domain}
 }
 
-// SetInboundHolds wires the inbound hold-for-human queue (ADR 0021): the filter
-// that decides which synced messages are held, the agent (owner) they belong to,
-// and the bounce-spoof guard (ADR 0024). When the guard is set with holdSpoof,
-// spoof candidates also join the held queue. Without it, HeldList is empty.
-func (s *Service) SetInboundHolds(flt *filter.Filter, owner string, guard *bounceguard.Guard, holdSpoof bool) {
-	s.filter, s.owner, s.guard, s.holdSpoof = flt, owner, guard, holdSpoof
+// SetInboundHolds wires the inbound hold-for-human queue (ADR 0021/0023): the
+// per-inbox filters that decide which synced messages are held, the agent (owner)
+// they belong to, and the bounce-spoof guard (ADR 0024). When the guard is set
+// with holdSpoof, spoof candidates also join the held queue. Without filters,
+// HeldList is empty.
+func (s *Service) SetInboundHolds(filters map[string]*filter.Filter, owner string, guard *bounceguard.Guard, holdSpoof bool) {
+	s.filters, s.owner, s.guard, s.holdSpoof = filters, owner, guard, holdSpoof
 }
 
 // HeldList returns the inbound messages held for a human decision with no
 // decision yet — a hold-rule match (ADR 0021) or, under on_spoof=hold-for-human,
-// a bounce-spoof candidate (ADR 0024). The inbound mirror of the outbound List.
+// a bounce-spoof candidate (ADR 0024) — aggregated across every inbox (ADR 0023),
+// each evaluated by its own filter. The inbound mirror of the outbound List.
 func (s *Service) HeldList() ([]inbound.Message, error) {
 	if s.inbox == nil {
 		return nil, nil
 	}
-	msgs, err := s.inbox.List(s.owner, inbound.DefaultInbox)
-	if err != nil {
-		return nil, err
-	}
 	now := time.Now()
 	var held []inbound.Message
-	for _, m := range msgs {
-		if m.HoldDecision != "" {
-			continue // already decided
+	for _, inbox := range s.inboxNames() {
+		msgs, err := s.inbox.List(s.owner, inbox)
+		if err != nil {
+			return nil, err
 		}
-		if s.filter.Decide(m, now) == filter.Hold || s.guardHoldsSpoof(m) {
-			held = append(held, m)
+		flt := s.filters[inbox]
+		for _, m := range msgs {
+			if m.HoldDecision != "" {
+				continue // already decided
+			}
+			if (flt != nil && flt.Decide(m, now) == filter.Hold) || s.guardHoldsSpoof(m, inbox) {
+				held = append(held, m)
+			}
 		}
 	}
 	return held, nil
 }
 
-// guardHoldsSpoof reports whether m is a bounce-spoof candidate routed to the
-// held queue (on_spoof=hold-for-human, ADR 0024). False when the guard is off or
-// on_spoof=hide (hidden spoofs aren't a human-decision queue item).
-func (s *Service) guardHoldsSpoof(m inbound.Message) bool {
+// inboxNames returns the configured inbox names in stable order (the held queue is
+// aggregated deterministically across inboxes).
+func (s *Service) inboxNames() []string {
+	names := make([]string, 0, len(s.filters))
+	for inbox := range s.filters {
+		names = append(names, inbox)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// guardHoldsSpoof reports whether m (in the given inbox) is a bounce-spoof
+// candidate routed to the held queue (on_spoof=hold-for-human, ADR 0024). False
+// when the guard is off or on_spoof=hide (hidden spoofs aren't a human-decision
+// queue item).
+func (s *Service) guardHoldsSpoof(m inbound.Message, inbox string) bool {
 	if s.guard == nil || !s.holdSpoof {
 		return false
 	}
@@ -93,7 +111,7 @@ func (s *Service) guardHoldsSpoof(m inbound.Message) bool {
 	// the two stay consistent. The error rides along with spoof=true; the read
 	// face logs it.
 	spoof, _ := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
-		fm, e := s.inbox.Get(s.owner, inbound.DefaultInbox, m.ID)
+		fm, e := s.inbox.Get(s.owner, inbox, m.ID)
 		return fm.Raw, e
 	})
 	return spoof
@@ -114,12 +132,29 @@ func envelopeFromLocals(m inbound.Message) []string {
 
 // ExposeHeld approves a held message for the agent to see (ADR 0021).
 func (s *Service) ExposeHeld(id string) (inbound.Message, error) {
-	return s.inbox.SetHoldDecision(s.owner, inbound.DefaultInbox, id, inbound.HoldApproved)
+	return s.setHold(id, inbound.HoldApproved)
 }
 
 // DropHeld rejects a held message — it stays hidden from the agent (ADR 0021).
 func (s *Service) DropHeld(id string) (inbound.Message, error) {
-	return s.inbox.SetHoldDecision(s.owner, inbound.DefaultInbox, id, inbound.HoldRejected)
+	return s.setHold(id, inbound.HoldRejected)
+}
+
+// setHold applies a hold decision to the message with this (store-wide unique) id,
+// resolving which inbox holds it (ADR 0023): the id is unique across the store, so
+// at most one inbox's (owner,inbox)-scoped record matches and the rest return
+// ErrNotFound. Returns ErrNotFound if no inbox holds it.
+func (s *Service) setHold(id, decision string) (inbound.Message, error) {
+	for _, inbox := range s.inboxNames() {
+		m, err := s.inbox.SetHoldDecision(s.owner, inbox, id, decision)
+		if err == nil {
+			return m, nil
+		}
+		if !errors.Is(err, inbound.ErrNotFound) {
+			return inbound.Message{}, err
+		}
+	}
+	return inbound.Message{}, inbound.ErrNotFound
 }
 
 // Outcome is the result of an approve/reject action. Status is the committed

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -224,7 +224,7 @@ func TestInboundHoldQueue(t *testing.T) {
 	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(flt, "agent", nil, false)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, "agent", nil, false)
 
 	_, _, err = inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1}) // allowed
 	require.NoError(t, err)
@@ -253,6 +253,44 @@ func TestInboundHoldQueue(t *testing.T) {
 	assert.Empty(t, list)
 }
 
+// The held queue aggregates across inboxes (ADR 0023), each evaluated by its own
+// filter; expose/drop resolves the inbox from the store-wide-unique id.
+func TestInboundHoldQueueMultiInbox(t *testing.T) {
+	q, _ := seedStore(t)
+	inbox := newInbound(t)
+	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	hold, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
+	require.NoError(t, err)
+	svc.SetInboundHolds(map[string]*filter.Filter{"work": hold, "personal": hold}, "agent", nil, false)
+
+	_, workHeld, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Inbox: "work", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+	_, persHeld, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Inbox: "personal", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+	// Same upstream coords but different inbox → distinct records (ADR 0023).
+	require.NotEqual(t, workHeld.ID, persHeld.ID)
+	// An allowed message in work (no hold label) is not held.
+	_, _, err = inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Inbox: "work", UpstreamUID: 2, UIDValidity: 1})
+	require.NoError(t, err)
+
+	list, err := svc.HeldList()
+	require.NoError(t, err)
+	require.Len(t, list, 2) // aggregated across both inboxes
+
+	// ExposeHeld resolves the personal inbox from the id; work's hold remains.
+	_, err = svc.ExposeHeld(persHeld.ID)
+	require.NoError(t, err)
+	list, err = svc.HeldList()
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.Equal(t, workHeld.ID, list[0].ID)
+	assert.Equal(t, "work", list[0].Inbox)
+
+	// An unknown id resolves to no inbox.
+	_, err = svc.ExposeHeld("99999")
+	require.ErrorIs(t, err, inbound.ErrNotFound)
+}
+
 // Under on_spoof=hold-for-human, a bounce-spoof candidate joins the held queue
 // (ADR 0024) alongside filter holds; ordinary mail does not.
 func TestInboundBounceGuardHold(t *testing.T) {
@@ -263,7 +301,7 @@ func TestInboundBounceGuardHold(t *testing.T) {
 	require.NoError(t, err)
 	// Verifier says "no valid Darbaan signature" → a bounce-shaped message is a spoof.
 	guard := bounceguard.New(func([]byte) (bool, error) { return false, nil })
-	svc.SetInboundHolds(passthrough, "agent", guard, true /* hold-for-human */)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: passthrough}, "agent", guard, true /* hold-for-human */)
 
 	// A bounce-shaped message from MAILER-DAEMON (envelope From hits the precheck;
 	// the stored raw is bounce-shaped) → spoof → held.


### PR DESCRIPTION
Multi-inbox slice 3c-iii of 5 (ADR 0023) — admin held-list aggregation across inboxes. The last inbound N>1 follow-up (noted in 3b/3c-ii).

## What
- `HeldList` now spans every configured inbox: it iterates the inboxes and evaluates each message with its own per-inbox filter (plus the shared bounce guard), so the operator sees holds from all inboxes in one queue, in stable inbox order.
- `SetInboundHolds` takes the per-inbox filter map instead of a single filter.
- Expose/drop resolve the inbox from the message id: the store id is unique store-wide, so `setHold` tries each inbox's `(owner,inbox)`-scoped `SetHoldDecision` and the single match wins (the rest return `ErrNotFound`). **The HTTP `/{id}/expose|drop` and Telegram callers are unchanged** — no API ripple.

## N=1 unchanged
One inbox (default) → the queue and expose/drop behave exactly as before.

## Cross-package
admin (held-list + expose/drop) + cmd (passes the filter map to `SetInboundHolds`).

## Tests
New `TestInboundHoldQueueMultiInbox`: holds in two inboxes aggregate into one queue; same upstream coords in different inboxes are distinct records; expose resolves the right inbox by id and leaves the other inbox's hold; an unknown id → `ErrNotFound`. All existing admin tests pass. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

With this, the **inbound multi-inbox path is complete** (config → per-inbox store/sync → N-mailbox read face → N syncers w/ per-inbox secrets → aggregated held queue). Next: 4 (outbound From→inbox routing) → 5 (gate Change-sender). Builds on 1/2a/2b/3a/3b/3c-i/3c-ii (merged).
