### PR TITLE
feat(imapsync): Reconcile — retract messages that left the source (#140 slice 4)

### DIFF
--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -1,9 +1,14 @@
 package imapsync
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/emersion/go-imap/v2"
+
+	"github.com/yaad-index/darbaan/internal/audit"
+	"github.com/yaad-index/darbaan/internal/inbound"
 )
 
 // ListUpstreamUIDs returns the inbox mailbox's current UIDVALIDITY and the full
@@ -45,4 +50,110 @@ func (s *Syncer) ListUpstreamUIDs() (uidValidity uint32, uids []uint32, err erro
 		out[i] = uint32(u)
 	}
 	return sel.UIDValidity, out, nil
+}
+
+// ReconcileOptions configures one reconciliation pass (ADR 0026).
+type ReconcileOptions struct {
+	// Audit receives a "retract" record for each retracted message (the ADR 0007
+	// hash chain). nil disables auditing (a no-op); the production wiring always
+	// supplies the real log.
+	Audit audit.AuditLog
+}
+
+// Reconcile runs one upstream-reconciliation pass for this syncer's inbox
+// (ADR 0026): it retracts the local copy of every synced message that has LEFT
+// the source mailbox (deleted, archived out, or un-labeled out of a label-folder-
+// scoped mailbox), while NEVER modifying the upstream itself (ADR 0002). It
+// returns the number of messages retracted.
+//
+// Guards, applied in order:
+//
+//  1. List the current upstream present-set (read-only, ListUpstreamUIDs). Any
+//     failure returns an error and retracts nothing — reconciliation never
+//     deletes on a failed or incomplete listing (fail-safe).
+//  2. UIDVALIDITY-skip: if the mailbox's current UIDVALIDITY differs from the
+//     forward-sync cursor's, the whole UID space changed (a mailbox reset, a full
+//     re-sync per ADR 0019) — NOT a signal that every message was deleted. Skip
+//     presence-deletion this cycle and let the forward sync own the re-sync.
+//  3. Synced-only set-diff: a record is a retraction candidate only if it carries
+//     an upstream UID (UpstreamUID != 0 — locally-generated bounces are never
+//     reconciled), matches the current UIDVALIDITY (records under a superseded
+//     validity are the forward re-sync's concern), and its UID is absent from the
+//     upstream present-set.
+//  4. Retract each candidate (RemoveSynced) and append a retract audit record.
+//     Per-message failures are collected and the pass continues (best-effort), so
+//     one stuck record never blocks the rest; the next cycle retries the failures.
+//
+// The safety cap that holds a too-large purge (ADR 0026) is layered on top of
+// this pass in a following increment — its insertion point is just before the
+// retraction loop.
+func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, error) {
+	// Guard 1: authoritative present-set (read-only). Failure ⇒ skip (fail-safe).
+	uidValidity, upUIDs, err := s.ListUpstreamUIDs()
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: reconcile: %w", err)
+	}
+
+	loaded, err := s.state.Load(s.stateKey())
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: reconcile: load state: %w", err)
+	}
+	// Guard 2: UIDVALIDITY-skip. A mismatch (mailbox reset, or no forward sync yet)
+	// means the UID space changed, not that everything was deleted.
+	if loaded.UIDValidity != uidValidity {
+		return 0, nil
+	}
+
+	present := make(map[uint32]bool, len(upUIDs))
+	for _, u := range upUIDs {
+		present[u] = true
+	}
+
+	msgs, err := s.store.List(s.owner, s.inbox)
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: reconcile: list store: %w", err)
+	}
+	// Guard 3: synced-only set-diff. Skip locally-generated records (no upstream
+	// UID) and records under a superseded UIDVALIDITY; a candidate is a synced
+	// record whose UID is no longer present upstream.
+	var gone []inbound.Message
+	for _, m := range msgs {
+		if m.UpstreamUID == 0 || m.UIDValidity != uidValidity {
+			continue
+		}
+		if !present[m.UpstreamUID] {
+			gone = append(gone, m)
+		}
+	}
+
+	// (safety-cap insertion point — a following increment holds the pass here when
+	// |gone| exceeds a configured fraction of the synced set.)
+
+	// Guard 4: retract each candidate + audit, best-effort.
+	removed := 0
+	var errs []error
+	for _, m := range gone {
+		if err := ctx.Err(); err != nil {
+			return removed, err
+		}
+		if err := s.store.RemoveSynced(s.owner, s.inbox, m.ID); err != nil {
+			errs = append(errs, fmt.Errorf("retract %s (uid %d): %w", m.ID, m.UpstreamUID, err))
+			continue
+		}
+		removed++
+		if opts.Audit != nil {
+			// Best-effort audit (the message store is the source of truth; a failed
+			// append must not fail an already-committed retraction — ADR 0011).
+			_ = opts.Audit.Append(audit.Record{
+				Event:     "retract",
+				Agent:     s.owner,
+				MessageID: m.ID,
+				Detail:    fmt.Sprintf("inbox=%s upstream_uid=%d left source", inbound.NormInbox(s.inbox), m.UpstreamUID),
+			})
+		}
+	}
+	if len(errs) > 0 {
+		return removed, fmt.Errorf("imapsync: reconcile: %d of %d retraction(s) failed: %w", len(errs), len(gone), errors.Join(errs...))
+	}
+	return removed, nil
 }

