### PR TITLE
feat(inboxcfg): per-inbox reconcile opt-in + interval (#140 slice 3)

### DIFF
--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -13,6 +13,7 @@ package inboxcfg
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -34,6 +35,17 @@ type Inbox struct {
 	DefaultVisibility string    `yaml:"default_visibility"`
 	Rules             yaml.Node `yaml:"rules"`
 	FilterFile        string    `yaml:"filter_file"`
+
+	// Upstream reconciliation (ADR 0026): when the source drops a synced message
+	// (deleted, archived out, or un-labeled out of a label-folder-scoped mailbox),
+	// Darbaan retracts its local copy. The upstream is never modified — retraction
+	// is local-only. It is OPT-IN and OFF unless ReconcileEnabled is set, so an
+	// upgrade never starts retracting on deploy by surprise; the operator turns it
+	// on per inbox. ReconcileInterval is the period between reconcile passes — a
+	// full UID listing, heavier than the incremental forward poll, so typically
+	// longer; empty uses the runtime default. It is only meaningful when enabled.
+	ReconcileEnabled  bool   `yaml:"reconcile_enabled"`
+	ReconcileInterval string `yaml:"reconcile_interval"`
 }
 
 // Backend is an inbox's upstream account coordinates (ADR 0009). Secrets
@@ -103,6 +115,13 @@ func Validate(inboxes []Inbox) error {
 		envSeen[ep] = name
 		if _, err := in.Filter(); err != nil {
 			return fmt.Errorf("inboxcfg: inbox %q: %w", name, err)
+		}
+		// Fail-fast on a malformed reconcile interval for an enabled inbox, so a bad
+		// duration is caught at load, not at the first reconcile pass (ADR 0026).
+		if in.ReconcileEnabled {
+			if _, err := in.ReconcileDuration(); err != nil {
+				return fmt.Errorf("inboxcfg: inbox %q: %w", name, err)
+			}
 		}
 	}
 	return nil
@@ -177,4 +196,23 @@ func (in Inbox) Filter() (*filter.Filter, error) {
 		return nil, fmt.Errorf("marshal filter: %w", err)
 	}
 	return filter.Compile(b)
+}
+
+// ReconcileDuration parses the inbox's reconcile interval (ADR 0026). An empty
+// interval returns (0, nil) — the caller substitutes the runtime default. A set
+// interval must be a positive Go duration (e.g. "1h", "30m", "6h"); zero or
+// negative is an error. It is only meaningful when ReconcileEnabled is set.
+func (in Inbox) ReconcileDuration() (time.Duration, error) {
+	s := strings.TrimSpace(in.ReconcileInterval)
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid reconcile_interval %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("reconcile_interval must be positive, got %q", s)
+	}
+	return d, nil
 }

--- a/internal/inboxcfg/reconcile_config_test.go
+++ b/internal/inboxcfg/reconcile_config_test.go
@@ -1,0 +1,76 @@
+package inboxcfg_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/inboxcfg"
+)
+
+// The reconcile fields parse from the inboxes: doc, and default OFF when absent
+// (opt-in, so an upgrade never starts retracting by surprise — ADR 0026).
+func TestReconcileConfigParse(t *testing.T) {
+	doc := []byte(`
+inboxes:
+  - name: work
+    reconcile_enabled: true
+    reconcile_interval: "2h"
+  - name: personal
+`)
+	inboxes, err := inboxcfg.Parse(doc)
+	require.NoError(t, err)
+	require.Len(t, inboxes, 2)
+
+	assert.True(t, inboxes[0].ReconcileEnabled)
+	assert.Equal(t, "2h", inboxes[0].ReconcileInterval)
+
+	assert.False(t, inboxes[1].ReconcileEnabled, "absent reconcile_enabled defaults OFF")
+	assert.Empty(t, inboxes[1].ReconcileInterval)
+}
+
+func TestReconcileDuration(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", 0, false}, // empty → runtime default
+		{"1h", time.Hour, false},
+		{"30m", 30 * time.Minute, false},
+		{"6h", 6 * time.Hour, false},
+		{"nope", 0, true}, // unparseable
+		{"0s", 0, true},   // zero rejected
+		{"-1h", 0, true},  // negative rejected
+	}
+	for _, c := range cases {
+		d, err := inboxcfg.Inbox{ReconcileInterval: c.in}.ReconcileDuration()
+		if c.wantErr {
+			assert.Error(t, err, "interval %q", c.in)
+			continue
+		}
+		require.NoError(t, err, "interval %q", c.in)
+		assert.Equal(t, c.want, d, "interval %q", c.in)
+	}
+}
+
+// Validate fail-fasts on a bad interval only for an ENABLED inbox; a disabled
+// inbox's interval is meaningless and not validated.
+func TestValidateReconcileInterval(t *testing.T) {
+	enabledBad := []inboxcfg.Inbox{{Name: "work", ReconcileEnabled: true, ReconcileInterval: "nope"}}
+	assert.Error(t, inboxcfg.Validate(enabledBad), "enabled + bad interval is rejected at load")
+
+	enabledZero := []inboxcfg.Inbox{{Name: "work", ReconcileEnabled: true, ReconcileInterval: "0s"}}
+	assert.Error(t, inboxcfg.Validate(enabledZero), "enabled + zero interval is rejected")
+
+	enabledOK := []inboxcfg.Inbox{{Name: "work", ReconcileEnabled: true, ReconcileInterval: "1h"}}
+	assert.NoError(t, inboxcfg.Validate(enabledOK))
+
+	enabledEmpty := []inboxcfg.Inbox{{Name: "work", ReconcileEnabled: true}}
+	assert.NoError(t, inboxcfg.Validate(enabledEmpty), "enabled + empty interval uses the runtime default")
+
+	disabledBad := []inboxcfg.Inbox{{Name: "work", ReconcileInterval: "nope"}}
+	assert.NoError(t, inboxcfg.Validate(disabledBad), "a disabled inbox's interval is not validated")
+}


### PR DESCRIPTION
## Slice 3 of #140 (ADR 0026 upstream reconciliation)

The per-inbox config surface for reconciliation. Config only — consumed by the reconcile pass and cadence in following slices.

### Fields (per inbox)
- **`reconcile_enabled`** — opt-in, **default OFF**. An upgrade never starts retracting on deploy by surprise; the operator turns it on per inbox (ADR 0026).
- **`reconcile_interval`** — the period between reconcile passes. A full UID listing is heavier than the incremental forward poll, so this is typically longer. Empty uses the runtime default.

### Parsing + validation
- `ReconcileDuration()` parses the interval: positive Go duration (`1h`, `30m`, …); empty → `(0, nil)` = runtime default; zero/negative/unparseable → error.
- `Validate` fail-fasts on a malformed interval **only for an enabled inbox**, so a bad duration is caught at load, not at the first pass. A disabled inbox's interval is meaningless and not validated.

### Scope
No behavior wired yet — the reconcile pass (slice 4), cap/latch (slice 5), and cadence loop (slice 6) consume these. Tests cover YAML parse + default-off, the duration table, and the enabled/disabled validation split.

Part of #140.