### PR TITLE
feat(outbound): per-inbox senders + send dispatch by inbox (ADR 0023, 4b/5)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -235,6 +235,43 @@ func inboxIMAPPassword(name string) string {
 	return ""
 }
 
+// inboxSMTPPassword resolves an inbox's upstream SMTP password (ADR 0012/0023):
+// the per-inbox env DARBAAN_INBOX_<EnvPrefix>_SMTP_PASSWORD, falling back to the
+// legacy DARBAAN_SMTP_PASSWORD for the implicit default inbox.
+func inboxSMTPPassword(name string) string {
+	if v := os.Getenv("DARBAAN_INBOX_" + inboxcfg.EnvPrefix(name) + "_SMTP_PASSWORD"); v != "" {
+		return v
+	}
+	if name == inbound.DefaultInbox {
+		return os.Getenv("DARBAAN_SMTP_PASSWORD")
+	}
+	return ""
+}
+
+// newSenders builds one upstream Sender per configured inbox (ADR 0023), keyed by
+// inbox name, from each inbox's backend coords + per-inbox SMTP secret. An inbox
+// with no sender_type uses the stub (default-deny holds, ADR 0003). At N=1 the
+// implicit default carries the legacy SMTP flags, so its sender is unchanged.
+func (cli *CLI) newSenders(inboxes []inboxcfg.Inbox) (map[string]backend.Sender, error) {
+	senders := make(map[string]backend.Sender, len(inboxes))
+	for _, in := range inboxes {
+		st := in.Backend.SenderType
+		if st == "" {
+			st = "stub"
+		}
+		snd, err := backend.New(st, backend.Config{
+			Host:     in.Backend.SMTPHost,
+			Username: in.Backend.SMTPUsername,
+			Password: inboxSMTPPassword(in.Name),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("inbox %q sender: %w", in.Name, err)
+		}
+		senders[in.Name] = snd
+	}
+	return senders, nil
+}
+
 // newSyncers builds one inbound sync engine per configured inbox that has an
 // upstream IMAP backend (ADR 0019/0023), keyed by inbox name; inboxes with no
 // backend host are skipped (no sync). The syncers share one sync-state store
@@ -538,6 +575,15 @@ func (*ServeCmd) Run(cli *CLI) error {
 		}
 		filters[in.Name] = f
 	}
+
+	// One upstream sender per inbox (ADR 0023): an approved message is delivered
+	// via the sender of the inbox it was submitted as. At N=1 this is the legacy
+	// sender under the default inbox.
+	senders, err := cli.newSenders(inboxes)
+	if err != nil {
+		return err
+	}
+	svc.SetSenders(senders)
 
 	// One local service hosts both agent faces (ADR 0001): SMTP submission
 	// (outbound trap) and IMAP read (the agent reads its bounces). The submission

--- a/cmd/darbaan/sync_test.go
+++ b/cmd/darbaan/sync_test.go
@@ -35,6 +35,29 @@ func TestInboxIMAPPassword(t *testing.T) {
 	assert.Empty(t, inboxIMAPPassword("nopass"))                       // non-default, no env → empty
 }
 