--- a/internal/imapsync/reconcile_pass_test.go
+++ b/internal/imapsync/reconcile_pass_test.go
@@ -1,0 +1,164 @@
+package imapsync_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/audit"
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// expungeUID permanently removes a message from the upstream INBOX (mark \Deleted
+// + EXPUNGE) — simulating a message leaving the source mailbox.
+func expungeUID(t *testing.T, addr string, uid uint32) {
+	t.Helper()
+	c, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
+	require.NoError(t, c.Login(upUser, upPass).Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	sf := &imap.StoreFlags{Op: imap.StoreFlagsAdd, Flags: []imap.Flag{imap.FlagDeleted}}
+	require.NoError(t, c.Store(imap.UIDSetNum(imap.UID(uid)), sf, nil).Close())
+	require.NoError(t, c.Expunge().Close())
+}
+
+// captureAudit records appended audit entries for assertions.
+type captureAudit struct{ recs []audit.Record }
+
+func (c *captureAudit) Append(r audit.Record) error { c.recs = append(c.recs, r); return nil }
+func (c *captureAudit) Verify() error               { return nil }
+func (c *captureAudit) Close() error                { return nil }
+
+// A message removed from the source is retracted locally, and only that one; a
+// retract audit record is written.
+func TestReconcileRetractsGoneMessages(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\n1")
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\n2")
+	appendMsg(t, user, "From: c@x.test\r\nSubject: three\r\n\r\n3")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+
+	expungeUID(t, addr, 2) // UID 2 leaves the source
+
+	aud := &captureAudit{}
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{Audit: aud})
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "exactly the gone message is retracted")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	uids := map[uint32]bool{}
+	for _, m := range msgs {
+		uids[m.UpstreamUID] = true
+	}
+	assert.Equal(t, map[uint32]bool{1: true, 3: true}, uids, "present messages stay, the gone one is retracted")
+
+	require.Len(t, aud.recs, 1)
+	assert.Equal(t, "retract", aud.recs[0].Event)
+	assert.Equal(t, "agent", aud.recs[0].Agent)
+}
+
+// Nothing left the source ⇒ nothing retracted.
+func TestReconcileNoChange(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\n1")
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\n2")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, removed)
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 2)
+}
+
+// A UIDVALIDITY mismatch is a mailbox reset (forward re-sync's job), NOT a
+// signal that every message was deleted — reconcile must skip, never mass-delete.
+func TestReconcileSkipsOnUIDVALIDITYChange(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\n1")
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\n2")
+
+	store := newInbound(t)
+	state := newState(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, state, 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+
+	expungeUID(t, addr, 1) // a message leaves...
+
+	// ...but the recorded cursor's UIDVALIDITY no longer matches the mailbox's.
+	cur, err := state.Load("INBOX")
+	require.NoError(t, err)
+	require.NoError(t, state.Save("INBOX", imapsync.State{UIDValidity: cur.UIDValidity + 1, LastUID: cur.LastUID}))
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, removed, "UIDVALIDITY mismatch ⇒ skip")
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 2, "both records retained on a UIDVALIDITY skip")
+}
+
+// A locally-generated record (no upstream UID, e.g. a bounce) is never reconciled,
+// even though it is absent from the upstream present-set.
+func TestReconcileKeepsLocallyGenerated(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: synced\r\n\r\n1")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+
+	_, err = store.Add(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, From: "MAILER-DAEMON@x", To: "agent@x",
+		Subject: "bounce", Raw: []byte("bounce"),
+	})
+	require.NoError(t, err)
+
+	expungeUID(t, addr, 1) // the synced message leaves the source
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "only the synced message is retracted")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, uint32(0), msgs[0].UpstreamUID, "the locally-generated bounce is kept")
+}
+
+// A failed listing surfaces an error and retracts nothing (fail-safe) — never
+// delete on uncertainty.
+func TestReconcileSkipsOnFailedListing(t *testing.T) {
+	store := newInbound(t)
+	_, _, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 1, UIDValidity: 1,
+	})
+	require.NoError(t, err)
+
+	down := func() (*imapclient.Client, error) { return nil, errors.New("upstream down") }
+	syncer := imapsync.New(down, "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.Error(t, err)
+	assert.Zero(t, removed)
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 1, "nothing retracted on a failed listing")
+}


