### PR TITLE
feat(admin): reconcile status + release operator UX (#140 slice 7)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -101,6 +101,7 @@ type CLI struct {
 	Serve      ServeCmd      `cmd:"" help:"Run the SMTP + IMAP faces and the admin API."`
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
 	Holds      HoldsCmd      `cmd:"" help:"Inspect and decide inbound messages held for a human (ADR 0021)."`
+	Reconcile  ReconcileCmd  `cmd:"" help:"Inspect and release inboxes held by the reconcile safety cap (ADR 0026)."`
 	Filter     FilterCmd     `cmd:"" help:"Inspect the inbound filter without starting serve (ADR 0021/0022)."`
 	Telegram   TelegramCmd   `cmd:"" help:"Run the Telegram approval client (a separate admin-API client process)."`
 	DkimPubkey DkimPubkeyCmd `cmd:"" name:"dkim-pubkey" help:"Print the DKIM public-key record to pin to the agent."`
@@ -482,6 +483,57 @@ func (c *CLI) adminClient() (*admin.Client, error) {
 	return admin.NewClient(c.AdminAddr, token), nil
 }
 
+// ReconcileCmd groups the reconcile safety-cap controls (ADR 0026), each a thin
+// client of the running serve's admin API.
+type ReconcileCmd struct {
+	Status  ReconcileStatusCmd  `cmd:"" help:"List inboxes whose reconciliation the safety cap has held."`
+	Release ReconcileReleaseCmd `cmd:"" help:"Release a held inbox: confirm the large retraction and resume reconciliation."`
+}
+
+// ReconcileStatusCmd lists inboxes the reconcile safety cap has suspended.
+type ReconcileStatusCmd struct{}
+
+func (*ReconcileStatusCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	st, err := client.ReconcileStatus(context.Background())
+	if err != nil {
+		return err
+	}
+	held := 0
+	for _, s := range st {
+		if s.Suspended {
+			fmt.Printf("%s\tHELD\t%d candidate(s)\n", s.Inbox, s.HeldCount)
+			held++
+		}
+	}
+	if held == 0 {
+		fmt.Println("no inboxes are held by the reconcile safety cap")
+	}
+	return nil
+}
+
+// ReconcileReleaseCmd releases a held inbox: the operator confirms the large
+// retraction is legitimate, so it completes once and reconciliation resumes.
+type ReconcileReleaseCmd struct {
+	Inbox string `arg:"" help:"Inbox name to release."`
+}
+
+func (c *ReconcileReleaseCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	res, err := client.ReleaseReconcile(context.Background(), c.Inbox)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("released %s: retracted %d message(s)\n", res.Inbox, res.Purged)
+	return nil
+}
+
 // TelegramCmd runs the Telegram approval client — a separate long-running
 // process that is a client of the admin API (ADR 0017), not part of serve.
 type TelegramCmd struct{}
@@ -692,6 +744,33 @@ func (*ServeCmd) Run(cli *CLI) error {
 		return err
 	}
 	defer stopSync()
+
+	// Wire the reconcile safety-cap controls onto the admin surface (ADR 0026):
+	// release a latched inbox (clear + cap-bypassed purge once) and report each
+	// inbox's latch. Only when an inbox has an upstream — otherwise the endpoints
+	// report unavailable.
+	if len(syncers) > 0 {
+		svc.SetReconcileControls(
+			func(ctx context.Context, name string) (int, error) {
+				syn, ok := syncers[name]
+				if !ok {
+					return 0, fmt.Errorf("inbox %q has no upstream to reconcile", name)
+				}
+				return syn.ReleaseReconcile(ctx, imapsync.ReconcileOptions{Audit: al})
+			},
+			func() ([]admin.ReconcileStatus, error) {
+				out := make([]admin.ReconcileStatus, 0, len(syncers))
+				for name, syn := range syncers {
+					rs, lerr := syn.ReconcileLatch()
+					if lerr != nil {
+						return nil, lerr
+					}
+					out = append(out, admin.ReconcileStatus{Inbox: name, Suspended: rs.Suspended, HeldCount: rs.HeldCount})
+				}
+				return out, nil
+			},
+		)
+	}
 	// The inbound bounce-spoof guard (ADR 0024) runs ahead of the user filter on
 	// both faces, verifying with the bounce signer's own key. On by default; an
 	// explicit opt-out is logged. on_spoof=hold-for-human routes spoofs to the

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -153,3 +153,38 @@ func (c *Client) action(ctx context.Context, path string, body io.Reader) (Outco
 	}
 	return out, nil
 }
