### PR TITLE
feat(reconcile): safety-cap latch — hold a too-large purge (#140 slice 5a)

### DIFF
--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -4,12 +4,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/emersion/go-imap/v2"
 
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/inbound"
 )
+
+// DefaultReconcileCapFraction is the safety-cap fraction used when an inbox does
+// not configure one (ADR 0026): a pass that would retract more than this fraction
+// of the inbox's synced set latches instead of purging. Half the set is a
+// conservative anomaly threshold; the operator can tune it per inbox.
+const DefaultReconcileCapFraction = 0.5
+
+// DefaultReconcileCapFloor is the absolute floor used when an inbox does not
+// configure one (ADR 0026): the cap never latches unless at least this many
+// messages would be retracted, regardless of the fraction. Without it a pure
+// fraction would latch a tiny inbox on a single normal removal (1 of 2 = 50%);
+// the floor keeps the cap an anomaly backstop that only bites at scale.
+const DefaultReconcileCapFloor = 5
+
+// ErrReconcileHeld is returned by Reconcile when the safety cap has the inbox
+// latched (this pass tripped it, or a prior pass did and it has not been
+// released). It is an expected hold, not a failure: the caller distinguishes it
+// with errors.Is and reports it as held, not as an error.
+var ErrReconcileHeld = errors.New("imapsync: reconcile held: cap exceeded, awaiting operator release")
 
 // ListUpstreamUIDs returns the inbox mailbox's current UIDVALIDITY and the full
 // set of UIDs present upstream right now. It is the authoritative present-set
@@ -58,6 +78,15 @@ type ReconcileOptions struct {
 	// hash chain). nil disables auditing (a no-op); the production wiring always
 	// supplies the real log.
 	Audit audit.AuditLog
+	// CapFraction is the safety-cap fraction (ADR 0026): a pass that would retract
+	// more than this fraction of the synced set latches instead of purging. A value
+	// outside (0,1] falls back to DefaultReconcileCapFraction.
+	CapFraction float64
+	// CapFloor is the safety-cap absolute floor: the cap never latches unless at
+	// least this many messages would be retracted. A value < 1 falls back to
+	// DefaultReconcileCapFloor. The latch rule is the conjunction of both:
+	// retract-count >= floor AND retract-count > fraction * synced-set.
+	CapFloor int
 }
 
 // Reconcile runs one upstream-reconciliation pass for this syncer's inbox