+func TestInboxSMTPPassword(t *testing.T) {
+	t.Setenv("DARBAAN_INBOX_WORK_SMTP_PASSWORD", "wpass")
+	t.Setenv("DARBAAN_SMTP_PASSWORD", "legacy")
+	assert.Equal(t, "wpass", inboxSMTPPassword("work"))                // per-inbox env
+	assert.Equal(t, "legacy", inboxSMTPPassword(inbound.DefaultInbox)) // default → legacy fallback
+	assert.Empty(t, inboxSMTPPassword("nopass"))                       // non-default, no env → empty
+}
+
+func TestNewSendersPerInbox(t *testing.T) {
+	cli := &CLI{}
+	inboxes := []inboxcfg.Inbox{
+		{Name: inbound.DefaultInbox, Backend: inboxcfg.Backend{SenderType: "stub"}},
+		{Name: "work", Backend: inboxcfg.Backend{SenderType: "stub"}},
+		{Name: "no-type"}, // no sender_type → stub (default-deny)
+	}
+	senders, err := cli.newSenders(inboxes)
+	require.NoError(t, err)
+	require.Len(t, senders, 3)
+	require.NotNil(t, senders["work"])
+	require.NotNil(t, senders[inbound.DefaultInbox])
+	require.NotNil(t, senders["no-type"])
+}
+
 // Inbound sync is off by default: with no inbox carrying an upstream host,
 // newSyncers returns an empty map (no state store opened) and a no-op stop, and
 // never errors. An empty map makes imapKeywordWriter nil (local-only labels);

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -33,7 +33,7 @@ type Signer interface {
 type Service struct {
 	store     sluice.MessageStore
 	inbox     inbound.InboundStore
-	sender    backend.Sender
+	senders   map[string]backend.Sender // per-inbox upstream sender (ADR 0023), keyed by inbox name
 	signer    Signer
 	router    *policy.Router
 	domain    string
@@ -47,7 +47,28 @@ type Service struct {
 // the sender can never permanently fail (the stub) and rejection is unused; in
 // serve they are always provided.
 func NewService(store sluice.MessageStore, inbox inbound.InboundStore, sender backend.Sender, signer Signer, router *policy.Router, domain string) *Service {
-	return &Service{store: store, inbox: inbox, sender: sender, signer: signer, router: router, domain: domain}
+	// The single sender becomes the default inbox's; SetSenders installs the
+	// per-inbox map in serve (ADR 0023). Keeps existing callers/tests unchanged.
+	return &Service{store: store, inbox: inbox, senders: map[string]backend.Sender{inbound.DefaultInbox: sender}, signer: signer, router: router, domain: domain}
+}
+
+// SetSenders installs the per-inbox upstream senders (ADR 0023): an approved
+// message is delivered via the sender of the inbox it was submitted as. serve
+// builds one per configured inbox; tests/callers that only need one inbox keep
+// using NewService's single sender.
+func (s *Service) SetSenders(senders map[string]backend.Sender) {
+	if len(senders) > 0 {
+		s.senders = senders
+	}
+}
+
+// senderFor returns the upstream sender for a message's inbox, falling back to the
+// default inbox's sender when the message carries no/unknown inbox (ADR 0023).
+func (s *Service) senderFor(inbox string) backend.Sender {
+	if snd := s.senders[inbound.NormInbox(inbox)]; snd != nil {
+		return snd
+	}
+	return s.senders[inbound.DefaultInbox]
 }
 
 // SetInboundHolds wires the inbound hold-for-human queue (ADR 0021/0023): the
@@ -224,7 +245,7 @@ func (s *Service) ApproveID(ctx context.Context, id string) (Outcome, error) {
 	}
 	out := Outcome{ID: m.ID, Status: string(sluice.StatusApproved), Detail: fmt.Sprintf("approved by %s", m.DecidedBy)}
 
-	sendErr := s.sender.Send(ctx, m)
+	sendErr := s.senderFor(m.Inbox).Send(ctx, m) // deliver via the message's inbox's sender (ADR 0023)
 	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr)
 	if rerr != nil {
 		return Outcome{}, rerr

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -99,6 +99,32 @@ func (failingInbound) Get(string, string, string) (inbound.Message, error) {
 func (failingInbound) SetSeen(string, string, string, bool) error { return nil }
 func (failingInbound) Close() error                               { return nil }
 
+type senderFunc func(sluice.Message) error
+
+func (f senderFunc) Send(_ context.Context, m sluice.Message) error { return f(m) }
+
+// ADR 0023: an approved message is delivered via the sender of the inbox it was
+// submitted as.
+func TestApproveDispatchesToInboxSender(t *testing.T) {
+	q, defID := seedStore(t) // default-inbox message
+	workMsg, err := q.Enqueue(sluice.Submission{Agent: "agent", Inbox: "work", From: "w@x.test", Rcpt: []string{"d@y.test"}, Raw: []byte("w")})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	var workSent, defSent int
+	svc.SetSenders(map[string]backend.Sender{
+		"work":               senderFunc(func(sluice.Message) error { workSent++; return nil }),
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { defSent++; return nil }),
+	})
+
+	_, err = svc.ApproveID(context.Background(), workMsg.ID)
+	require.NoError(t, err)
+	_, err = svc.ApproveID(context.Background(), defID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, workSent, "work message → work sender")
+	assert.Equal(t, 1, defSent, "default message → default sender")
+}
+
 func TestApproveStubHoldsDefaultDeny(t *testing.T) {
 	q, id := seedStore(t)
 	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")


### PR DESCRIPTION
Multi-inbox slice 4b of 5 (ADR 0023) — per-inbox upstream senders + send dispatch. Completes the outbound side.

> Stacked on #137 (4a). Base is the 4a branch; once 4a merges I'll retarget this to main (or it auto-fast-forwards). No adr/ touch here → 2-of-N.

## What
- `newSenders` builds one upstream Sender per configured inbox, from each inbox's backend coords + its own SMTP password (`DARBAAN_INBOX_<EnvPrefix>_SMTP_PASSWORD`, legacy `DARBAAN_SMTP_PASSWORD` fallback for the default). An inbox with no `sender_type` → stub (default-deny holds).
- The admin service holds a per-inbox Sender map (`SetSenders`) and delivers an approved message via the sender of **the inbox it was submitted as** (the inbox stamped in 4a), falling back to the default inbox's sender for an empty/unknown inbox.

## Back-compat
`NewService` still takes a single sender — stored as the default inbox's — so every existing caller/test is unchanged; serve installs the full map via `SetSenders`. N=1 byte-for-byte: the implicit default carries the legacy SMTP flags, so its sender is exactly today's.

## Cross-package
admin (Sender map + dispatch) + cmd (newSenders + inboxSMTPPassword + SetSenders wiring).

## Tests
admin `TestApproveDispatchesToInboxSender` (a work-inbox message → the work sender, a default message → the default sender). cmd `newSenders` per-inbox build + `inboxSMTPPassword` env + legacy fallback. All existing admin/cmd tests pass unchanged. Gate green: build, vet, gofmt, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).

With 4a+4b, **outbound multi-inbox is complete**: From→inbox routing at submit + per-inbox delivery. Next: 5 (Telegram gate Change-sender).
