### PR TITLE
feat(outbound): route submission From→inbox + reject unmatched (ADR 0023, 4a/5)

### DIFF
--- a/adr/0023-multi-inbox.md
+++ b/adr/0023-multi-inbox.md
@@ -64,10 +64,13 @@ via **that inbox's backend**. The match is on the **RFC 5321 address-portion**
 display name or address casing never changes which inbox is selected. A reply
 defaults to the identity of the inbox that **received** the original
 (Darbaan knows which mailbox a held/synced message belongs to), so "reply" stays on
-the right account without the agent having to restate it. A From that matches no
-configured identity is **rejected at submit** (fail-closed, ADR 0003 spirit) rather
-than silently sent from a default — sending as the wrong account is the failure mode
-to prevent.
+the right account without the agent having to restate it. A submit From whose
+address matches a configured inbox `identity` routes to that inbox; otherwise, if a
+`default` inbox exists it routes there (**catch-all**, From **not rewritten** —
+preserves N=1/legacy behavior); otherwise it is **rejected at submit** (fail-closed,
+ADR 0003 spirit). So N=1 (the implicit `default`) accepts any From byte-for-byte,
+and a multi-inbox config with no `default` rejects an unmatched From — sending as
+the wrong account is the failure mode to prevent.
 
 ### Sender override at the approval gate (Change)
 
@@ -123,8 +126,10 @@ what turns on multi-inbox.
   future multi-agent split but cost credential multiplication now.
 - **Mailbox naming:** flat (`work`, `personal`) vs nested under `INBOX/`. Leaning
   flat top-level mailboxes; minor, settle in implementation.
-- **Unmatched-From on submit:** reject (chosen) vs route to a configured default
-  inbox. Reject is safer; revisit if it proves annoying in practice.
+- **Unmatched-From on submit:** resolved to matched-identity → that inbox, else a
+  configured `default` inbox as catch-all (From not rewritten), else reject. This
+  keeps N=1 byte-for-byte (the implicit `default` is the catch-all) while a
+  multi-inbox config with no `default` still rejects unmatched-From.
 
 ## Follow-ups
 

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -522,17 +522,6 @@ func (*ServeCmd) Run(cli *CLI) error {
 		return err
 	}
 
-	// One local service hosts both agent faces (ADR 0001): SMTP submission
-	// (outbound trap) and IMAP read (the agent reads its bounces).
-	smtpSrv, err := listener.NewServer(listener.ServerConfig{
-		Addr:          cli.ListenerAddr,
-		Domain:        cli.ListenerDomain,
-		TLSConfig:     tlsConfig,
-		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, q)
-	if err != nil {
-		return err
-	}
 	// Resolve the configured inboxes (ADR 0023): a config with no inboxes: is one
 	// implicit "default" inbox built from the legacy top-level flags, so a
 	// single-inbox deployment is unchanged. Each inbox's filter is compiled up
@@ -548,6 +537,23 @@ func (*ServeCmd) Run(cli *CLI) error {
 			return fmt.Errorf("inbox %q: %w", in.Name, ferr)
 		}
 		filters[in.Name] = f
+	}
+
+	// One local service hosts both agent faces (ADR 0001): SMTP submission
+	// (outbound trap) and IMAP read (the agent reads its bounces). The submission
+	// face routes each From to an inbox (ADR 0023): matched Identity → that inbox,
+	// else the default catch-all, else refused at MAIL FROM.
+	route := func(from string) (string, bool) {
+		return inboxcfg.Route(inboxes, from, inbound.DefaultInbox)
+	}
+	smtpSrv, err := listener.NewServer(listener.ServerConfig{
+		Addr:          cli.ListenerAddr,
+		Domain:        cli.ListenerDomain,
+		TLSConfig:     tlsConfig,
+		AllowInsecure: cli.ListenerAllowInsecure,
+	}, cred, q, route)
+	if err != nil {
+		return err
 	}
 
 	// One inbound syncer per inbox with an upstream (ADR 0019/0023), built before

--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -128,6 +128,29 @@ func EnvPrefix(name string) string {
 	return b.String()
 }
 