@@ -84,10 +113,23 @@ type ReconcileOptions struct {
 //     Per-message failures are collected and the pass continues (best-effort), so
 //     one stuck record never blocks the rest; the next cycle retries the failures.
 //
-// The safety cap that holds a too-large purge (ADR 0026) is layered on top of
-// this pass in a following increment — its insertion point is just before the
-// retraction loop.
+// Before retracting, a SAFETY CAP holds a too-large purge: if the candidate set
+// clears an absolute floor and exceeds a configured fraction of the synced set,
+// the pass latches the inbox (suspends reconciliation) and returns
+// ErrReconcileHeld instead of purging — the anomaly backstop against a
+// source-side mass removal silently emptying the store. A latched inbox stays
+// held (every pass returns ErrReconcileHeld) until an operator release.
 func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, error) {
+	// Already latched by a prior pass and not yet released: hold without listing or
+	// purging (no wasted upstream round-trip).
+	rs, err := s.state.LoadReconcile(s.stateKey())
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: reconcile: load latch: %w", err)
+	}
+	if rs.Suspended {
+		return 0, ErrReconcileHeld
+	}
+
 	// Guard 1: authoritative present-set (read-only). Failure ⇒ skip (fail-safe).
 	uidValidity, upUIDs, err := s.ListUpstreamUIDs()
 	if err != nil {
@@ -117,17 +159,38 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 	// UID) and records under a superseded UIDVALIDITY; a candidate is a synced
 	// record whose UID is no longer present upstream.
 	var gone []inbound.Message
+	syncedCount := 0
 	for _, m := range msgs {
 		if m.UpstreamUID == 0 || m.UIDValidity != uidValidity {
 			continue
 		}
+		syncedCount++
 		if !present[m.UpstreamUID] {
 			gone = append(gone, m)
 		}
 	}
 
-	// (safety-cap insertion point — a following increment holds the pass here when
-	// |gone| exceeds a configured fraction of the synced set.)
+	// Safety cap (ADR 0026): hold a too-large purge instead of auto-purging. Latch
+	// only when the candidate set BOTH clears the absolute floor (so a tiny inbox
+	// never false-latches on a normal single removal) AND exceeds the configured
+	// fraction of the synced set. A latch suspends the inbox until an operator
+	// release; the upstream is untouched (nothing is purged this pass).
+	frac := opts.CapFraction
+	if frac <= 0 || frac > 1 {
+		frac = DefaultReconcileCapFraction
+	}
+	floor := opts.CapFloor
+	if floor < 1 {
+		floor = DefaultReconcileCapFloor
+	}
+	if len(gone) >= floor && float64(len(gone)) > frac*float64(syncedCount) {
+		if err := s.state.SaveReconcile(s.stateKey(), ReconcileState{Suspended: true, HeldCount: len(gone)}); err != nil {
+			return 0, fmt.Errorf("imapsync: reconcile: latch: %w", err)
+		}
+		log.Printf("darbaan: reconcile HELD for inbox %q: a pass would retract %d of %d synced messages (cap %.0f%%); suspended pending operator release",
+			inbound.NormInbox(s.inbox), len(gone), syncedCount, frac*100)
+		return 0, ErrReconcileHeld
+	}
 
 	// Guard 4: retract each candidate + audit, best-effort.
 	removed := 0

--- a/internal/imapsync/reconcile_cap_test.go
+++ b/internal/imapsync/reconcile_cap_test.go
@@ -1,0 +1,126 @@
+package imapsync_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// syncN appends n messages upstream (UIDs 1..n) and syncs them into a fresh
+// store, returning the wired syncer, store, and state.
+func syncN(t *testing.T, n int) (string, *imapsync.Syncer, inbound.InboundStore, imapsync.StateStore) {
+	t.Helper()
+	addr, user := startUpstream(t)
+	for i := 1; i <= n; i++ {
+		appendMsg(t, user, fmt.Sprintf("From: a@x.test\r\nSubject: m%d\r\n\r\n%d", i, i))
+	}
+	store := newInbound(t)
+	state := newState(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, state, 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	return addr, syncer, store, state
+}
+
+// The cap latches the inbox when a single pass would retract too much, purging
+// nothing and suspending until an operator release (ADR 0026).
+func TestReconcileCapLatchesLargePurge(t *testing.T) {
+	addr, syncer, store, state := syncN(t, 8)
+	for uid := uint32(1); uid <= 6; uid++ { // 6 of 8 leave (>=floor 5, >50%)
+		expungeUID(t, addr, uid)
+	}
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	assert.ErrorIs(t, err, imapsync.ErrReconcileHeld)
+	assert.Zero(t, removed, "a latched pass purges nothing")
+
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 8, "nothing is retracted while latched")
+
+	rs, err := state.LoadReconcile("INBOX")
+	require.NoError(t, err)
+	assert.True(t, rs.Suspended)
+	assert.Equal(t, 6, rs.HeldCount)
+}
+
+// An already-latched inbox stays held on every pass and never purges — and does
+// not even contact the upstream (the failing dialer must not be called).
+func TestReconcileStaysHeldWhenSuspended(t *testing.T) {
+	store := newInbound(t)
+	state := newState(t)
+	_, _, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+	require.NoError(t, state.SaveReconcile("INBOX", imapsync.ReconcileState{Suspended: true, HeldCount: 9}))
+
+	failDial := func() (*imapclient.Client, error) { return nil, errors.New("must not dial while held") }
+	syncer := imapsync.New(failDial, "INBOX", "agent", inbound.DefaultInbox, store, state, 0)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	assert.ErrorIs(t, err, imapsync.ErrReconcileHeld)
+	assert.Zero(t, removed)
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 1)
+}
+
+// The floor protects a tiny inbox: removing 1 of 2 (50%) is below the floor, so
+// it is a normal retraction, not a latch.
+func TestReconcileCapFloorProtectsTinyInbox(t *testing.T) {
+	addr, syncer, _, _ := syncN(t, 2)
+	expungeUID(t, addr, 1)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err, "below the floor ⇒ no latch")
+	assert.Equal(t, 1, removed)
+}
+
+// A custom CapFraction is honored: with an 80% cap, a purge the default (50%)
+// would latch is allowed through.
+func TestReconcileCapFractionOption(t *testing.T) {
+	addr, syncer, _, _ := syncN(t, 8)
+	for uid := uint32(1); uid <= 5; uid++ { // 5/8: >floor, >50%, but <80%
+		expungeUID(t, addr, uid)
+	}
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{CapFraction: 0.8})
+	require.NoError(t, err, "5/8 is under an 80% cap ⇒ no latch")
+	assert.Equal(t, 5, removed)
+}
+
+// A custom CapFloor is honored: a lower floor latches a purge the default floor
+// (5) would let through.
+func TestReconcileCapFloorOption(t *testing.T) {
+	addr, syncer, store, _ := syncN(t, 6)
+	for uid := uint32(1); uid <= 4; uid++ { // 4/6: >50%, but below the default floor 5
+		expungeUID(t, addr, uid)
+	}
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{CapFloor: 3})
+	assert.ErrorIs(t, err, imapsync.ErrReconcileHeld, "floor 3 ⇒ 4 retractions latch")
+	assert.Zero(t, removed)
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 6, "nothing purged while latched")
+}
+
+// The reconcile latch round-trips and is independent of the sync cursor — a
+// cursor Save must not clear a latch.
+func TestReconcileStateIndependentOfCursor(t *testing.T) {
+	state := newState(t)
+
+	got, err := state.LoadReconcile("INBOX")
+	require.NoError(t, err)
+	assert.False(t, got.Suspended, "unset key reads as not-suspended")
+
+	require.NoError(t, state.SaveReconcile("INBOX", imapsync.ReconcileState{Suspended: true, HeldCount: 7}))
+	require.NoError(t, state.Save("INBOX", imapsync.State{UIDValidity: 42, LastUID: 99})) // a forward-sync cursor write
+
+	got, err = state.LoadReconcile("INBOX")
+	require.NoError(t, err)
+	assert.True(t, got.Suspended, "a cursor Save does not clear the latch")
+	assert.Equal(t, 7, got.HeldCount)
+}