+
+// ReconcileStatus lists each inbox's reconciliation latch (ADR 0026).
+func (c *Client) ReconcileStatus(ctx context.Context) ([]ReconcileStatus, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/reconcile", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errorFrom(resp)
+	}
+	var st []ReconcileStatus
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
+// ReleaseReconcile releases a latched inbox — confirm the large retraction and
+// resume reconciliation (ADR 0026).
+func (c *Client) ReleaseReconcile(ctx context.Context, inbox string) (ReconcileReleaseResult, error) {
+	resp, err := c.request(ctx, http.MethodPost, "/reconcile/"+inbox+"/release", nil)
+	if err != nil {
+		return ReconcileReleaseResult{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ReconcileReleaseResult{}, errorFrom(resp)
+	}
+	var res ReconcileReleaseResult
+	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
+		return ReconcileReleaseResult{}, err
+	}
+	return res, nil
+}

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -41,6 +41,10 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 	mux.HandleFunc("POST /holds/{id}/expose", s.auth(s.handleExpose))
 	mux.HandleFunc("POST /holds/{id}/drop", s.auth(s.handleDrop))
 
+	// Reconcile safety-cap controls (ADR 0026): list held inboxes, release one.
+	mux.HandleFunc("GET /reconcile", s.auth(s.handleReconcileStatus))
+	mux.HandleFunc("POST /reconcile/{inbox}/release", s.auth(s.handleReconcileRelease))
+
 	s.http = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	return s, nil
 }
@@ -130,6 +134,36 @@ func (s *Server) writeHold(w http.ResponseWriter, m inbound.Message, err error) 
 		return
 	}
 	writeJSON(w, http.StatusOK, m)
