### PR TITLE
feat(reconcile): operator-ack release — clear latch + cap-bypassed purge (#140 slice 5b)

### DIFF
--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -87,6 +87,11 @@ type ReconcileOptions struct {
 	// DefaultReconcileCapFloor. The latch rule is the conjunction of both:
 	// retract-count >= floor AND retract-count > fraction * synced-set.
 	CapFloor int
+	// BypassCap skips the safety cap for this pass. It is set by ReleaseReconcile
+	// for the operator-ack release of a latched inbox: the operator has confirmed
+	// the large removal is legitimate, so the held purge completes without
+	// re-latching. Normal (non-release) passes leave it false.
+	BypassCap bool
 }
 
 // Reconcile runs one upstream-reconciliation pass for this syncer's inbox
@@ -183,7 +188,7 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 	if floor < 1 {
 		floor = DefaultReconcileCapFloor
 	}
-	if len(gone) >= floor && float64(len(gone)) > frac*float64(syncedCount) {
+	if !opts.BypassCap && len(gone) >= floor && float64(len(gone)) > frac*float64(syncedCount) {
 		if err := s.state.SaveReconcile(s.stateKey(), ReconcileState{Suspended: true, HeldCount: len(gone)}); err != nil {
 			return 0, fmt.Errorf("imapsync: reconcile: latch: %w", err)
 		}
@@ -219,4 +224,28 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 		return removed, fmt.Errorf("imapsync: reconcile: %d of %d retraction(s) failed: %w", len(errs), len(gone), errors.Join(errs...))
 	}
 	return removed, nil
+}
+
+// ReleaseReconcile is the operator-ack release of a latched inbox (ADR 0026): it
+// clears the reconcile latch and runs one pass with the safety cap bypassed, so
+// the held retraction completes once. The operator has confirmed the large
+// removal is legitimate; after this pass, normal capped operation resumes (a new
+// anomaly would latch again). The pass re-lists the upstream, so the purge
+// reflects the source's state at release time, not a stale snapshot from when it
+// latched.
+func (s *Syncer) ReleaseReconcile(ctx context.Context, opts ReconcileOptions) (int, error) {
+	// Clear the latch first so the suspended-check in Reconcile lets the pass run;
+	// BypassCap then stops it from re-latching on the same large purge.
+	if err := s.state.SaveReconcile(s.stateKey(), ReconcileState{}); err != nil {
+		return 0, fmt.Errorf("imapsync: release: clear latch: %w", err)
+	}
+	opts.BypassCap = true
+	return s.Reconcile(ctx, opts)
+}
+
+// ReconcileLatch reports the inbox's current reconcile latch (ADR 0026) — whether
+// reconciliation is suspended and the candidate count that tripped it. The
+// operator status surface reads it to show which inboxes are held.
+func (s *Syncer) ReconcileLatch() (ReconcileState, error) {
+	return s.state.LoadReconcile(s.stateKey())
 }

--- a/internal/imapsync/reconcile_release_test.go
+++ b/internal/imapsync/reconcile_release_test.go
@@ -1,0 +1,86 @@
+package imapsync_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// Releasing a latched inbox performs the confirmed purge once and clears the
+// latch — normal capped operation then resumes (ADR 0026).
+func TestReleaseReconcilePurgesAndClears(t *testing.T) {
+	addr, syncer, store, state := syncN(t, 8)
+	for uid := uint32(1); uid <= 6; uid++ {
+		expungeUID(t, addr, uid)
+	}
+
+	_, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.ErrorIs(t, err, imapsync.ErrReconcileHeld, "the large purge latches first")
+
+	removed, err := syncer.ReleaseReconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 6, removed, "the confirmed purge completes once")
+
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 2, "the 6 gone messages are retracted; the 2 present remain")
+
+	rs, err := state.LoadReconcile("INBOX")
+	require.NoError(t, err)
+	assert.False(t, rs.Suspended, "the latch is cleared after release")
+}
+
+// Release clears the latch even when there is nothing left to purge (e.g. the
+// source has since changed) — the operator's release is honored regardless.
+func TestReleaseClearsLatchWithNothingToPurge(t *testing.T) {
+	_, syncer, store, state := syncN(t, 3) // nothing expunged
+	require.NoError(t, state.SaveReconcile("INBOX", imapsync.ReconcileState{Suspended: true, HeldCount: 9}))
+
+	removed, err := syncer.ReleaseReconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, removed, "nothing gone upstream ⇒ nothing purged")
+
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 3)
+	rs, _ := state.LoadReconcile("INBOX")
+	assert.False(t, rs.Suspended, "the latch is cleared even with nothing to purge")
+}
+
+// The release pass re-lists the upstream FRESH and purges the current gone-set,
+// not the snapshot from when it latched — so a change during the hold is
+// reflected (here, a 7th message leaves while held → release purges 7, not 6).
+// The cap is bypassed for this one pass, so the larger purge does not re-latch.
+func TestReleaseUsesFreshUpstreamState(t *testing.T) {
+	addr, syncer, store, _ := syncN(t, 8)
+	for uid := uint32(1); uid <= 6; uid++ {
+		expungeUID(t, addr, uid)
+	}
+	_, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.ErrorIs(t, err, imapsync.ErrReconcileHeld, "latched at 6")
+
+	expungeUID(t, addr, 7) // a 7th leaves the source during the hold
+
+	removed, err := syncer.ReleaseReconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 7, removed, "release re-lists and purges the CURRENT gone-set (7), not the latched snapshot (6)")
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 1, "only the still-present message (UID 8) remains")
+}
+
+// ReconcileLatch exposes the latch for the operator status surface.
+func TestReconcileLatchQuery(t *testing.T) {
+	addr, syncer, _, _ := syncN(t, 8)
+	for uid := uint32(1); uid <= 6; uid++ {
+		expungeUID(t, addr, uid)
+	}
+	_, _ = syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+
+	rs, err := syncer.ReconcileLatch()
+	require.NoError(t, err)
+	assert.True(t, rs.Suspended)
+	assert.Equal(t, 6, rs.HeldCount)
+}


### PR DESCRIPTION
## Slice 5b of #140 (ADR 0026 upstream reconciliation)

The operator-ack release half of the safety-cap latch.

### `Syncer.ReleaseReconcile(ctx, opts)`
Clears the inbox's reconcile latch and runs **one pass with the cap bypassed** over a **fresh upstream listing**, so the held retraction completes once. Key semantics (settling the release-pass review note on #147):
- **Fresh re-list, not the latched snapshot.** The release pass re-lists the upstream and purges the *current* gone-set — so a change during the hold is reflected, and a message that returned during the hold is **not** wrongly purged.
- **Cap bypassed for that one pass** (`ReconcileOptions.BypassCap`), so the confirmed large purge does not re-latch. Normal capped operation resumes after.

### `Syncer.ReconcileLatch()`
Exposes the latch (suspended + held-count) for the operator status surface (slice 6).

### Not in this slice
The admin endpoint + CLI that expose release/status, the cadence loop that activates reconcile, and the serve-log/status notification land with the serve wiring (slice 6; Telegram push tracked in #149).

### Tests
Release purges the held set + clears the latch; release clears the latch even with nothing to purge; the **fresh-relist** test — a 7th message leaves *during* the hold so release purges 7 (current gone-set), not the snapshot of 6; `ReconcileLatch` reflects a latch.

Part of #140.