--- a/internal/imapsync/state.go
+++ b/internal/imapsync/state.go
@@ -21,14 +21,33 @@ type State struct {
 	LastUID     uint32 `json:"last_uid"`
 }
 
-// StateStore persists the sync cursor per mailbox.
+// ReconcileState is the per-inbox reconciliation latch (ADR 0026 safety cap).
+// When a single reconcile pass would retract more than the configured fraction of
+// the inbox's synced set, reconciliation is SUSPENDED for that inbox and held
+// until an operator release — the anomaly backstop against a source-side mass
+// removal silently emptying the store. It is kept separate from the sync cursor
+// (State) so a forward sync never clears the latch.
+type ReconcileState struct {
+	Suspended bool `json:"suspended"`
+	HeldCount int  `json:"held_count,omitempty"` // candidates when it latched (operator info)
+}
+
+// StateStore persists the sync cursor and the reconcile latch per mailbox.
 type StateStore interface {
 	Load(mailbox string) (State, error)
 	Save(mailbox string, st State) error
+	// LoadReconcile / SaveReconcile persist the reconciliation latch (ADR 0026),
+	// keyed like the cursor but in a separate namespace so a cursor Save never
+	// clears a latch. An unset key reads as the zero ReconcileState (not suspended).
+	LoadReconcile(mailbox string) (ReconcileState, error)
+	SaveReconcile(mailbox string, rs ReconcileState) error
 	Close() error
 }
 
-var bucketSyncState = []byte("syncstate")
+var (
+	bucketSyncState      = []byte("syncstate")
+	bucketReconcileState = []byte("reconcilestate")
+)
 
 type bboltState struct{ db *bbolt.DB }
 
