### PR TITLE
feat(inbound): RemoveSynced — hard-retract a synced message (#140 slice 1)

### DIFF
--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -97,6 +97,7 @@ func (failingInbound) Get(string, string, string) (inbound.Message, error) {
 	return inbound.Message{}, inbound.ErrNotFound
 }
 func (failingInbound) SetSeen(string, string, string, bool) error { return nil }
+func (failingInbound) RemoveSynced(string, string, string) error  { return nil }
 func (failingInbound) Close() error                               { return nil }
 
 type senderFunc func(sluice.Message) error

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -316,6 +316,56 @@ func (s *bboltStore) SetSeen(owner, inbox, id string, seen bool) error {
 	})
 }
 
+// RemoveSynced hard-removes an upstream-synced message (ADR 0026 reconciliation):
+// its metadata record, its dedup-index entry, and its content blob. It refuses a
+// locally-generated record (UpstreamUID == 0, e.g. a signed bounce) — those have
+// no upstream and are never reconciled — and is (owner, inbox)-scoped.
+//
+// The metadata record and the dedup-index entry are removed in one txn; the blob
+// is deleted AFTER the commit. The ordering mirrors the blob-first WRITE path
+// (put/SetContent, ADR 0018) inverted: removing metadata first means a crash
+// before the blob delete only ORPHANS the blob (no record references it), which
+// the startup sweep reclaims — it can never leave a metadata pointer to a missing
+// blob.
+func (s *bboltStore) RemoveSynced(owner, inbox, id string) error {
+	var blobbed bool
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		rec, key, err := loadStored(tx, id)
+		if err != nil {
+			return err
+		}
+		if !recScoped(rec, owner, inbox) {
+			return ErrNotFound // do not retract another owner's/inbox's message
+		}
+		if rec.UpstreamUID == 0 {
+			return fmt.Errorf("refusing to retract locally-generated message %s (no upstream UID)", id)
+		}
+		if err := tx.Bucket(bucketInbound).Delete(key); err != nil {
+			return err
+		}
+		// Clear the dedup index so the message re-syncs cleanly if it returns to the
+		// source later (ADR 0026 re-appearance): a stale index entry would suppress
+		// the re-add as a false duplicate.
+		idxKey := syncedKey(rec.Owner, rec.Inbox, rec.UIDValidity, rec.UpstreamUID)
+		if err := tx.Bucket(bucketSynced).Delete(idxKey); err != nil {
+			return err
+		}
+		blobbed = rec.Blobbed
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("inbound: remove synced %s: %w", id, err)
+	}
+	if blobbed {
+		// Best-effort: a present record's blob. Delete is idempotent (a missing blob
+		// is not an error); a real failure only orphans it for the next sweep.
+		if err := s.blobs.Delete(id); err != nil {
+			log.Printf("darbaan: inbound retract %s: blob delete failed (orphan, will be swept): %v", id, err)
+		}
+	}
+	return nil
+}
+
 // SetKeywords replaces the owner's message's keyword set (ADR 0020) and marks it
 // dirty for upstream reconcile. The local store is canonical; the returned
 // message carries the new keywords (without content). Metadata-only write.

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -168,6 +168,15 @@ type InboundStore interface {
 	// SetSeen sets or clears the \Seen flag on the inbox's message — the only
 	// mutable flag the v1 IMAP face persists. (owner, inbox)-scoped like Get.
 	SetSeen(owner, inbox, id string, seen bool) error
+	// RemoveSynced hard-removes an upstream-synced message — its metadata record,
+	// dedup-index entry, and content blob — so it disappears from the read face
+	// entirely. This is the retraction path for upstream reconciliation (ADR 0026):
+	// the source dropped the message, so Darbaan drops its local copy (the upstream
+	// itself is never touched). It is (owner, inbox)-scoped like Get and **refuses a
+	// locally-generated record** (UpstreamUID == 0, e.g. a signed bounce) — those
+	// have no upstream and are never reconciled. Returns ErrNotFound if the
+	// (owner, inbox) has no such message.
+	RemoveSynced(owner, inbox, id string) error
 	// Close releases the underlying resources.
 	Close() error
 }

