### PR TITLE
ci: release-please uses a PAT so tags + release PRs trigger workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
+          # Use a PAT instead of the default GITHUB_TOKEN. Events made with
+          # GITHUB_TOKEN do not trigger further workflows (GitHub's
+          # anti-recursion rule), which suppressed two things: the release PR's
+          # CI never ran (so the required check was absent and the PR could not
+          # merge without an admin override), and the release tag did not fire
+          # the image publish. A PAT acts as a real account, so the release PR
+          # gets its CI run and the tag triggers tag-gated workflows.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: go
           # No custom release-rules — the action's defaults match the
           # conventional-commits type→bump table the fleet follows.


### PR DESCRIPTION
## What
release-please now uses a PAT (`secrets.RELEASE_PLEASE_TOKEN`) instead of the default GITHUB_TOKEN.

## Why
Events made with GITHUB_TOKEN do not trigger further workflows (GitHub's anti-recursion rule). Two consequences hit while cutting v0.6.0:
- The release PR's CI never ran, so the required status check was absent and the PR could not merge without an admin override.
- The release tag did not fire the image-publish workflow, so it had to be run manually.

A PAT acts as a real account: the release PR gets its CI run (mergeable on reviews alone) and the tag triggers the tag-gated publish automatically. `docker-publish` already triggers on `push: tags: ['v*']`, so no change is needed there.

## Operator action required BEFORE merge
Add a repo secret **`RELEASE_PLEASE_TOKEN`** holding a PAT with `contents: write` + `pull-requests: write` (classic-PAT equivalent: `repo` + `workflow`). Without the secret present, the action would receive an empty token, so add the secret first, then merge.