+// Route resolves which inbox an outbound submission's From belongs to (ADR 0023):
+// the inbox whose Identity equals from (exact RFC5321 address match, case-
+// insensitive); else the inbox named defaultName if one is configured (catch-all,
+// From not rewritten — preserves N=1/legacy behavior); else ("", false), which the
+// caller rejects at submit. So N=1 (an implicit default) accepts any From, and a
+// multi-inbox config with no default rejects an unmatched From.
+func Route(inboxes []Inbox, from, defaultName string) (string, bool) {
+	want := strings.ToLower(strings.TrimSpace(from))
+	hasDefault := false
+	for _, in := range inboxes {
+		if in.Name == defaultName {
+			hasDefault = true
+		}
+		if id := strings.ToLower(strings.TrimSpace(in.Identity)); id != "" && id == want {
+			return in.Name, true
+		}
+	}
+	if hasDefault {
+		return defaultName, true
+	}
+	return "", false
+}
+
 // Filter compiles the inbox's filter (ADR 0021/0022): from the filter_file path
 // if set, else from the inline {default_visibility, rules}. The two are mutually
 // exclusive — both set is a config error. An inbox with neither yields a

--- a/internal/inboxcfg/inboxcfg_test.go
+++ b/internal/inboxcfg/inboxcfg_test.go
@@ -38,6 +38,32 @@ func TestValidateEnvPrefixCollision(t *testing.T) {
 	require.NoError(t, inboxcfg.Validate([]inboxcfg.Inbox{{Name: "work"}, {Name: "personal"}}))
 }
 
