### PR TITLE
refactor: structured logging with log/slog (#151)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -16,7 +16,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -98,6 +98,9 @@ type CLI struct {
 	ApprovalStrict []string `name:"approval-strict" default:"manual" help:"Approver chain for the strict path."`
 	ApprovalLight  []string `name:"approval-light" default:"manual" help:"Approver chain for the light path."`
 
+	LogLevel  string `name:"log-level" default:"info" enum:"debug,info,warn,error" help:"Log verbosity."`
+	LogFormat string `name:"log-format" default:"text" enum:"text,json" help:"Log handler: text (human-readable) or json (structured ingest)."`
+
 	Serve      ServeCmd      `cmd:"" help:"Run the SMTP + IMAP faces and the admin API."`
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
 	Holds      HoldsCmd      `cmd:"" help:"Inspect and decide inbound messages held for a human (ADR 0021)."`
@@ -116,7 +119,28 @@ func main() {
 	}
 	ctx, err := parser.Parse(os.Args[1:])
 	parser.FatalIfErrorf(err)
+	parser.FatalIfErrorf(cli.setupLogging())
 	ctx.FatalIfErrorf(ctx.Run(&cli))
+}
+
+// setupLogging builds the structured logger from --log-level/--log-format and
+// installs it as the slog default, so every subcommand (and every component that
+// falls back to slog.Default()) logs through it.
+func (c *CLI) setupLogging() error {
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(c.LogLevel)); err != nil {
+		return fmt.Errorf("log-level: %w", err)
+	}
+	opts := &slog.HandlerOptions{Level: level}
+	var h slog.Handler
+	switch c.LogFormat {
+	case "json":
+		h = slog.NewJSONHandler(os.Stderr, opts)
+	default: // "text"
+		h = slog.NewTextHandler(os.Stderr, opts)
+	}
+	slog.SetDefault(slog.New(h))
+	return nil
 }
 
 func (c *CLI) router() *policy.Router {
@@ -306,6 +330,9 @@ func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore)
 		pass := inboxIMAPPassword(in.Name)
 		dial := imapsync.Dialer(in.Backend.IMAPHost, in.Backend.IMAPUsername, pass)
 		syn := imapsync.New(dial, mailbox, cli.AgentUsername, in.Name, store, state, maxAge)
+		// Per-inbox structured logger (#151): every sync/reconcile record this
+		// syncer emits is tagged with its inbox.
+		syn.SetLogger(slog.Default().With("inbox", in.Name))
 		// Gmail label write-through (ADR 0020 20c): capability-gated, harmless on a
 		// non-Gmail backend (reports not-supported → WriteKeywords uses plain keywords).
 		syn.SetLabelStore(imapsync.RawGmailLabelStore(in.Backend.IMAPHost, in.Backend.IMAPUsername, pass, mailbox))
@@ -372,28 +399,28 @@ func imapKeywordWriter(syncers map[string]*imapsync.Syncer) listener.KeywordWrit
 // cancelled. Sync errors are logged, never fatal — a flaky or unreachable
 // upstream must not take down serve.
 func (cli *CLI) runSyncLoop(ctx context.Context, inbox string, syncer *imapsync.Syncer) {
-	fmt.Fprintf(os.Stderr, "darbaan: inbound sync for inbox %q every %s\n", inbox, cli.InboundIMAPPollInterval)
+	slog.Info("inbound sync loop started", "inbox", inbox, "interval", cli.InboundIMAPPollInterval.String())
 	t := time.NewTicker(cli.InboundIMAPPollInterval)
 	defer t.Stop()
-	runSync(ctx, syncer) // initial pull at startup
+	runSync(ctx, inbox, syncer) // initial pull at startup
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			runSync(ctx, syncer)
+			runSync(ctx, inbox, syncer)
 		}
 	}
 }
 
