### PR TITLE
feat(imapsync): ListUpstreamUIDs — upstream present-set (#140 slice 2)

### DIFF
--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -1,0 +1,48 @@
+package imapsync
+
+import (
+	"fmt"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// ListUpstreamUIDs returns the inbox mailbox's current UIDVALIDITY and the full
+// set of UIDs present upstream right now. It is the authoritative present-set
+// that upstream reconciliation (ADR 0026) diffs against the synced store to find
+// messages that have left the source (deleted, archived out, or un-labeled out of
+// a label-folder-scoped mailbox).
+//
+// It is strictly READ-ONLY: EXAMINE (not SELECT) plus UID SEARCH ALL, and writes
+// nothing — the upstream is never modified (ADR 0002). It returns an error on any
+// failure (connect / examine / search); reconciliation treats that as "skip this
+// cycle" and never deletes on a failed or incomplete listing (fail-safe).
+//
+// The returned UIDs are unsorted (the order the server reports); the caller diffs
+// them as a set, so order does not matter.
+func (s *Syncer) ListUpstreamUIDs() (uidValidity uint32, uids []uint32, err error) {
+	c, err := s.dial()
+	if err != nil {
+		return 0, nil, fmt.Errorf("imapsync: connect: %w", err)
+	}
+	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
+
+	// EXAMINE opens the mailbox read-only — a listing can never set \Seen or
+	// otherwise perturb the source.
+	sel, err := c.Select(s.mailbox, &imap.SelectOptions{ReadOnly: true}).Wait()
+	if err != nil {
+		return 0, nil, fmt.Errorf("imapsync: examine %q: %w", s.mailbox, err)
+	}
+
+	// Empty criteria encode to SEARCH ALL: the complete set of UIDs present under
+	// sel.UIDValidity.
+	data, err := c.UIDSearch(&imap.SearchCriteria{}, nil).Wait()
+	if err != nil {
+		return 0, nil, fmt.Errorf("imapsync: uid search all in %q: %w", s.mailbox, err)
+	}
+	all := data.AllUIDs()
+	out := make([]uint32, len(all))
+	for i, u := range all {
+		out[i] = uint32(u)
+	}
+	return sel.UIDValidity, out, nil
+}

--- a/internal/imapsync/reconcile_test.go
+++ b/internal/imapsync/reconcile_test.go
@@ -1,0 +1,42 @@
+package imapsync_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// ListUpstreamUIDs returns the mailbox's current UIDVALIDITY and the full set of
+// present UIDs — the authoritative present-set reconciliation (ADR 0026) diffs
+// against the synced store.
+func TestListUpstreamUIDs(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\n1")
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\n2")
+	appendMsg(t, user, "From: c@x.test\r\nSubject: three\r\n\r\n3")
+
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, newInbound(t), newState(t), 0)
+
+	uidValidity, uids, err := syncer.ListUpstreamUIDs()
+	require.NoError(t, err)
+	assert.NotZero(t, uidValidity, "a selected mailbox always reports a UIDVALIDITY")
+	assert.ElementsMatch(t, []uint32{1, 2, 3}, uids, "every appended message's UID is listed")
+}
+
+// An empty mailbox lists no UIDs but still reports its UIDVALIDITY — the
+// reconcile guard distinguishes "source is empty" (UIDVALIDITY present, no UIDs)
+// from "listing failed" (error), and only the latter is skipped.
+func TestListUpstreamUIDsEmpty(t *testing.T) {
+	addr, _ := startUpstream(t)
+
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, newInbound(t), newState(t), 0)
+
+	uidValidity, uids, err := syncer.ListUpstreamUIDs()
+	require.NoError(t, err)
+	assert.NotZero(t, uidValidity)
+	assert.Empty(t, uids)
+}


### PR DESCRIPTION
## Slice 2 of #140 (ADR 0026 upstream reconciliation)

The IMAP present-set query the reconcile pass diffs against the synced store.

### What
`Syncer.ListUpstreamUIDs() (uidValidity uint32, uids []uint32, err error)` — EXAMINE the inbox mailbox **read-only** + `UID SEARCH ALL`, returning the mailbox's current UIDVALIDITY and the full set of UIDs present upstream right now.

### Why
ADR 0026 reconciliation finds messages that have left the source by diffing the authoritative upstream present-set against the synced store. This is that query.

### Read-only invariant
EXAMINE (not SELECT) + SEARCH only — writes nothing, so a listing can never set `\\Seen` or perturb the source (ADR 0002 read-only-upstream).

### Fail-safe
Any failure (connect / examine / search) returns an error; the reconcile pass (a following slice) treats that as "skip this cycle" and never deletes on a failed or incomplete listing. An empty mailbox is distinct: UIDVALIDITY present, zero UIDs — not an error.

### Scope
Foundation only — not yet wired into any loop; the reconcile pass is its first caller. Tests cover the populated present-set and the empty-mailbox case.

Part of #140.