+func TestRoute(t *testing.T) {
+	inboxes := []inboxcfg.Inbox{
+		{Name: "work", Identity: "agent@company.example"},
+		{Name: "personal", Identity: "me@personal.example"},
+		{Name: "default", Identity: "agent@darbaan.example"},
+	}
+	mustRoute := func(from, want string) {
+		t.Helper()
+		got, ok := inboxcfg.Route(inboxes, from, "default")
+		require.True(t, ok, from)
+		assert.Equal(t, want, got, from)
+	}
+	mustRoute("agent@company.example", "work")     // exact identity match
+	mustRoute("ME@Personal.Example", "personal")   // case-insensitive
+	mustRoute("agent@darbaan.example", "default")  // matches the default's own identity
+	mustRoute("random@nowhere.example", "default") // unmatched → default catch-all
+
+	// No "default" inbox configured → an unmatched From is rejected.
+	noDefault := []inboxcfg.Inbox{{Name: "work", Identity: "agent@company.example"}}
+	_, ok := inboxcfg.Route(noDefault, "random@nowhere.example", "default")
+	assert.False(t, ok)
+	got, ok := inboxcfg.Route(noDefault, "agent@company.example", "default") // matched still routes
+	require.True(t, ok)
+	assert.Equal(t, "work", got)
+}
+
 func TestInboxFilterFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "f.yaml")
 	require.NoError(t, os.WriteFile(path,

--- a/internal/listener/smtp.go
+++ b/internal/listener/smtp.go
@@ -29,16 +29,32 @@ type Enqueuer interface {
 	Enqueue(sluice.Submission) (sluice.Message, error)
 }
 
+// Router resolves which inbox an authenticated submission's From routes to (ADR
+// 0023), reporting false when the From matches no inbox and there is no default —
+// the submission is then refused at MAIL FROM. nil routes every From to the
+// default inbox (single-inbox / back-compat).
+type Router func(from string) (inbox string, ok bool)
+
 // Backend is the go-smtp backend for the submission face.
 type Backend struct {
 	cred  Credential
 	queue Enqueuer
+	route Router
 }
 
-// NewBackend builds a Backend that authenticates against cred and traps every
-// accepted submission into queue.
-func NewBackend(cred Credential, queue Enqueuer) *Backend {
-	return &Backend{cred: cred, queue: queue}
+// NewBackend builds a Backend that authenticates against cred, routes each
+// submission's From to an inbox via route (nil = always the default inbox), and
+// traps every accepted submission into queue.
+func NewBackend(cred Credential, queue Enqueuer, route Router) *Backend {
+	return &Backend{cred: cred, queue: queue, route: route}
+}
+
+// resolveInbox routes a From to its inbox (ADR 0023); ok=false means refuse.
+func (b *Backend) resolveInbox(from string) (string, bool) {
+	if b.route == nil {
+		return "", true // back-compat: any From → default inbox
+	}
+	return b.route(from)
 }
 
 // NewSession starts a new SMTP session.
@@ -51,6 +67,7 @@ type session struct {
 	backend *Backend
 	authed  bool
 	from    string
+	inbox   string // the inbox From routed to (ADR 0023)
 	rcpt    []string
 }
 
@@ -74,7 +91,18 @@ func (s *session) Mail(from string, _ *smtp.MailOptions) error {
 	if !s.authed {
 		return smtp.ErrAuthRequired
 	}
+	// Route the From to an inbox (ADR 0023); refuse a From that matches no inbox
+	// and has no default catch-all, fail-fast at MAIL FROM.
+	inbox, ok := s.backend.resolveInbox(from)
+	if !ok {
+		return &smtp.SMTPError{
+			Code:         550,
+			EnhancedCode: smtp.EnhancedCode{5, 7, 1},
+			Message:      "sender address is not configured for any inbox",
+		}
+	}
 	s.from = from
+	s.inbox = inbox
 	return nil
 }
 
@@ -99,6 +127,7 @@ func (s *session) Data(r io.Reader) error {
 	}
 	if _, err := s.backend.queue.Enqueue(sluice.Submission{
 		Agent: s.backend.cred.Username,
+		Inbox: s.inbox,
 		From:  s.from,
 		Rcpt:  s.rcpt,
 		Raw:   raw,
@@ -110,6 +139,7 @@ func (s *session) Data(r io.Reader) error {
 
 func (s *session) Reset() {
 	s.from = ""
+	s.inbox = ""
 	s.rcpt = nil
 }
 
@@ -136,12 +166,13 @@ type Server struct {
 
 // NewServer wires the submission face. TLS is required: NewServer refuses to
 // start a plaintext listener that would carry credentials in the clear unless
-// AllowInsecure is explicitly set (local/testing).
-func NewServer(cfg ServerConfig, cred Credential, queue Enqueuer) (*Server, error) {
+// AllowInsecure is explicitly set (local/testing). route maps each submission's
+// From to an inbox (ADR 0023; nil = always the default inbox).
+func NewServer(cfg ServerConfig, cred Credential, queue Enqueuer, route Router) (*Server, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
-	srv := smtp.NewServer(NewBackend(cred, queue))
+	srv := smtp.NewServer(NewBackend(cred, queue, route))
 	srv.Addr = cfg.Addr
 	srv.Domain = cfg.Domain
 	srv.TLSConfig = cfg.TLSConfig

--- a/internal/listener/smtp_test.go
+++ b/internal/listener/smtp_test.go
@@ -42,7 +42,18 @@ func startServer(t *testing.T, cfg listener.ServerConfig, q listener.Enqueuer) s
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	srv, err := listener.NewServer(cfg, testCred, q)
+	srv, err := listener.NewServer(cfg, testCred, q, nil)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+func startServerRoute(t *testing.T, cfg listener.ServerConfig, q listener.Enqueuer, route listener.Router) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewServer(cfg, testCred, q, route)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -100,6 +111,43 @@ func TestSubmitOverTLSEnqueuesOnePending(t *testing.T) {
 	assert.Equal(t, []string{"dest@example.test"}, full.Rcpt)
 }
 
+// ADR 0023: the submission face routes From to an inbox — a matched From stamps
+// the inbox on the queued message; an unmatched From with no default is refused
+// at MAIL FROM.
+func TestSubmitRoutesFromToInbox(t *testing.T) {
+	q := newSluice(t)
+	route := func(from string) (string, bool) {
+		if from == "work@company.test" {
+			return "work", true
+		}
+		return "", false // unmatched, no default → refuse
+	}
+	addr := startServerRoute(t, listener.ServerConfig{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{selfSigned(t)}},
+	}, q, route)
+
+	c, err := smtp.DialStartTLS(addr, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Auth(sasl.NewPlainClient("", testCred.Username, testCred.Password)))
+
+	// Matched From → the routed inbox is stamped on the queued message.
+	const raw = "From: work@company.test\r\nTo: d@x.test\r\nSubject: s\r\n\r\nbody\r\n"
+	require.NoError(t, c.SendMail("work@company.test", []string{"d@x.test"}, strings.NewReader(raw)))
+	metas, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	full, err := q.Get(metas[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, "work", full.Inbox)
+
+	// Unmatched From with no default → refused at MAIL FROM (nothing else queued).
+	require.Error(t, c.Mail("stranger@elsewhere.test", nil))
+	metas, err = q.List()
+	require.NoError(t, err)
+	assert.Len(t, metas, 1)
+}
+
 func TestPlaintextRequiresAuth(t *testing.T) {
 	q := newSluice(t)
 	addr := startServer(t, listener.ServerConfig{AllowInsecure: true}, q)
@@ -129,9 +177,9 @@ func TestBadCredentialRejected(t *testing.T) {
 
 func TestNewServerRequiresTLS(t *testing.T) {
 	q := newSluice(t)
-	_, err := listener.NewServer(listener.ServerConfig{}, testCred, q)
+	_, err := listener.NewServer(listener.ServerConfig{}, testCred, q, nil)
 	require.Error(t, err)
 
-	_, err = listener.NewServer(listener.ServerConfig{AllowInsecure: true}, testCred, q)
+	_, err = listener.NewServer(listener.ServerConfig{AllowInsecure: true}, testCred, q, nil)
 	require.NoError(t, err)
 }

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -129,6 +129,7 @@ func (s *bboltStore) Enqueue(sub Submission) (Message, error) {
 		msg = Message{
 			ID:         strconv.FormatUint(seq, 10),
 			Agent:      sub.Agent,
+			Inbox:      sub.Inbox,
 			From:       sub.From,
 			Rcpt:       append([]string(nil), sub.Rcpt...),
 			Raw:        sub.Raw,

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -42,6 +42,7 @@ const (
 // Submission is a new outbound message to trap, as captured from the SMTP face.
 type Submission struct {
 	Agent string   // authenticated agent identity (ADR 0002)
+	Inbox string   // the inbox the From routed to (ADR 0023); "" = default
 	From  string   // envelope MAIL FROM
 	Rcpt  []string // envelope RCPT TO
 	Raw   []byte   // raw message/rfc822
@@ -51,6 +52,7 @@ type Submission struct {
 type Message struct {
 	ID         string    `json:"id"`
 	Agent      string    `json:"agent"`
+	Inbox      string    `json:"inbox,omitempty"` // routed inbox (ADR 0023); "" reads as default
 	From       string    `json:"from"`
 	Rcpt       []string  `json:"rcpt"`
 	Raw        []byte    `json:"raw"`


### PR DESCRIPTION
Multi-inbox slice 4a of 5 (ADR 0023) — outbound From→inbox routing at submission. First outbound slice.

## What
- `inboxcfg.Route(inboxes, from, defaultName)`: a From whose address matches a configured inbox `Identity` (exact RFC5321 address, case-insensitive) → that inbox; else, if a `default` inbox exists → that inbox (catch-all, From **not** rewritten); else `("", false)` → reject.
- SMTP submission face: resolves+validates the From at **MAIL FROM** (refuses a truly-unmatched From with no default: `550 5.7.1`), and **stamps the resolved inbox** on the sluice message so the post-approval send (4b) picks that inbox's backend.
- Sluice `Submission`/`Message` gain an `Inbox` field (empty reads as default, like the inbound store).

## N=1 byte-for-byte
The implicit default inbox is the catch-all, so any From is accepted exactly as today. (cmd passes a route closure over the resolved inboxes; a `nil` route also means default-everything for back-compat.)

## Doc (per the review note)
Folds the ADR 0023 outbound-section update into this PR (the doc change belongs with the impl that motivates it): the old "unmatched → reject" line becomes matched→inbox / default-catch-all / else-reject, plus the alternatives-considered entry.

## Gate note
This PR touches `adr/0023-multi-inbox.md` (the directed doc fold-in) → please confirm the gate: today's 2-of-N, or operator hard-gate for the `adr/` touch. Holding the merge for that call.

## Cross-package
inboxcfg (Route) + sluice (Inbox field) + listener/smtp (Router + reject + stamp) + cmd (route closure) + adr/ (doc).

## Tests
`inboxcfg.Route` table (exact match, case-insensitive, default's-own-identity, catch-all, no-default reject, matched-without-default). SMTP `TestSubmitRoutesFromToInbox`: matched From stamps the inbox; unmatched-no-default refused at MAIL FROM. All existing tests pass. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

Next: 4b (per-inbox Senders + send-path dispatch by the stamped inbox). Builds on the merged inbound slices + 3a resolution.