-func runSync(ctx context.Context, s *imapsync.Syncer) {
+func runSync(ctx context.Context, inbox string, s *imapsync.Syncer) {
 	n, err := s.Sync(ctx)
 	if err != nil {
-		log.Printf("darbaan: inbound sync: %v", err)
+		slog.Error("inbound sync failed", "inbox", inbox, "err", err)
 		return
 	}
 	if n > 0 {
-		log.Printf("darbaan: inbound sync pulled %d new message(s)", n)
+		slog.Info("inbound sync pulled messages", "inbox", inbox, "count", n)
 	}
 }
 
@@ -447,7 +474,7 @@ func reconcileTargets(inboxes []inboxcfg.Inbox, syncers map[string]*imapsync.Syn
 // cancelled (ADR 0026). Like the sync loop, errors are logged, never fatal — a
 // flaky upstream or a held cap must not take down serve.
 func (cli *CLI) runReconcileLoop(ctx context.Context, t reconcileTarget) {
-	fmt.Fprintf(os.Stderr, "darbaan: reconcile for inbox %q every %s\n", t.inbox, t.interval)
+	slog.Info("reconcile loop started", "inbox", t.inbox, "interval", t.interval.String())
 	tk := time.NewTicker(t.interval)
 	defer tk.Stop()
 	runReconcile(ctx, t) // initial pass at startup
@@ -465,11 +492,13 @@ func runReconcile(ctx context.Context, t reconcileTarget) {
 	n, err := t.syncer.Reconcile(ctx, t.opts)
 	switch {
 	case errors.Is(err, imapsync.ErrReconcileHeld):
-		log.Printf("darbaan: reconcile for inbox %q HELD by the safety cap; awaiting operator release", t.inbox)
+		// The syncer logs the "reconcile held" event once on the transition; this
+		// per-cycle line stays at debug so a held inbox does not spam the log.
+		slog.Debug("reconcile still held", "inbox", t.inbox)
 	case err != nil:
-		log.Printf("darbaan: reconcile for inbox %q: %v", t.inbox, err)
+		slog.Error("reconcile failed", "inbox", t.inbox, "err", err)
 	case n > 0:
-		log.Printf("darbaan: reconcile for inbox %q retracted %d message(s)", t.inbox, n)
+		slog.Info("reconcile retracted messages", "inbox", t.inbox, "count", n)
 	}
 }
 
@@ -547,6 +576,7 @@ func (*TelegramCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
+	tc.SetLogger(slog.Default().With("component", "telegram"))
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 	return tc.Run(ctx)
@@ -783,7 +813,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if cli.BounceGuardEnabled {
 		guard = bounceguard.New(sgn.Verify)
 	} else {
-		fmt.Fprintln(os.Stderr, "darbaan: bounce-spoof guard DISABLED (bounce-guard-enabled=false)")
+		slog.Warn("bounce-spoof guard disabled", "reason", "bounce-guard-enabled=false")
 	}
 	holdSpoof := cli.BounceGuardOnSpoof == "hold-for-human"
 	// The admin hold-for-human queue and the read face share one filter + owner +
@@ -805,7 +835,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// Run one sync poll loop per inbox with an upstream (shared shutdown ctx;
 	// errors logged, never fatal).
 	if len(syncers) == 0 {
-		fmt.Fprintln(os.Stderr, "darbaan: inbound sync disabled (no inbox has an upstream configured)")
+		slog.Info("inbound sync disabled", "reason", "no inbox has an upstream configured")
 	}
 	for name, syn := range syncers {
 		go cli.runSyncLoop(ctx, name, syn)
@@ -817,7 +847,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	for _, in := range inboxes {
 		if in.ReconcileEnabled {
 			if _, ok := syncers[in.Name]; !ok {
-				fmt.Fprintf(os.Stderr, "darbaan: reconcile enabled for inbox %q but it has no upstream — not running\n", in.Name)
+				slog.Warn("reconcile enabled but inbox has no upstream; not running", "inbox", in.Name)
 			}
 		}
 	}
@@ -846,8 +876,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	go func() { errs <- ignoreClosed(imapSrv.ListenAndServe(cli.IMAPAddr)) }()
 	go func() { errs <- ignoreClosed(adminSrv.ListenAndServe()) }()
 
-	fmt.Fprintf(os.Stderr, "darbaan: SMTP on %s, IMAP on %s, admin on %s\n",
-		cli.ListenerAddr, cli.IMAPAddr, cli.AdminAddr)
+	slog.Info("serve listening", "smtp", cli.ListenerAddr, "imap", cli.IMAPAddr, "admin", cli.AdminAddr)
 
 	// Return on the first server to exit; close the rest and drain them.
 	err = <-errs

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"sort"
 	"strings"
 	"time"
@@ -30,6 +30,7 @@ type Syncer struct {
 	state      StateStore
 	maxAge     time.Duration  // recency cutoff; 0 = no cutoff (ADR 0008)
 	labelStore LabelStoreFunc // Gmail X-GM-LABELS writer; nil = plain keywords only (ADR 0020)
+	logger     *slog.Logger   // structured logger; defaults to slog.Default(), injectable via SetLogger
 }
 
 // SetLabelStore installs the Gmail X-GM-LABELS label writer (ADR 0020 20c). When
@@ -37,11 +38,20 @@ type Syncer struct {
 // (capability-gated) and falls back to plain keywords elsewhere.
 func (s *Syncer) SetLabelStore(fn LabelStoreFunc) { s.labelStore = fn }
 
+// SetLogger injects the structured logger for this syncer (ADR 0026 #151). serve
+// passes a per-inbox logger (logger.With("inbox", name)) so every sync/reconcile
+// record is tagged with its inbox; unset falls back to slog.Default().
+func (s *Syncer) SetLogger(l *slog.Logger) {
+	if l != nil {
+		s.logger = l
+	}
+}
+
 // New builds a Syncer. owner is the agent the synced mail belongs to; inbox is the
 // named inbox this syncer feeds (ADR 0023; empty reads as DefaultInbox). maxAge is
 // the recency cutoff for the initial/full sync (0 = pull everything).
 func New(dial DialFunc, mailbox, owner, inbox string, store inbound.InboundStore, state StateStore, maxAge time.Duration) *Syncer {
-	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, inbox: inbox, store: store, state: state, maxAge: maxAge}
+	return &Syncer{dial: dial, mailbox: mailbox, owner: owner, inbox: inbox, store: store, state: state, maxAge: maxAge, logger: slog.Default()}
 }
 
 // stateKey is the sync-cursor key for this syncer's inbox. The default inbox uses
@@ -380,7 +390,7 @@ func (s *Syncer) WriteKeywords(owner, inbox, id string, add, remove []string) er
 func (s *Syncer) reconcileKeywords() {
 	dirty, err := s.store.DirtyKeywords(s.owner, s.inbox)
 	if err != nil {
-		log.Printf("darbaan: keyword reconcile list: %v", err)
+		s.logger.Warn("keyword reconcile: list dirty failed", "err", err)
 		return
 	}
 	for _, m := range dirty {
@@ -389,11 +399,11 @@ func (s *Syncer) reconcileKeywords() {
 		// upstream). Deliberate — acceptable for the add-dominated labeling flow;
 		// the deferred convergent read-side / go-imap upstream swap cleans it up.
 		if err := s.WriteKeywords(s.owner, s.inbox, m.ID, m.Keywords, nil); err != nil {
-			log.Printf("darbaan: keyword reconcile %s deferred: %v", m.ID, err)
+			s.logger.Warn("keyword reconcile deferred", "id", m.ID, "err", err)
 			continue
 		}
 		if err := s.store.ClearKeywordsDirty(s.owner, s.inbox, m.ID); err != nil {
-			log.Printf("darbaan: keyword reconcile clear %s: %v", m.ID, err)
+			s.logger.Warn("keyword reconcile: clear dirty failed", "id", m.ID, "err", err)
 		}
 	}
 }

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/emersion/go-imap/v2"
 
@@ -198,8 +197,9 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 		if err := s.state.SaveReconcile(s.stateKey(), ReconcileState{Suspended: true, HeldCount: len(gone)}); err != nil {
 			return 0, fmt.Errorf("imapsync: reconcile: latch: %w", err)
 		}
-		log.Printf("darbaan: reconcile HELD for inbox %q: a pass would retract %d of %d synced messages (cap %.0f%%); suspended pending operator release",
-			inbound.NormInbox(s.inbox), len(gone), syncedCount, frac*100)
+		// Structured "reconcile held" event — the hook for the #149 latch-push
+		// notification. The inbox is carried by the injected per-inbox logger.
+		s.logger.Warn("reconcile held", "candidates", len(gone), "synced", syncedCount, "cap_fraction", frac)
 		return 0, ErrReconcileHeld
 	}
 

--- a/internal/imapsync/reconcile_log_test.go
+++ b/internal/imapsync/reconcile_log_test.go
@@ -1,0 +1,45 @@
+package imapsync_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+)
+
+// The cap latch emits a structured "reconcile held" event through the injected
+// logger — carrying the inbox (from the injected per-inbox logger) plus the
+// candidate/synced/cap attrs. This is the hook the #149 latch-push consumes, and
+// it demonstrates the logger is injectable/testable (#151).
+func TestReconcileHeldEmitsStructuredEvent(t *testing.T) {
+	addr, syncer, _, _ := syncN(t, 8)
+	for uid := uint32(1); uid <= 6; uid++ {
+		expungeUID(t, addr, uid)
+	}
+
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	syncer.SetLogger(slog.New(h).With("inbox", "work"))
+
+	_, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.ErrorIs(t, err, imapsync.ErrReconcileHeld)
+
+	var rec map[string]any
+	for _, ln := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		var m map[string]any
+		if json.Unmarshal(ln, &m) == nil && m["msg"] == "reconcile held" {
+			rec = m
+		}
+	}
+	require.NotNil(t, rec, "a structured 'reconcile held' record is emitted")
+	assert.Equal(t, "WARN", rec["level"])
+	assert.Equal(t, "work", rec["inbox"], "inbox comes from the injected per-inbox logger")
+	assert.Equal(t, float64(6), rec["candidates"])
+	assert.Equal(t, float64(8), rec["synced"])
+}

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -109,7 +109,7 @@ func (s *bboltStore) sweepOrphans() error {
 		return err
 	}
 	if n > 0 {
-		log.Printf("darbaan: inbound reclaimed %d orphan blob(s) at startup", n)
+		slog.Info("inbound reclaimed orphan blobs at startup", "count", n)
 	}
 	return nil
 }
@@ -360,7 +360,7 @@ func (s *bboltStore) RemoveSynced(owner, inbox, id string) error {
 		// Best-effort: a present record's blob. Delete is idempotent (a missing blob
 		// is not an error); a real failure only orphans it for the next sweep.
 		if err := s.blobs.Delete(id); err != nil {
-			log.Printf("darbaan: inbound retract %s: blob delete failed (orphan, will be swept): %v", id, err)
+			slog.Warn("inbound retract: blob delete failed (orphan, will be swept)", "id", id, "err", err)
 		}
 	}
 	return nil

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -6,7 +6,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"sort"
 	"strconv"
@@ -193,7 +193,7 @@ func (s *imapSession) guardHides(m inbound.Message, inbox string) bool {
 		return fm.Raw, e
 	})
 	if err != nil {
-		log.Printf("darbaan imap: bounce-guard %s: %v", m.ID, err)
+		slog.Warn("imap bounce-guard check failed", "id", m.ID, "err", err)
 	}
 	if !spoof {
 		return false
@@ -420,7 +420,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 				// their labels are local-only, nothing to replicate.
 				if s.writeKeywords != nil && m.UpstreamUID != 0 {
 					if err := s.writeKeywords(s.owner, s.selectedInbox, m.ID, added, removed); err != nil {
-						log.Printf("darbaan: imap keyword write-through for %s deferred: %v", m.ID, err)
+						slog.Warn("imap keyword write-through deferred", "id", m.ID, "err", err)
 					} else {
 						_ = s.store.ClearKeywordsDirty(s.owner, s.selectedInbox, m.ID)
 					}
@@ -557,7 +557,7 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 		// — but log it: a skipped candidate is a silently-missing result.
 		ok, err := matchSearch(seqNum, m, criteria, s.rawResolver(*m))
 		if err != nil {
-			log.Printf("darbaan: imap search skipped message %s: %v", m.ID, err)
+			slog.Warn("imap search skipped message", "id", m.ID, "err", err)
 			continue
 		}
 		if !ok {

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -3,7 +3,7 @@ package sluice
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -100,7 +100,7 @@ func (s *bboltStore) sweepOrphans() error {
 		return err
 	}
 	if n > 0 {
-		log.Printf("darbaan: sluice reclaimed %d orphan blob(s) at startup", n)
+		slog.Info("sluice reclaimed orphan blobs at startup", "count", n)
 	}
 	return nil
 }
@@ -114,7 +114,7 @@ func (s *bboltStore) Close() error { return s.db.Close() }
 // (ADR 0011, #17 trade-off).
 func (s *bboltStore) writeAudit(rec audit.Record) {
 	if err := s.audit.Append(rec); err != nil {
-		log.Printf("darbaan: best-effort audit append failed for message %s (%s): %v", rec.MessageID, rec.Event, err)
+		slog.Warn("best-effort audit append failed", "message_id", rec.MessageID, "event", rec.Event, "err", err)
 	}
 }
 

--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -3,7 +3,6 @@ package telegram
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/go-telegram/bot"
@@ -19,7 +18,7 @@ import (
 func (c *Client) pollHolds(ctx context.Context) {
 	held, err := c.admin.HeldList(ctx)
 	if err != nil {
-		log.Printf("darbaan telegram: poll holds: %v", err)
+		c.logger.Error("telegram poll holds failed", "err", err)
 		return
 	}
 	c.prunePostedHolds(held)
@@ -28,7 +27,7 @@ func (c *Client) pollHolds(ctx context.Context) {
 			continue
 		}
 		if err := c.notifyHold(ctx, m); err != nil {
-			log.Printf("darbaan telegram: notify hold %s: %v", m.ID, err)
+			c.logger.Warn("telegram notify hold failed", "id", m.ID, "err", err)
 			continue
 		}
 		c.markPostedHold(m.ID)

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -49,10 +49,20 @@ type Client struct {
 	operatorID   int64
 	pollInterval time.Duration
 
+	logger *slog.Logger // structured logger; defaults to slog.Default(), injectable via SetLogger
+
 	mu          sync.Mutex
 	posted      map[string]bool     // sluice message ids already sent to the operator
 	postedHolds map[string]bool     // inbound-hold ids already sent (separate id space)
 	pending     map[int]rejectState // reject reason prompts awaiting the operator's reply, keyed by prompt message id
+}
+
+// SetLogger injects the structured logger for the Telegram client (#151);
+// unset falls back to slog.Default().
+func (c *Client) SetLogger(l *slog.Logger) {
+	if l != nil {
+		c.logger = l
+	}
 }
 
 // rejectState remembers, for a reason force-reply prompt, which held message it
@@ -95,6 +105,7 @@ func New(token string, operatorID int64, pollInterval time.Duration, adminClient
 		admin:        adminClient,
 		operatorID:   operatorID,
 		pollInterval: pollInterval,
+		logger:       slog.Default(),
 		posted:       make(map[string]bool),
 		postedHolds:  make(map[string]bool),
 		pending:      make(map[int]rejectState),
@@ -117,7 +128,7 @@ func (c *Client) Run(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("telegram: connect: %w", err)
 	}
-	log.Printf("darbaan telegram: ready — bot @%s, operator %d, polling the queue every %s", me.Username, c.operatorID, c.pollInterval)
+	c.logger.Info("telegram client ready", "bot", me.Username, "operator", c.operatorID, "poll_interval", c.pollInterval.String())
 
 	go c.pollLoop(ctx)
 	c.bot.Start(ctx) // long-poll loop; returns when ctx is cancelled
@@ -146,7 +157,7 @@ func (c *Client) pollLoop(ctx context.Context) {
 func (c *Client) poll(ctx context.Context) {
 	metas, err := c.admin.List(ctx)
 	if err != nil {
-		log.Printf("darbaan telegram: poll: %v", err)
+		c.logger.Error("telegram poll failed", "err", err)
 		return
 	}
 	c.prunePosted(metas)
@@ -155,7 +166,7 @@ func (c *Client) poll(ctx context.Context) {
 			continue
 		}
 		if err := c.notify(ctx, m); err != nil {
-			log.Printf("darbaan telegram: notify %s: %v", m.ID, err)
+			c.logger.Warn("telegram notify failed", "id", m.ID, "err", err)
 			continue
 		}
 		c.markPosted(m.ID)
@@ -168,7 +179,7 @@ func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
 	// fetch failure still notifies, falling back to the envelope values.
 	raw, err := c.admin.Show(ctx, m.ID)
 	if err != nil {
-		log.Printf("darbaan telegram: fetch body %s: %v", m.ID, err)
+		c.logger.Warn("telegram fetch body failed", "id", m.ID, "err", err)
 	}
 	from, to, headerSet, parsed := headerAddrs(raw)
 	if from == "" {
@@ -245,7 +256,7 @@ func (c *Client) sendAttachments(ctx context.Context, queueID string, anchorID i
 			params.ReplyParameters = &models.ReplyParameters{MessageID: anchorID}
 		}
 		if _, err := c.bot.SendDocument(ctx, params); err != nil {
-			log.Printf("darbaan telegram: upload attachment %s: %v", a.filename, err)
+			c.logger.Warn("telegram upload attachment failed", "filename", a.filename, "err", err)
 		}
 	}
 }
@@ -273,7 +284,7 @@ func (c *Client) sendFullBody(ctx context.Context, queueID string, anchorID int,
 		return
 	}
 	if len(data) > maxUpload {
-		log.Printf("darbaan telegram: full body %s too large to attach (%d bytes)", queueID, len(data))
+		c.logger.Warn("telegram full body too large to attach", "id", queueID, "bytes", len(data))
 		return
 	}
 	params := &bot.SendDocumentParams{
@@ -285,7 +296,7 @@ func (c *Client) sendFullBody(ctx context.Context, queueID string, anchorID int,
 		params.ReplyParameters = &models.ReplyParameters{MessageID: anchorID}
 	}
 	if _, err := c.bot.SendDocument(ctx, params); err != nil {
-		log.Printf("darbaan telegram: upload full body %s: %v", queueID, err)
+		c.logger.Warn("telegram upload full body failed", "id", queueID, "err", err)
 	}
 }
 
@@ -490,7 +501,7 @@ func (c *Client) isOperator(cq *models.CallbackQuery) bool {
 
 // denyCallback rejects a callback from anyone but the operator.
 func (c *Client) denyCallback(ctx context.Context, b *bot.Bot, cq *models.CallbackQuery) {
-	log.Printf("darbaan telegram: ignored callback from non-operator %d", cq.From.ID)
+	c.logger.Warn("telegram ignored callback from non-operator", "from", cq.From.ID)
 	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
 		CallbackQueryID: cq.ID, Text: "Not authorized.", ShowAlert: true,
 	})
@@ -522,7 +533,7 @@ func (c *Client) editResult(ctx context.Context, b *bot.Bot, chatID int64, msgID
 		Text:        result,
 		ReplyMarkup: emptyKeyboard(),
 	})
-	log.Printf("darbaan telegram: %s", result)
+	c.logger.Info("telegram decision result", "result", result)
 }
 
 // handleRejectPermanent / handleRejectRetryable are the two reject buttons; both
@@ -564,7 +575,7 @@ func (c *Client) promptReason(ctx context.Context, b *bot.Bot, cq *models.Callba
 		},
 	})
 	if err != nil {
-		log.Printf("darbaan telegram: reject prompt %s: %v", id, err)
+		c.logger.Warn("telegram reject prompt failed", "id", id, "err", err)
 		// Dismiss the spinner so the button doesn't hang on a network error.
 		_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{
 			CallbackQueryID: cq.ID, Text: "Could not start the reason prompt.",


### PR DESCRIPTION
## #151 — structured logging with log/slog

Migrates operational logging from stdlib `log.Printf` + `fmt.Fprintf(os.Stderr)` to leveled, structured `slog`. Stdlib only, no third-party dep, **no behavior change** (all existing tests pass unchanged).

### The seam
`main` builds a `*slog.Logger` from two new flags and installs it as the slog default:
- `--log-level` (debug|info|warn|error, default info)
- `--log-format` (text|json, default text)

Every subcommand — and every component that falls back to `slog.Default()` — logs through it.

### Injection
- **imapsync Syncer** carries a per-inbox logger (`logger.With("inbox", name)`), so every sync/reconcile record is inbox-tagged. `SetLogger` makes it injectable/testable.
- **Telegram client** is tagged `component=telegram`, also via `SetLogger`.
- **Leaf/best-effort lines** (sluice + inbound orphan-sweep / best-effort audit-append fail; the IMAP handler's best-effort errors) use the configured `slog.Default()` rather than rippling the store/session constructors + every store test — matching the agreed call for non-per-inbox lines.

### The #149 hook
The reconcile cap-latch log is now a structured **`reconcile held`** event (attrs: `candidates`, `synced`, `cap_fraction`, plus `inbox` from the injected logger) — the clean event the #149 latch-push will consume. Tested: a capturing handler asserts the structured record + attrs.

### Fields to attrs
`inbox`, `id`, `event`, `count`, `err`, etc. Secrets are never logged (the Telegram token stays out; only the bot username + operator id appear).

### Not converted
The two `queue ls` / `holds ls` empty-state messages stay as CLI output (not operational logs).

Closes #151.