### PR DESCRIPTION
## Slice 4 of #140 (ADR 0026 upstream reconciliation)

The reconcile pass: retract the local copy of every synced message that has left the source mailbox, **never** modifying the upstream.

### `Syncer.Reconcile(ctx, ReconcileOptions{Audit})` — four guards, in order
1. **List (read-only) → fail-safe.** `ListUpstreamUIDs` (EXAMINE + UID SEARCH ALL). Any failure returns an error and retracts nothing — never delete on a failed or incomplete listing.
2. **UIDVALIDITY-skip.** If the mailbox's current UIDVALIDITY ≠ the forward-sync cursor's, the UID space reset (a full re-sync per ADR 0019), not a mass deletion — skip presence-deletion this cycle.
3. **Synced-only set-diff.** A candidate must carry an upstream UID (`UpstreamUID != 0`, so locally-generated bounces are never reconciled), match the current UIDVALIDITY (superseded-validity records are the forward re-sync's concern), and be absent from the present-set.
4. **Retract + audit.** `RemoveSynced` each candidate and append a `retract` audit record. Per-message failures are collected best-effort, so one stuck record never blocks the rest; the next cycle retries.

### Audit is orchestrator-side
The inbound store is audit-free (only the sluice writes audit today), so the retract record is written here, where the audit log is in scope — not inside the store. `ReconcileOptions.Audit` nil = no-op; production always supplies the real log.

### Re: the slice-1 sentinel-error nit
Reconcile filters `UpstreamUID == 0` in guard 3 **before** calling `RemoveSynced`, so the store's locally-generated refusal is unreachable from the pass — no sentinel needed here; the refusal stays defense-in-depth.

### Not in this slice
The safety cap that holds a too-large purge (and its operator-ack latch) is **slice 5** — its insertion point is marked in code, just before the retraction loop. Cadence wiring is slice 6. So `Reconcile` is not yet driven by any loop.

### Tests
Retract-gone-message (expunge upstream → exactly that one retracted + audit record), no-op when nothing left, UIDVALIDITY-change skip (no mass-delete), locally-generated bounce kept, failed-listing fail-safe.

Part of #140.