@@ -42,7 +61,10 @@ func NewStateStore(path string) (StateStore, error) {
 		return nil, fmt.Errorf("imapsync: open state db: %w", err)
 	}
 	if err := db.Update(func(tx *bbolt.Tx) error {
-		_, e := tx.CreateBucketIfNotExists(bucketSyncState)
+		if _, e := tx.CreateBucketIfNotExists(bucketSyncState); e != nil {
+			return e
+		}
+		_, e := tx.CreateBucketIfNotExists(bucketReconcileState)
 		return e
 	}); err != nil {
 		_ = db.Close()
@@ -78,6 +100,36 @@ func (s *bboltState) Save(mailbox string, st State) error {
 		return tx.Bucket(bucketSyncState).Put([]byte(mailbox), enc)
 	}); err != nil {
 		return fmt.Errorf("imapsync: save state %q: %w", mailbox, err)
+	}
+	return nil
+}
+
+// LoadReconcile returns the reconcile latch for a mailbox, or the zero
+// ReconcileState (not suspended) if none is recorded.
+func (s *bboltState) LoadReconcile(mailbox string) (ReconcileState, error) {
+	var rs ReconcileState
+	err := s.db.View(func(tx *bbolt.Tx) error {
+		v := tx.Bucket(bucketReconcileState).Get([]byte(mailbox))
+		if v == nil {
+			return nil // zero ReconcileState — never latched
+		}
+		return json.Unmarshal(v, &rs)
+	})
+	if err != nil {
+		return ReconcileState{}, fmt.Errorf("imapsync: load reconcile state %q: %w", mailbox, err)
+	}
+	return rs, nil
+}
+
+func (s *bboltState) SaveReconcile(mailbox string, rs ReconcileState) error {
+	enc, err := json.Marshal(rs)
+	if err != nil {
+		return err
+	}
+	if err := s.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketReconcileState).Put([]byte(mailbox), enc)
+	}); err != nil {
+		return fmt.Errorf("imapsync: save reconcile state %q: %w", mailbox, err)
 	}
 	return nil
 }

--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -46,6 +46,19 @@ type Inbox struct {
 	// longer; empty uses the runtime default. It is only meaningful when enabled.
 	ReconcileEnabled  bool   `yaml:"reconcile_enabled"`
 	ReconcileInterval string `yaml:"reconcile_interval"`
+
+	// ReconcileCapFraction is the safety-cap fraction (ADR 0026): a reconcile pass
+	// that would retract more than this fraction of the inbox's synced set latches
+	// (suspends reconciliation, pending an operator release) instead of purging —
+	// the anomaly backstop against a source-side mass removal silently emptying the
+	// store. Zero uses the runtime default; a set value must be in (0,1].
+	ReconcileCapFraction float64 `yaml:"reconcile_cap_fraction"`
+	// ReconcileCapFloor is the safety-cap absolute floor: the cap never latches
+	// unless at least this many messages would be retracted (so a tiny inbox never
+	// false-latches on a normal single removal). Zero uses the runtime default; a
+	// set value must be >= 1. The latch rule is the conjunction of both —
+	// retract-count >= floor AND retract-count > fraction * synced-set.
+	ReconcileCapFloor int `yaml:"reconcile_cap_floor"`
 }
 
 // Backend is an inbox's upstream account coordinates (ADR 0009). Secrets
@@ -121,6 +134,12 @@ func Validate(inboxes []Inbox) error {
 		if in.ReconcileEnabled {
 			if _, err := in.ReconcileDuration(); err != nil {
 				return fmt.Errorf("inboxcfg: inbox %q: %w", name, err)
+			}
+			if f := in.ReconcileCapFraction; f != 0 && (f < 0 || f > 1) {
+				return fmt.Errorf("inboxcfg: inbox %q: reconcile_cap_fraction must be in (0,1], got %v", name, f)
+			}
+			if fl := in.ReconcileCapFloor; fl != 0 && fl < 1 {
+				return fmt.Errorf("inboxcfg: inbox %q: reconcile_cap_floor must be >= 1, got %d", name, fl)
 			}
 		}
 	}

