### PR TITLE
fix(reconcile): release refuses a non-held inbox (#154)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -756,7 +756,11 @@ func (*ServeCmd) Run(cli *CLI) error {
 				if !ok {
 					return 0, fmt.Errorf("inbox %q has no upstream to reconcile", name)
 				}
-				return syn.ReleaseReconcile(ctx, imapsync.ReconcileOptions{Audit: al})
+				n, rerr := syn.ReleaseReconcile(ctx, imapsync.ReconcileOptions{Audit: al})
+				if errors.Is(rerr, imapsync.ErrReconcileNotHeld) {
+					return 0, admin.ErrReconcileNotHeld // → 409 at the API
+				}
+				return n, rerr
 			},
 			func() ([]admin.ReconcileStatus, error) {
 				out := make([]admin.ReconcileStatus, 0, len(syncers))

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -159,6 +159,10 @@ func (s *Server) handleReconcileRelease(w http.ResponseWriter, r *http.Request) 
 		writeErr(w, http.StatusServiceUnavailable, err)
 		return
 	}
+	if errors.Is(err, ErrReconcileNotHeld) {
+		writeErr(w, http.StatusConflict, err) // not held → nothing to release
+		return
+	}
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, err)
 		return

--- a/internal/admin/reconcile_test.go
+++ b/internal/admin/reconcile_test.go
@@ -64,3 +64,18 @@ func TestReconcileUnavailableOverHTTP(t *testing.T) {
 	_, err = c.ReleaseReconcile(ctx, "work")
 	require.Error(t, err)
 }
+
+// Releasing a non-held inbox surfaces as an error to the client (the service
+// returns ErrReconcileNotHeld → 409).
+func TestReconcileReleaseNotHeldOverHTTP(t *testing.T) {
+	q, _ := seedStore(t)
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetReconcileControls(
+		func(_ context.Context, _ string) (int, error) { return 0, admin.ErrReconcileNotHeld },
+		func() ([]admin.ReconcileStatus, error) { return nil, nil },
+	)
+	c := admin.NewClient(startServer(t, svc, "tok"), "tok")
+
+	_, err := c.ReleaseReconcile(context.Background(), "work")
+	require.Error(t, err)
+}

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -66,6 +66,11 @@ type ReconcileReleaseResult struct {
 // an upstream syncer, so there is nothing to reconcile or release.
 var ErrReconcileUnavailable = errors.New("admin: reconcile control not available (no upstream inbox configured)")
 
+// ErrReconcileNotHeld is returned by ReleaseReconcile when the inbox is not held
+// by the safety cap — there is nothing to release. serve translates the syncer's
+// equivalent error into this so the API can answer 409 (conflict) rather than 500.
+var ErrReconcileNotHeld = errors.New("admin: inbox is not held by the reconcile safety cap (nothing to release)")
+
 // SetReconcileControls wires the reconcile release/status callbacks (ADR 0026).
 // serve supplies them over its per-inbox syncers; without them the endpoints
 // report ErrReconcileUnavailable.

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -31,6 +31,12 @@ const DefaultReconcileCapFloor = 5
 // with errors.Is and reports it as held, not as an error.
 var ErrReconcileHeld = errors.New("imapsync: reconcile held: cap exceeded, awaiting operator release")
 
+// ErrReconcileNotHeld is returned by ReleaseReconcile when the inbox is not
+// latched — there is nothing to release. The guard matters because release runs
+// CAP-BYPASSED: releasing a non-held inbox would purge the current gone-set with
+// no safety cap, so release refuses unless the cap is actually holding it.
+var ErrReconcileNotHeld = errors.New("imapsync: inbox is not held by the safety cap (nothing to release)")
+
 // ListUpstreamUIDs returns the inbox mailbox's current UIDVALIDITY and the full
 // set of UIDs present upstream right now. It is the authoritative present-set
 // that upstream reconciliation (ADR 0026) diffs against the synced store to find
@@ -234,6 +240,16 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 // reflects the source's state at release time, not a stale snapshot from when it
 // latched.
 func (s *Syncer) ReleaseReconcile(ctx context.Context, opts ReconcileOptions) (int, error) {
+	// Refuse to release an inbox that is not actually held: release runs the pass
+	// cap-bypassed, so releasing a non-held inbox would purge with no safety cap.
+	// Only a real latch may be released (ErrReconcileNotHeld otherwise).
+	rs, err := s.state.LoadReconcile(s.stateKey())
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: release: load latch: %w", err)
+	}
+	if !rs.Suspended {
+		return 0, ErrReconcileNotHeld
+	}
 	// Clear the latch first so the suspended-check in Reconcile lets the pass run;
 	// BypassCap then stops it from re-latching on the same large purge.
 	if err := s.state.SaveReconcile(s.stateKey(), ReconcileState{}); err != nil {

--- a/internal/imapsync/reconcile_guard_test.go
+++ b/internal/imapsync/reconcile_guard_test.go
@@ -1,0 +1,33 @@
+package imapsync_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// Release refuses a non-held inbox. Without the guard, release runs cap-bypassed,
+// so releasing an inbox the cap never latched would purge a large gone-set with
+// no safety check — release must require an actual latch first (#154).
+func TestReleaseRejectsNonHeld(t *testing.T) {
+	addr, syncer, store, state := syncN(t, 8)
+	for uid := uint32(1); uid <= 6; uid++ {
+		expungeUID(t, addr, uid) // a large removal — but the inbox was never latched
+	}
+
+	removed, err := syncer.ReleaseReconcile(context.Background(), imapsync.ReconcileOptions{})
+	assert.ErrorIs(t, err, imapsync.ErrReconcileNotHeld)
+	assert.Zero(t, removed, "release on a non-held inbox purges nothing")
+
+	msgs, _ := store.List("agent", inbound.DefaultInbox)
+	assert.Len(t, msgs, 8, "no cap-bypassed purge on a non-held inbox")
+
+	rs, err := state.LoadReconcile("INBOX")
+	require.NoError(t, err)
+	assert.False(t, rs.Suspended, "a refused release leaves the (unset) latch untouched")
+}


### PR DESCRIPTION
## #154 — release-guard before the v0.6.0 cut

`ReleaseReconcile` runs the pass **cap-bypassed**, so releasing an inbox the safety cap never latched would purge the current gone-set with no cap — a footgun once reconcile is enabled on a real inbox.

### Fix
Release now checks the latch first and refuses unless the inbox is actually suspended.
- **imapsync**: a `Suspended` precheck at the top of `ReleaseReconcile` → `ErrReconcileNotHeld` (the real guard — the cap-bypass can't fire on a non-held inbox even off the admin path).
- **admin**: `ErrReconcileNotHeld` → **409 Conflict** on `POST /reconcile/{inbox}/release`; serve translates the syncer's error to the admin sentinel.

### Tests
- imapsync: a non-held inbox with a large removal (6 of 8 gone) is **not** purged by release — `ErrReconcileNotHeld`, store intact (the footgun is closed).
- admin: releasing a non-held inbox surfaces as a client error (409).

Closes #154.