### PR TITLE
feat(admin,telegram): Change-sender at the approval gate (#139)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -749,6 +749,16 @@ func (*ServeCmd) Run(cli *CLI) error {
 	}
 	svc.SetSenders(senders)
 
+	// The configured inbox send identities feed the Change-sender picker + the
+	// ApproveAs From-rewrite (ADR 0023 slice 5). Only inboxes with an identity.
+	identities := make(map[string]string, len(inboxes))
+	for _, in := range inboxes {
+		if in.Identity != "" {
+			identities[in.Name] = in.Identity
+		}
+	}
+	svc.SetInboxIdentities(identities)
+
 	// One local service hosts both agent faces (ADR 0001): SMTP submission
 	// (outbound trap) and IMAP read (the agent reads its bounces). The submission
 	// face routes each From to an inbox (ADR 0023): matched Identity → that inbox,

--- a/internal/admin/change_sender.go
+++ b/internal/admin/change_sender.go
@@ -1,0 +1,73 @@
+package admin
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"sort"
+
+	"github.com/emersion/go-message/textproto"
+
+	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// ErrUnknownInbox is returned by ApproveAs when the requested inbox is not a
+// configured inbox with a send identity.
+var ErrUnknownInbox = errors.New("admin: unknown inbox (no configured send identity)")
+
+// InboxIdentity pairs a configured inbox name with its send identity (ADR 0023).
+type InboxIdentity struct {
+	Name     string `json:"name"`
+	Identity string `json:"identity"`
+}
+
+// SetInboxIdentities installs the per-inbox send identities (ADR 0023 slice 5):
+// the identities the operator may re-pick at approval time, and the address
+// ApproveAs rewrites From to. serve builds it from the configured inboxes; only
+// inboxes with a non-empty identity are eligible.
+func (s *Service) SetInboxIdentities(m map[string]string) { s.identities = m }
+
+// Inboxes lists the configured inboxes that have a send identity (ADR 0023 slice
+// 5), sorted by name — the operator's Change-sender choices.
+func (s *Service) Inboxes() []InboxIdentity {
+	out := make([]InboxIdentity, 0, len(s.identities))
+	for name, id := range s.identities {
+		if id != "" {
+			out = append(out, InboxIdentity{Name: inbound.NormInbox(name), Identity: id})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// sendBody returns the bytes that would be sent for a message: the human-amended
+// body if one was released (ADR 0004), else the original raw.
+func sendBody(m sluice.Message) []byte {
+	if m.Released != nil {
+		return m.Released
+	}
+	return m.Raw
+}
+
+// rewriteFrom returns raw with its From header replaced by identity, preserving
+// the message BODY byte-for-byte (ADR 0025): it re-reads only the header block via
+// textproto, sets From, then re-appends the original body untouched — no MIME
+// re-encode, so attachments/structure are unchanged.
+func rewriteFrom(raw []byte, identity string) ([]byte, error) {
+	br := bufio.NewReader(bytes.NewReader(raw))
+	hdr, err := textproto.ReadHeader(br)
+	if err != nil {
+		return nil, err
+	}
+	hdr.Set("From", identity)
+	var buf bytes.Buffer
+	if err := textproto.WriteHeader(&buf, hdr); err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(&buf, br); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/admin/change_sender_internal_test.go
+++ b/internal/admin/change_sender_internal_test.go
@@ -1,0 +1,39 @@
+package admin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rewriteFrom replaces the From header and leaves every other header + the body
+// untouched.
+func TestRewriteFrom(t *testing.T) {
+	raw := []byte("From: assistant@x.test\r\nTo: d@y.test\r\nSubject: hi\r\n\r\nbody line 1\r\nbody line 2\r\n")
+	out, err := rewriteFrom(raw, "personal@y.test")
+	require.NoError(t, err)
+	s := string(out)
+	assert.Contains(t, s, "From: personal@y.test")
+	assert.NotContains(t, s, "assistant@x.test")
+	assert.Contains(t, s, "Subject: hi")
+	assert.Contains(t, s, "body line 1\r\nbody line 2\r\n")
+}
+
+// The MIME body is preserved byte-for-byte (ADR 0025): only the top-level From
+// header changes; the multipart body — including a "From " line inside it — is
+// unchanged.
+func TestRewriteFromPreservesBody(t *testing.T) {
+	body := "--b\r\nContent-Type: text/plain\r\n\r\nreply; a From: line inside the body must stay\r\n--b--\r\n"
+	raw := []byte("From: assistant@x.test\r\nMIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary=b\r\n\r\n" + body)
+
+	out, err := rewriteFrom(raw, "personal@y.test")
+	require.NoError(t, err)
+
+	_, gotBody, found := strings.Cut(string(out), "\r\n\r\n")
+	require.True(t, found)
+	assert.Equal(t, body, gotBody, "body preserved byte-for-byte")
+	assert.Contains(t, string(out), "From: personal@y.test")
+	assert.NotContains(t, string(out), "assistant@x.test")
+}

--- a/internal/admin/change_sender_test.go
+++ b/internal/admin/change_sender_test.go
@@ -1,0 +1,101 @@
+package admin_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/backend"
+	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/sluice"
+)
+
+// ApproveAs sends via the chosen inbox's sender, rewrites both the envelope and
+// the header From to that inbox's identity, and leaves the stored record as
+// submitted (ADR 0023 slice 5).
+func TestApproveAsSendsFromChosenIdentity(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: inbound.DefaultInbox, From: "assistant@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: assistant@x.test\r\nTo: d@y.test\r\nSubject: hi\r\n\r\nbody\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	var sentVia string
+	var sent sluice.Message
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(msg sluice.Message) error { sentVia = "default"; sent = msg; return nil }),
+		"work":               senderFunc(func(msg sluice.Message) error { sentVia = "work"; sent = msg; return nil }),
+	})
+	svc.SetInboxIdentities(map[string]string{inbound.DefaultInbox: "default@x.test", "work": "work@x.test"})
+
+	out, err := svc.ApproveAs(context.Background(), m.ID, "work")
+	require.NoError(t, err)
+	assert.Equal(t, string(sluice.StatusSent), out.Status)
+	assert.Equal(t, "work", sentVia, "sent via the chosen inbox's sender")
+	assert.Equal(t, "work@x.test", sent.From, "envelope MAIL FROM rewritten to the chosen identity")
+	assert.Contains(t, string(sent.Released), "From: work@x.test", "header From rewritten in the sent body")
+	assert.NotContains(t, string(sent.Released), "assistant@x.test")
+
+	stored, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "assistant@x.test", stored.From, "the stored record keeps the original From (send-time rewrite only)")
+}
+
+func TestApproveAsUnknownInbox(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", From: "a@x.test", Rcpt: []string{"d@y.test"}, Raw: []byte("From: a@x.test\r\n\r\nb\r\n")})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetInboxIdentities(map[string]string{inbound.DefaultInbox: "d@x.test"})
+
+	_, err = svc.ApproveAs(context.Background(), m.ID, "nope")
+	assert.ErrorIs(t, err, admin.ErrUnknownInbox)
+}
+
+// Inboxes lists only inboxes with a non-empty identity, sorted by name.
+func TestInboxesList(t *testing.T) {
+	q, _ := seedStore(t)
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetInboxIdentities(map[string]string{"work": "w@x.test", "default": "d@x.test", "recv-only": ""})
+
+	got := svc.Inboxes()
+	require.Len(t, got, 2, "only inboxes with a send identity")
+	assert.Equal(t, "default", got[0].Name)
+	assert.Equal(t, "work", got[1].Name)
+}
+
+// GET /inboxes and POST /queue/{id}/approve-as/{inbox} round-trip through the
+// client → server → service (ADR 0023 slice 5).
+func TestChangeSenderRoundtrip(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", From: "assistant@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: assistant@x.test\r\nTo: d@y.test\r\n\r\nbody\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	var sentVia string
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { sentVia = "default"; return nil }),
+		"work":               senderFunc(func(sluice.Message) error { sentVia = "work"; return nil }),
+	})
+	svc.SetInboxIdentities(map[string]string{inbound.DefaultInbox: "default@x.test", "work": "work@x.test"})
+	c := admin.NewClient(startServer(t, svc, "tok"), "tok")
+	ctx := context.Background()
+
+	ids, err := c.Inboxes(ctx)
+	require.NoError(t, err)
+	require.Len(t, ids, 2)
+
+	out, err := c.ApproveAs(ctx, m.ID, "work")
+	require.NoError(t, err)
+	assert.Equal(t, string(sluice.StatusSent), out.Status)
+	assert.Equal(t, "work", sentVia)
+}

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -89,6 +89,30 @@ func (c *Client) Approve(ctx context.Context, id string) (Outcome, error) {
 	return c.action(ctx, "/queue/"+id+"/approve", nil)
 }
 