--- a/internal/inboxcfg/reconcile_config_test.go
+++ b/internal/inboxcfg/reconcile_config_test.go
@@ -74,3 +74,28 @@ func TestValidateReconcileInterval(t *testing.T) {
 	disabledBad := []inboxcfg.Inbox{{Name: "work", ReconcileInterval: "nope"}}
 	assert.NoError(t, inboxcfg.Validate(disabledBad), "a disabled inbox's interval is not validated")
 }
+
+func TestReconcileCapParse(t *testing.T) {
+	doc := []byte("inboxes:\n  - name: work\n    reconcile_enabled: true\n    reconcile_cap_fraction: 0.3\n    reconcile_cap_floor: 10\n")
+	inboxes, err := inboxcfg.Parse(doc)
+	require.NoError(t, err)
+	require.Len(t, inboxes, 1)
+	assert.InDelta(t, 0.3, inboxes[0].ReconcileCapFraction, 1e-9)
+	assert.Equal(t, 10, inboxes[0].ReconcileCapFloor)
+}
+
+// The cap fraction (0,1] and floor >=1 are validated only for an enabled inbox;
+// zero means "runtime default".
+func TestValidateReconcileCap(t *testing.T) {
+	en := func(f float64, fl int) []inboxcfg.Inbox {
+		return []inboxcfg.Inbox{{Name: "work", ReconcileEnabled: true, ReconcileCapFraction: f, ReconcileCapFloor: fl}}
+	}
+	assert.Error(t, inboxcfg.Validate(en(1.5, 0)), "fraction >1 rejected")
+	assert.Error(t, inboxcfg.Validate(en(-0.1, 0)), "negative fraction rejected")
+	assert.Error(t, inboxcfg.Validate(en(0, -1)), "floor <1 rejected")
+	assert.NoError(t, inboxcfg.Validate(en(0.3, 1)))
+	assert.NoError(t, inboxcfg.Validate(en(0, 0)), "zero fraction/floor = runtime default")
+
+	disabled := []inboxcfg.Inbox{{Name: "work", ReconcileCapFraction: 9, ReconcileCapFloor: -5}}
+	assert.NoError(t, inboxcfg.Validate(disabled), "the cap is not validated when reconciliation is disabled")
+}


### PR DESCRIPTION
## Slice 5a of #140 (ADR 0026 upstream reconciliation)

The safety-cap **latch** — the anomaly backstop that holds a too-large purge. Builds to the ADR 0026 amendment in #147.

### Cap rule (conjunction)
Latch iff **both**: `retract-count >= floor` AND `retract-count > fraction * synced-set`. The floor stops a tiny inbox false-latching on a normal single removal (1 of 2 = 50% but only 1 message); the fraction only bites at scale.
- Defaults: `fraction = 0.5`, `floor = 5`, both per-inbox configurable (`reconcile_cap_fraction`, `reconcile_cap_floor`), validated when reconciliation is enabled.

### Latch = suspend, not transient-skip
On breach the pass retracts **nothing**, suspends reconciliation for the inbox, logs an alert, and returns `ErrReconcileHeld`. A latched inbox stays held every cycle (returns `ErrReconcileHeld` without even listing upstream) until an operator release.

### Suspended state is runtime store state
A dedicated `ReconcileState{Suspended, HeldCount}` in its **own bbolt bucket**, separate from the forward-sync cursor (`State`) — a cursor write must never clear the latch (tested), and config is read-only at runtime so a config flag won't do.

### Not in this slice
The operator-ack **release** (clear the latch + perform the confirmed purge once) is slice 5b — it will re-run the pass cap-bypassed so the purge reflects the upstream at release time. Cadence wiring is slice 6.

### Tests
Cap latches a large purge (6/8 → held, nothing purged, suspended+count recorded); an already-suspended inbox stays held without dialing; the floor protects a tiny inbox; custom `CapFraction` (5/8 under 80% passes) and custom `CapFloor` (4/6 with floor 3 latches) honored; latch round-trips and survives a cursor Save. Plus inboxcfg cap parse + validation.

### Cross-package touch
`internal/inboxcfg` gains the two cap fields + validation (consumed by the imapsync pass).

Builds to #147 (ADR 0026 amendment). Part of #140.