--- a/internal/inbound/remove_synced_test.go
+++ b/internal/inbound/remove_synced_test.go
@@ -1,0 +1,98 @@
+package inbound_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// RemoveSynced hard-removes a synced message: it vanishes from the read face, and
+// its dedup-index entry is cleared so the same upstream (UIDVALIDITY, UID) can
+// re-sync cleanly if it returns to the source (ADR 0026 re-appearance).
+func TestRemoveSyncedHardRemoves(t *testing.T) {
+	s := newStore(t)
+
+	_, m, err := s.AddSynced(inbound.Delivery{
+		Owner: "agent", Inbox: "work", UpstreamUID: 5, UIDValidity: 1,
+		Raw: []byte("From: a@x\r\n\r\nbody"),
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.RemoveSynced("agent", "work", m.ID))
+
+	_, err = s.Get("agent", "work", m.ID)
+	assert.ErrorIs(t, err, inbound.ErrNotFound, "removed message is gone from the read face")
+
+	list, err := s.List("agent", "work")
+	require.NoError(t, err)
+	assert.Empty(t, list, "removed message is gone from the listing")
+
+	// Re-add the same (UIDVALIDITY, UID): added=true proves the dedup index entry
+	// was cleared (a stale entry would suppress the re-add as a false duplicate).
+	added, _, err := s.AddSynced(inbound.Delivery{
+		Owner: "agent", Inbox: "work", UpstreamUID: 5, UIDValidity: 1,
+		Raw: []byte("From: a@x\r\n\r\nback"),
+	})
+	require.NoError(t, err)
+	assert.True(t, added, "after retraction the same upstream UID re-syncs as new")
+}
+
+// A pending (headers-only, ADR 0019) synced record has no content blob; removing
+// it must still succeed (no blob to delete) and clear the record.
+func TestRemoveSyncedPending(t *testing.T) {
+	s := newStore(t)
+
+	_, m, err := s.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: "work", UpstreamUID: 9, UIDValidity: 1,
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, s.RemoveSynced("agent", "work", m.ID))
+
+	_, err = s.Get("agent", "work", m.ID)
+	assert.ErrorIs(t, err, inbound.ErrNotFound)
+}
+
+// RemoveSynced refuses a locally-generated record (no upstream UID, e.g. a signed
+// bounce): those are never subject to reconciliation (ADR 0026). The error is NOT
+// ErrNotFound (the record exists), and the record stays readable.
+func TestRemoveSyncedRefusesLocallyGenerated(t *testing.T) {
+	s := newStore(t)
+
+	m, err := s.Add(inbound.Delivery{
+		Owner: "agent", Inbox: "work", From: "MAILER-DAEMON@x", To: "agent@x",
+		Subject: "bounce", Raw: []byte("From: MAILER-DAEMON@x\r\n\r\nbounce"),
+	})
+	require.NoError(t, err)
+
+	err = s.RemoveSynced("agent", "work", m.ID)
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, inbound.ErrNotFound), "refusal is a guard, not a not-found")
+
+	got, err := s.Get("agent", "work", m.ID)
+	require.NoError(t, err, "the locally-generated record is untouched")
+	assert.Equal(t, m.ID, got.ID)
+}
+
+// RemoveSynced is (owner, inbox)-scoped: a wrong owner or inbox is ErrNotFound and
+// leaves the record intact (no cross-tenant retraction).
+func TestRemoveSyncedScoping(t *testing.T) {
+	s := newStore(t)
+
+	_, m, err := s.AddSynced(inbound.Delivery{
+		Owner: "agent", Inbox: "work", UpstreamUID: 3, UIDValidity: 1,
+		Raw: []byte("From: a@x\r\n\r\nb"),
+	})
+	require.NoError(t, err)
+
+	assert.ErrorIs(t, s.RemoveSynced("other", "work", m.ID), inbound.ErrNotFound)
+	assert.ErrorIs(t, s.RemoveSynced("agent", "personal", m.ID), inbound.ErrNotFound)
+	assert.ErrorIs(t, s.RemoveSynced("agent", "work", "404"), inbound.ErrNotFound)
+
+	_, err = s.Get("agent", "work", m.ID)
+	require.NoError(t, err, "a mis-scoped or unknown remove leaves the record intact")
+}


### PR DESCRIPTION
## Slice 1 of #140 (ADR 0026 upstream reconciliation)

The retraction primitive the reconcile pass will use.

### What
`InboundStore.RemoveSynced(owner, inbox, id)` hard-removes an upstream-synced message — its metadata record, dedup-index entry, and content blob — so it disappears from the IMAP read face entirely.

### Guards
- **Refuses locally-generated records** (`UpstreamUID == 0`, e.g. signed bounces): they have no upstream and are never reconciled (ADR 0026 invariant).
- **(owner, inbox)-scoped** like `Get`: a mis-scoped or unknown id is `ErrNotFound`, leaving the record intact.
- **Dedup index cleared** on removal, so the same upstream (UIDVALIDITY, UID) re-syncs cleanly if the message returns to the source (ADR 0026 re-appearance).

### Ordering / durability
Metadata record + dedup index are removed in one bbolt txn; the content blob is deleted after the commit. This mirrors the blob-first write path (ADR 0018) inverted: a crash before the blob delete only orphans the blob (reclaimed by the startup sweep) — never a metadata pointer to a missing blob.

### Scope
Foundation only — `RemoveSynced` is not yet wired into any production path; the reconcile pass (a following slice) is its first caller. Direct unit tests cover hard-remove + re-sync, pending records, the locally-generated refusal, and scoping.

### Cross-package touch
`internal/admin` test fake (`failingInbound`) gains a one-line `RemoveSynced` stub to satisfy the widened interface. No production admin change.

Part of #140.