+// ApproveAs approves a held message and sends it from the given inbox's identity
+// (ADR 0023 slice 5).
+func (c *Client) ApproveAs(ctx context.Context, id, inbox string) (Outcome, error) {
+	return c.action(ctx, "/queue/"+id+"/approve-as/"+inbox, nil)
+}
+
+// Inboxes lists the configured inbox identities for the Change-sender picker
+// (ADR 0023 slice 5).
+func (c *Client) Inboxes(ctx context.Context) ([]InboxIdentity, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/inboxes", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errorFrom(resp)
+	}
+	var out []InboxIdentity
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // Reject rejects a held message with a reason.
 func (c *Client) Reject(ctx context.Context, id, reason string, retryable bool) (Outcome, error) {
 	body, _ := json.Marshal(map[string]any{"reason": reason, "retryable": retryable})

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -33,7 +33,11 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 	mux.HandleFunc("GET /queue", s.auth(s.handleList))
 	mux.HandleFunc("GET /queue/{id}", s.auth(s.handleShow))
 	mux.HandleFunc("POST /queue/{id}/approve", s.auth(s.handleApprove))
+	mux.HandleFunc("POST /queue/{id}/approve-as/{inbox}", s.auth(s.handleApproveAs))
 	mux.HandleFunc("POST /queue/{id}/reject", s.auth(s.handleReject))
+
+	// Configured inbox identities for the Change-sender picker (ADR 0023 slice 5).
+	mux.HandleFunc("GET /inboxes", s.auth(s.handleInboxes))
 
 	// Inbound hold-for-human queue (ADR 0021): expose = show to the agent, drop =
 	// keep hidden.
@@ -100,6 +104,19 @@ func (s *Server) handleShow(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request) {
 	out, err := s.svc.ApproveID(r.Context(), r.PathValue("id"))
 	writeAction(w, out, err)
+}
+
+func (s *Server) handleApproveAs(w http.ResponseWriter, r *http.Request) {
+	out, err := s.svc.ApproveAs(r.Context(), r.PathValue("id"), r.PathValue("inbox"))
+	if errors.Is(err, ErrUnknownInbox) {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeAction(w, out, err)
+}
+
+func (s *Server) handleInboxes(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.svc.Inboxes())
 }
 
 func (s *Server) handleHeldList(w http.ResponseWriter, _ *http.Request) {

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"time"
 
@@ -31,16 +32,17 @@ type Signer interface {
 
 // Service runs the approval orchestration against the stores serve owns.
 type Service struct {
-	store     sluice.MessageStore
-	inbox     inbound.InboundStore
-	senders   map[string]backend.Sender // per-inbox upstream sender (ADR 0023), keyed by inbox name
-	signer    Signer
-	router    *policy.Router
-	domain    string
-	filters   map[string]*filter.Filter // per-inbox filter for the hold-for-human queue (ADR 0021/0023)
-	owner     string                    // the agent whose inbound mailbox the holds belong to
-	guard     *bounceguard.Guard        // inbound bounce-spoof guard (ADR 0024; nil = off)
-	holdSpoof bool                      // on_spoof=hold-for-human → spoofs join the held queue
+	store      sluice.MessageStore
+	inbox      inbound.InboundStore
+	senders    map[string]backend.Sender // per-inbox upstream sender (ADR 0023), keyed by inbox name
+	identities map[string]string         // per-inbox send identity (ADR 0023 slice 5), keyed by inbox name; for ApproveAs
+	signer     Signer
+	router     *policy.Router
+	domain     string
+	filters    map[string]*filter.Filter // per-inbox filter for the hold-for-human queue (ADR 0021/0023)
+	owner      string                    // the agent whose inbound mailbox the holds belong to
+	guard      *bounceguard.Guard        // inbound bounce-spoof guard (ADR 0024; nil = off)
+	holdSpoof  bool                      // on_spoof=hold-for-human → spoofs join the held queue
 
 	// Reconcile controls (ADR 0026), wired by serve over its per-inbox syncers;
 	// nil when no inbox has an upstream (nothing to reconcile).
@@ -289,8 +291,28 @@ func (s *Service) decide(ctx context.Context, id string, human approver.Verdict)
 	}
 }
 
-// ApproveID approves a held message: commit, then send (downstream of commit).
+// ApproveID approves a held message and sends it as submitted, via its stamped
+// inbox's sender (ADR 0023). ApproveAs sends it from a chosen inbox's identity.
 func (s *Service) ApproveID(ctx context.Context, id string) (Outcome, error) {
+	return s.approve(ctx, id, "")
+}
+
+// ApproveAs approves a held message and sends it from asInbox's identity (ADR
+// 0023 slice 5, #139): the envelope MAIL FROM and the From header are rewritten
+// to that inbox's identity and the send is routed through that inbox's Sender.
+// asInbox must be a configured inbox that has an identity. The persisted record
+// keeps the message as submitted (send-time rewrite only); the chosen identity is
+// recorded in a structured log event.
+func (s *Service) ApproveAs(ctx context.Context, id, asInbox string) (Outcome, error) {
+	return s.approve(ctx, id, asInbox)
+}
+
+// approve commits the approve verdict, then sends downstream of the commit. When
+// asInbox is empty the message is sent as-stamped via its own inbox's sender;
+// otherwise its From (envelope + header) is rewritten to asInbox's identity and
+// it is sent via asInbox's sender — the send-time rewrite never mutates the
+// stored record.
+func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, error) {
 	m, err := s.decide(ctx, id, approver.Verdict{Disposition: approver.Approve})
 	if err != nil {
 		return Outcome{}, err
@@ -300,16 +322,37 @@ func (s *Service) ApproveID(ctx context.Context, id string) (Outcome, error) {
 	}
 	out := Outcome{ID: m.ID, Status: string(sluice.StatusApproved), Detail: fmt.Sprintf("approved by %s", m.DecidedBy)}
 
-	sendErr := s.senderFor(m.Inbox).Send(ctx, m) // deliver via the message's inbox's sender (ADR 0023)
+	sendInbox, sendMsg := m.Inbox, m
+	var identity string
+	if asInbox != "" {
+		identity = s.identities[inbound.NormInbox(asInbox)]
+		if identity == "" {
+			return Outcome{}, fmt.Errorf("%w: %q", ErrUnknownInbox, asInbox)
+		}
+		rewritten, rwErr := rewriteFrom(sendBody(m), identity)
+		if rwErr != nil {
+			return Outcome{}, fmt.Errorf("admin: rewrite From to %q: %w", identity, rwErr)
+		}
+		sendInbox = asInbox
+		sendMsg.From = identity      // envelope MAIL FROM
+		sendMsg.Released = rewritten // the sender prefers Released over Raw (send-time only)
+		slog.Info("approved-as", "message_id", m.ID, "inbox", inbound.NormInbox(asInbox), "identity", identity)
+	}
+
+	sendErr := s.senderFor(sendInbox).Send(ctx, sendMsg)
 	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr)
 	if rerr != nil {
 		return Outcome{}, rerr
 	}
 	out.Status = string(final.Status)
 
+	sentDetail := "approved and sent upstream"
+	if identity != "" {
+		sentDetail = "approved and sent upstream as " + identity
+	}
 	switch {
 	case sendErr == nil:
-		out.Detail = "approved and sent upstream"
+		out.Detail = sentDetail
 	case isSendPending(sendErr):
 		out.Detail = "approved; no real Sender configured — nothing left Darbaan"
 	case backend.IsPermanent(sendErr):

--- a/internal/telegram/change_sender_internal_test.go
+++ b/internal/telegram/change_sender_internal_test.go
@@ -1,0 +1,39 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+func TestParseApproveAs(t *testing.T) {
+	inbox, id, ok := parseApproveAs("approve_as:work:42")
+	require.True(t, ok)
+	assert.Equal(t, "work", inbox)
+	assert.Equal(t, "42", id)
+
+	// The id is the final ":"-separated field, so an inbox name containing ":"
+	// still parses correctly.
+	inbox, id, ok = parseApproveAs("approve_as:od:d:7")
+	require.True(t, ok)
+	assert.Equal(t, "od:d", inbox)
+	assert.Equal(t, "7", id)
+
+	_, _, ok = parseApproveAs("approve_as:noid")
+	assert.False(t, ok)
+}
+
+// The identity picker offers one approve-as button per identity, plus a Back.
+func TestIdentityKeyboard(t *testing.T) {
+	c := &Client{identities: []admin.InboxIdentity{{Name: "work", Identity: "w@x"}, {Name: "personal", Identity: "p@x"}}}
+	var data []string
+	for _, row := range c.identityKeyboard("42").InlineKeyboard {
+		for _, b := range row {
+			data = append(data, b.CallbackData)
+		}
+	}
+	assert.Equal(t, []string{"approve_as:work:42", "approve_as:personal:42", "chg_back:42"}, data)
+}

--- a/internal/telegram/format_internal_test.go
+++ b/internal/telegram/format_internal_test.go
@@ -35,7 +35,8 @@ func TestDisplaySubject(t *testing.T) {
 }
 
 func TestDecisionKeyboard(t *testing.T) {
-	kb := decisionKeyboard("42")
+	// A single identity (N=1) omits Change: plain Approve + the two rejects.
+	kb := (&Client{identities: []admin.InboxIdentity{{Name: "default", Identity: "d@x"}}}).decisionKeyboard("42")
 	var labels, data []string
 	for _, row := range kb.InlineKeyboard {
 		for _, b := range row {
@@ -43,10 +44,19 @@ func TestDecisionKeyboard(t *testing.T) {
 			data = append(data, b.CallbackData)
 		}
 	}
-	// All three decision buttons, each carrying its action + the message id.
 	assert.Len(t, labels, 3)
 	assert.Equal(t, []string{"approve:42", "reject_perm:42", "reject_retry:42"}, data)
 	assert.Contains(t, strings.Join(labels, "|"), "Approve")
+
+	// Two identities → a Change sender button appears.
+	kb2 := (&Client{identities: []admin.InboxIdentity{{Name: "a", Identity: "a@x"}, {Name: "b", Identity: "b@x"}}}).decisionKeyboard("42")
+	var data2 []string
+	for _, row := range kb2.InlineKeyboard {
+		for _, b := range row {
+			data2 = append(data2, b.CallbackData)
+		}
+	}
+	assert.Contains(t, data2, "change:42")
 }
 
 func TestDecisionResult(t *testing.T) {

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -40,6 +40,11 @@ const (
 	// drop = keep hidden.
 	cbExpose = "expose:"
 	cbDrop   = "drop:"
+	// Change-sender (ADR 0023 slice 5, #139): change opens the identity picker,
+	// approve_as approves-and-sends from a chosen inbox, back returns to Approve.
+	cbChange     = "change:"
+	cbApproveAs  = "approve_as:"
+	cbChangeBack = "chg_back:"
 )
 
 // Client is the Telegram approval interface.
@@ -50,6 +55,11 @@ type Client struct {
 	pollInterval time.Duration
 
 	logger *slog.Logger // structured logger; defaults to slog.Default(), injectable via SetLogger
+
+	// identities are the configured inbox send identities (ADR 0023 slice 5),
+	// fetched from serve at startup; the Change-sender picker offers them. Read-only
+	// after Run's initial fetch, so no lock is needed.
+	identities []admin.InboxIdentity
 
 	mu          sync.Mutex
 	posted      map[string]bool     // sluice message ids already sent to the operator
@@ -116,6 +126,11 @@ func New(token string, operatorID int64, pollInterval time.Duration, adminClient
 	// Inbound hold-for-human decisions (ADR 0021).
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbExpose, bot.MatchTypePrefix, c.handleExpose)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbDrop, bot.MatchTypePrefix, c.handleDrop)
+	// Change-sender picker (ADR 0023 slice 5). Prefixes are non-overlapping:
+	// "approve_as:" is not prefixed by "approve:", "chg_back:" not by "change:".
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbApproveAs, bot.MatchTypePrefix, c.handleApproveAs)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbChangeBack, bot.MatchTypePrefix, c.handleChangeBack)
+	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbChange, bot.MatchTypePrefix, c.handleChange)
 	// The reason force-reply arrives as a normal reply message, not a callback.
 	b.RegisterHandlerMatchFunc(isReply, c.handleReasonReply)
 	return c, nil
@@ -129,6 +144,14 @@ func (c *Client) Run(ctx context.Context) error {
 		return fmt.Errorf("telegram: connect: %w", err)
 	}
 	c.logger.Info("telegram client ready", "bot", me.Username, "operator", c.operatorID, "poll_interval", c.pollInterval.String())
+
+	// Fetch the configured inbox identities for the Change-sender picker (ADR 0023
+	// slice 5); best-effort — without them the gate simply omits Change.
+	if ids, ierr := c.admin.Inboxes(ctx); ierr != nil {
+		c.logger.Warn("telegram fetch inbox identities failed; change-sender disabled", "err", ierr)
+	} else {
+		c.identities = ids
+	}
 
 	go c.pollLoop(ctx)
 	c.bot.Start(ctx) // long-poll loop; returns when ctx is cancelled
@@ -209,7 +232,7 @@ func (c *Client) notify(ctx context.Context, m sluice.Meta) error {
 	sent, err := c.bot.SendMessage(ctx, &bot.SendMessageParams{
 		ChatID:      c.operatorID,
 		Text:        text,
-		ReplyMarkup: decisionKeyboard(m.ID),
+		ReplyMarkup: c.decisionKeyboard(m.ID),
 	})
 	if err != nil {
 		return err
@@ -413,18 +436,36 @@ func attachmentsLine(atts []attachment) string {
 	return "attachments: " + strings.Join(parts, ", ")
 }
 
-// decisionKeyboard lays in all three decision buttons; the callback data carries
-// the action + message id (handled by handleApprove / handleReject*).
-func decisionKeyboard(id string) models.InlineKeyboardMarkup {
-	return models.InlineKeyboardMarkup{
-		InlineKeyboard: [][]models.InlineKeyboardButton{
-			{{Text: "Approve", CallbackData: cbApprove + id}},
-			{
-				{Text: "Reject (permanent)", CallbackData: cbRejectPerm + id},
-				{Text: "Reject (retryable)", CallbackData: cbRejectRetry + id},
-			},
-		},
+// decisionKeyboard lays in the decision buttons; the callback data carries the
+// action + message id (handled by handleApprove / handleReject*). Change-sender
+// is offered only when there is more than one identity to pick from (N=1 → plain
+// Approve, ADR 0023 slice 5).
+func (c *Client) decisionKeyboard(id string) models.InlineKeyboardMarkup {
+	rows := [][]models.InlineKeyboardButton{
+		{{Text: "Approve", CallbackData: cbApprove + id}},
 	}
+	if len(c.identities) >= 2 {
+		rows = append(rows, []models.InlineKeyboardButton{{Text: "Change sender", CallbackData: cbChange + id}})
+	}
+	rows = append(rows, []models.InlineKeyboardButton{
+		{Text: "Reject (permanent)", CallbackData: cbRejectPerm + id},
+		{Text: "Reject (retryable)", CallbackData: cbRejectRetry + id},
+	})
+	return models.InlineKeyboardMarkup{InlineKeyboard: rows}
+}
+
+// identityKeyboard is the Change-sender picker: one button per configured inbox
+// identity (approve-and-send as that identity), plus a Back to the decision
+// buttons (ADR 0023 slice 5).
+func (c *Client) identityKeyboard(id string) models.InlineKeyboardMarkup {
+	rows := make([][]models.InlineKeyboardButton, 0, len(c.identities)+1)
+	for _, in := range c.identities {
+		rows = append(rows, []models.InlineKeyboardButton{
+			{Text: in.Identity, CallbackData: cbApproveAs + in.Name + ":" + id},
+		})
+	}
+	rows = append(rows, []models.InlineKeyboardButton{{Text: "« Back", CallbackData: cbChangeBack + id}})
+	return models.InlineKeyboardMarkup{InlineKeyboard: rows}
 }
 
 // handleApprove is the [Approve] button callback: verify the operator, approve
@@ -441,6 +482,75 @@ func (c *Client) handleApprove(ctx context.Context, b *bot.Bot, update *models.U
 	}
 	out, err := c.admin.Approve(ctx, id)
 	c.finishDecision(ctx, b, cq, "Approved", id, out, err)
+}
+
+// handleChange swaps the decision keyboard for the identity picker so the
+// operator can approve-and-send from a chosen inbox (ADR 0023 slice 5).
+func (c *Client) handleChange(ctx context.Context, b *bot.Bot, update *models.Update) {
+	cq := update.CallbackQuery
+	if !c.isOperator(cq) {
+		c.denyCallback(ctx, b, cq)
+		return
+	}
+	id := strings.TrimPrefix(cq.Data, cbChange)
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID})
+	if msg := cq.Message.Message; msg != nil {
+		_, _ = b.EditMessageReplyMarkup(ctx, &bot.EditMessageReplyMarkupParams{
+			ChatID:      msg.Chat.ID,
+			MessageID:   msg.ID,
+			ReplyMarkup: c.identityKeyboard(id),
+		})
+	}
+}
+
+// handleChangeBack restores the decision keyboard from the identity picker.
+func (c *Client) handleChangeBack(ctx context.Context, b *bot.Bot, update *models.Update) {
+	cq := update.CallbackQuery
+	if !c.isOperator(cq) {
+		c.denyCallback(ctx, b, cq)
+		return
+	}
+	id := strings.TrimPrefix(cq.Data, cbChangeBack)
+	_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID})
+	if msg := cq.Message.Message; msg != nil {
+		_, _ = b.EditMessageReplyMarkup(ctx, &bot.EditMessageReplyMarkupParams{
+			ChatID:      msg.Chat.ID,
+			MessageID:   msg.ID,
+			ReplyMarkup: c.decisionKeyboard(id),
+		})
+	}
+}
+
+// handleApproveAs is an identity-picker button: approve-and-send the message from
+// the chosen inbox's identity (ADR 0023 slice 5).
+func (c *Client) handleApproveAs(ctx context.Context, b *bot.Bot, update *models.Update) {
+	cq := update.CallbackQuery
+	if !c.isOperator(cq) {
+		c.denyCallback(ctx, b, cq)
+		return
+	}
+	inbox, id, ok := parseApproveAs(cq.Data)
+	if !ok {
+		_, _ = b.AnswerCallbackQuery(ctx, &bot.AnswerCallbackQueryParams{CallbackQueryID: cq.ID})
+		return
+	}
+	if !c.guardPending(ctx, b, cq, id) {
+		return
+	}
+	out, err := c.admin.ApproveAs(ctx, id, inbox)
+	c.finishDecision(ctx, b, cq, "Approved", id, out, err)
+}
+
+// parseApproveAs splits an approve_as callback ("approve_as:<inbox>:<id>") into
+// its inbox and (numeric) id. The id is the final ":"-separated field, so an
+// inbox name containing ":" is still handled.
+func parseApproveAs(data string) (inbox, id string, ok bool) {
+	rest := strings.TrimPrefix(data, cbApproveAs)
+	i := strings.LastIndex(rest, ":")
+	if i < 0 {
+		return "", "", false
+	}
+	return rest[:i], rest[i+1:], true
 }
 
 // guardPending pre-checks a tapped message's status so a stale duplicate tap is


### PR DESCRIPTION
## #139 — multi-inbox slice 5: Change-sender at the approval gate (ADR 0023)

The held-message Telegram gate gains **Approve** + **Change**. Change lists the configured inbox identities; selecting one **approves-and-sends from that identity** via that inbox's backend Sender (slice 4b). N=1 (≤1 identity) omits Change — plain Approve. Motivated by a real incident: a reply went from the wrong identity because the gate offered no switch at approval time.

### admin
- `ApproveAs(id, inbox)`: approve, then send **from that inbox's identity** — the envelope MAIL FROM **and** the `From:` header are rewritten to the identity, and the send routes through that inbox's Sender.
- **Body preserved byte-for-byte**: the From rewrite is surgical (textproto — replace the header, re-append the original body untouched), so MIME/attachment bodies (ADR 0025) are unchanged, no re-encode. No new dependency (go-message already present).
- **Persist-original**: the stored record keeps the message as submitted (send-time rewrite only). The chosen identity is recorded in a structured `approved-as` slog event (message_id, inbox, identity) — now that #157 landed.
- **No wrong-identity re-send path**: `decide()` rejects any non-Pending message and `Approve` is one-shot, so a re-send must re-enter the gate (another Change opportunity), never silently auto-send the original.
- `GET /inboxes` lists the identities; `POST /queue/{id}/approve-as/{inbox}`; unknown inbox → `ErrUnknownInbox` (400).

### telegram
- `[Change sender]` on the gate keyboard (only when there's more than one identity) opens the identity picker; picking one calls approve-as, **Back** returns to Approve. Identities are fetched from serve at startup — serve is the single source of truth, no config drift with the telegram process.

### Tests
rewriteFrom (+ MIME body preserved byte-for-byte); ApproveAs sends via the chosen sender with envelope+header From rewritten and the stored record unchanged; unknown-inbox error; Inboxes list; http round-trip (client→server); parseApproveAs (incl. inbox names containing `:`); the identity picker + N=1-omits-Change keyboard.

Closes #139.