+}
+
+func (s *Server) handleReconcileStatus(w http.ResponseWriter, _ *http.Request) {
+	st, err := s.svc.ReconcileStatusAll()
+	if errors.Is(err, ErrReconcileUnavailable) {
+		writeErr(w, http.StatusServiceUnavailable, err)
+		return
+	}
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	if st == nil {
+		st = []ReconcileStatus{}
+	}
+	writeJSON(w, http.StatusOK, st)
+}
+
+func (s *Server) handleReconcileRelease(w http.ResponseWriter, r *http.Request) {
+	inbox := r.PathValue("inbox")
+	n, err := s.svc.ReleaseReconcile(r.Context(), inbox)
+	if errors.Is(err, ErrReconcileUnavailable) {
+		writeErr(w, http.StatusServiceUnavailable, err)
+		return
+	}
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, ReconcileReleaseResult{Inbox: inbox, Purged: n})
 }
 
 func (s *Server) handleReject(w http.ResponseWriter, r *http.Request) {

--- a/internal/admin/reconcile_test.go
+++ b/internal/admin/reconcile_test.go
@@ -1,0 +1,66 @@
+package admin_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/backend"
+)
+
+// Without reconcile controls wired (no inbox has an upstream), both endpoints
+// report ErrReconcileUnavailable (ADR 0026).
+func TestReconcileControlsUnavailable(t *testing.T) {
+	q, _ := seedStore(t)
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+
+	_, err := svc.ReconcileStatusAll()
+	assert.ErrorIs(t, err, admin.ErrReconcileUnavailable)
+	_, err = svc.ReleaseReconcile(context.Background(), "work")
+	assert.ErrorIs(t, err, admin.ErrReconcileUnavailable)
+}
+
+// The reconcile status/release endpoints round-trip client → server → service →
+// the wired callbacks (ADR 0026).
+func TestReconcileControlsRoundtrip(t *testing.T) {
+	q, _ := seedStore(t)
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	released := ""
+	svc.SetReconcileControls(
+		func(_ context.Context, inbox string) (int, error) { released = inbox; return 4, nil },
+		func() ([]admin.ReconcileStatus, error) {
+			return []admin.ReconcileStatus{{Inbox: "work", Suspended: true, HeldCount: 9}}, nil
+		},
+	)
+	c := admin.NewClient(startServer(t, svc, "tok"), "tok")
+	ctx := context.Background()
+
+	st, err := c.ReconcileStatus(ctx)
+	require.NoError(t, err)
+	require.Len(t, st, 1)
+	assert.Equal(t, "work", st[0].Inbox)
+	assert.True(t, st[0].Suspended)
+	assert.Equal(t, 9, st[0].HeldCount)
+
+	res, err := c.ReleaseReconcile(ctx, "work")
+	require.NoError(t, err)
+	assert.Equal(t, "work", res.Inbox)
+	assert.Equal(t, 4, res.Purged)
+	assert.Equal(t, "work", released, "the release callback received the inbox name")
+}
+
+// Over HTTP, an unwired control surfaces as an error to the client (503).
+func TestReconcileUnavailableOverHTTP(t *testing.T) {
+	q, _ := seedStore(t)
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	c := admin.NewClient(startServer(t, svc, "tok"), "tok")
+	ctx := context.Background()
+
+	_, err := c.ReconcileStatus(ctx)
+	require.Error(t, err)
+	_, err = c.ReleaseReconcile(ctx, "work")
+	require.Error(t, err)
+}

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -41,6 +41,56 @@ type Service struct {
 	owner     string                    // the agent whose inbound mailbox the holds belong to
 	guard     *bounceguard.Guard        // inbound bounce-spoof guard (ADR 0024; nil = off)
 	holdSpoof bool                      // on_spoof=hold-for-human → spoofs join the held queue
+
+	// Reconcile controls (ADR 0026), wired by serve over its per-inbox syncers;
+	// nil when no inbox has an upstream (nothing to reconcile).
+	reconcileRelease func(ctx context.Context, inbox string) (int, error)
+	reconcileStatus  func() ([]ReconcileStatus, error)
+}
+
+// ReconcileStatus reports one inbox's reconciliation latch (ADR 0026): whether
+// the safety cap has it suspended, and the candidate count that tripped it.
+type ReconcileStatus struct {
+	Inbox     string `json:"inbox"`
+	Suspended bool   `json:"suspended"`
+	HeldCount int    `json:"held_count"`
+}
+
+// ReconcileReleaseResult is the outcome of releasing a latched inbox (ADR 0026).
+type ReconcileReleaseResult struct {
+	Inbox  string `json:"inbox"`
+	Purged int    `json:"purged"`
+}
+
+// ErrReconcileUnavailable is returned by the reconcile controls when no inbox has
+// an upstream syncer, so there is nothing to reconcile or release.
+var ErrReconcileUnavailable = errors.New("admin: reconcile control not available (no upstream inbox configured)")
+
+// SetReconcileControls wires the reconcile release/status callbacks (ADR 0026).
+// serve supplies them over its per-inbox syncers; without them the endpoints
+// report ErrReconcileUnavailable.
+func (s *Service) SetReconcileControls(release func(context.Context, string) (int, error), status func() ([]ReconcileStatus, error)) {
+	s.reconcileRelease = release
+	s.reconcileStatus = status
+}
+
+// ReleaseReconcile releases a latched inbox (ADR 0026): the operator confirms the
+// large retraction is legitimate; the held purge completes once and capped
+// reconciliation resumes. Returns the number retracted.
+func (s *Service) ReleaseReconcile(ctx context.Context, inbox string) (int, error) {
+	if s.reconcileRelease == nil {
+		return 0, ErrReconcileUnavailable
+	}
+	return s.reconcileRelease(ctx, inbox)
+}
+
+// ReconcileStatusAll lists every inbox's reconciliation latch (ADR 0026) so the
+// operator can discover which inboxes are held.
+func (s *Service) ReconcileStatusAll() ([]ReconcileStatus, error) {
+	if s.reconcileStatus == nil {
+		return nil, ErrReconcileUnavailable
+	}
+	return s.reconcileStatus()
 }
 
 // NewService wires the approval service. inbox and signer may be nil only when


### PR DESCRIPTION
Slice 7 of #140 (ADR 0026 upstream reconciliation) — the final slice: the operator pull surface for the safety-cap latch.

Admin service: SetReconcileControls wires release/status callbacks over serve's per-inbox syncers; ReconcileStatusAll / ReleaseReconcile, returning an unavailable sentinel when no inbox has an upstream.

Admin API + client: GET /reconcile (each inbox's latch) + POST /reconcile/{inbox}/release (clear the latch + one cap-bypassed pass = the confirmed purge once), mirrored in the client.

CLI: darbaan reconcile status (lists held inboxes + counts) and darbaan reconcile release <inbox> (confirm the large retraction and resume).

Serve wiring installs the controls over its syncers (release audits via the shared log), skipped when no inbox has an upstream — so a latched inbox is always operator-releasable before reconcile runs in prod.

Notification: agreed v1 is pull (reconcile status) + serve-log alert; push tracked as #149.

Tests: unavailable sentinel when unwired; HTTP round-trip for status + release; unwired surfaces as a client error.

Closes #140.