### PR TITLE
feat(agents): multi-agent config schema + per-agent auth (ADR 0027 slice 1)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/agentcfg"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/bounceguard"
@@ -218,6 +219,47 @@ func (c *CLI) resolveInboxes() ([]inboxcfg.Inbox, error) {
 		return nil, err
 	}
 	return inboxes, nil
+}
+
+// resolvePrincipals resolves the configured agent principals (ADR 0027): the
+// `agents:` list, each a login with per-inbox grants and a password read from
+// DARBAAN_AGENT_<NAME>_PASSWORD (ADR 0012). With no `agents:` list it returns a
+// single implicit agent authenticated by DARBAAN_AGENT_PASS, granted every inbox
+// read+send — the back-compat single-agent path, unchanged. Grants are validated
+// here; their enforcement (read/send scoping) lands in a later increment.
+func (c *CLI) resolvePrincipals(inboxes []inboxcfg.Inbox) ([]listener.Principal, error) {
+	data, err := c.configBytes()
+	if err != nil {
+		return nil, err
+	}
+	agents, err := agentcfg.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(agents) == 0 {
+		pass := os.Getenv("DARBAAN_AGENT_PASS")
+		if c.AgentUsername == "" || pass == "" {
+			return nil, errors.New("set agent-username (config/flag/DARBAAN_AGENT_USERNAME) and DARBAAN_AGENT_PASS")
+		}
+		return []listener.Principal{{Name: c.AgentUsername, Password: pass}}, nil
+	}
+	inboxNames := make(map[string]bool, len(inboxes))
+	for _, in := range inboxes {
+		inboxNames[in.Name] = true
+	}
+	if err := agentcfg.Validate(agents, inboxNames); err != nil {
+		return nil, err
+	}
+	principals := make([]listener.Principal, 0, len(agents))
+	for _, a := range agents {
+		env := agentcfg.PasswordEnv(a.Name)
+		pass := os.Getenv(env)
+		if pass == "" {
+			return nil, fmt.Errorf("agent %q: set %s (the password is supplied out-of-band, never in config — ADR 0012)", a.Name, env)
+		}
+		principals = append(principals, listener.Principal{Name: a.Name, Password: pass})
+	}
+	return principals, nil
 }
 
 // openInbound opens the inbound (served mailbox) store per config.
@@ -663,17 +705,6 @@ func (*VersionCmd) Run() error {
 type ServeCmd struct{}
 
 func (*ServeCmd) Run(cli *CLI) error {
-	// The password is a secret supplied at startup, kept in memory only; full
-	// at-rest encryption (age) lands with the deployment/secrets component
-	// (ADR 0012). Config carries only the username reference, never the secret.
-	cred := listener.Credential{
-		Username: cli.AgentUsername,
-		Password: os.Getenv("DARBAAN_AGENT_PASS"),
-	}
-	if cred.Username == "" || cred.Password == "" {
-		return errors.New("set agent-username (config/flag/DARBAAN_AGENT_USERNAME) and DARBAAN_AGENT_PASS")
-	}
-
 	var tlsConfig *tls.Config
 	if cli.ListenerTLSCert != "" || cli.ListenerTLSKey != "" {
 		cert, err := tls.LoadX509KeyPair(cli.ListenerTLSCert, cli.ListenerTLSKey)
@@ -740,6 +771,18 @@ func (*ServeCmd) Run(cli *CLI) error {
 		filters[in.Name] = f
 	}
 
+	// Resolve the agent principals (ADR 0027): the `agents:` list, each a login
+	// with per-inbox grants and a password from DARBAAN_AGENT_<NAME>_PASSWORD; or,
+	// with no `agents:`, a single implicit agent (DARBAAN_AGENT_PASS) granted every
+	// inbox — the back-compat single-agent path. The secret is kept in memory only
+	// (ADR 0012). Grants are validated here; their enforcement lands in a later
+	// increment.
+	principals, err := cli.resolvePrincipals(inboxes)
+	if err != nil {
+		return err
+	}
+	auth := listener.NewAuth(principals)
+
 	// One upstream sender per inbox (ADR 0023): an approved message is delivered
 	// via the sender of the inbox it was submitted as. At N=1 this is the legacy
 	// sender under the default inbox.
@@ -771,7 +814,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Domain:        cli.ListenerDomain,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, q, route)
+	}, auth, q, route)
 	if err != nil {
 		return err
 	}
@@ -834,7 +877,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, cred, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof)
+	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof)
 	if err != nil {
 		return err
 	}

--- a/internal/agentcfg/agentcfg.go
+++ b/internal/agentcfg/agentcfg.go
@@ -1,0 +1,223 @@
+// Package agentcfg is the multi-agent tenancy config schema (ADR 0027): the
+// `agents:` list that sits beside `inboxes:` (ADR 0023). Each agent is a login
+// principal with a per-inbox grant list ({read, send}); its password is supplied
+// out-of-band via env, never in config (ADR 0012). Sharing an inbox is expressed
+// by listing it under more than one agent; privacy is omission — an inbox absent
+// from an agent's grants is invisible to it.
+//
+// A config with no `agents:` list yields a single implicit agent (built by the
+// caller) granted read+send on every inbox, so an existing single-agent
+// deployment is unchanged (opt-in, exactly like `inboxes:`).
+//
+// This increment is schema + validation + per-agent authentication. Grant
+// ENFORCEMENT — IMAP read-scoping and SMTP send-scoping — lands in the later
+// increments; here the schema is parsed, validated, and each agent's default
+// inbox resolved, but access is not yet gated.
+package agentcfg
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/yaad-index/darbaan/internal/inboxcfg"
+)
+
+// Access is one direction an agent may be granted on an inbox (ADR 0027).
+const (
+	AccessRead = "read"
+	AccessSend = "send"
+)
+
+// Grant is an agent's access to one inbox: the inbox name and the directions
+// granted (a subset of {read, send}). Default marks this grant's inbox as the
+// agent's default_inbox — sugar for the top-level DefaultInbox field.
+type Grant struct {
+	Inbox   string   `yaml:"inbox"`
+	Access  []string `yaml:"access"`
+	Default bool     `yaml:"default"`
+}
+
+// Agent is one login principal (ADR 0027). The password is never a field — it is
+// read from the env var named by PasswordEnv(Name), per ADR 0012.
+type Agent struct {
+	Name         string  `yaml:"name"`
+	DefaultInbox string  `yaml:"default_inbox"`
+	Grants       []Grant `yaml:"grants"`
+}
+
+type fileConfig struct {
+	Agents []Agent `yaml:"agents"`
+}
+
+// Parse reads the `agents:` list from a config document. An absent or empty
+// `agents:` yields nil — the caller substitutes the single implicit agent.
+func Parse(data []byte) ([]Agent, error) {
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("agentcfg: parse: %w", err)
+	}
+	return fc.Agents, nil
+}
+
+// PasswordEnv is the env var an agent's Darbaan password is read from (ADR 0012):
+// DARBAAN_AGENT_<NAME>_PASSWORD, where <NAME> is mangled by the shared
+// inboxcfg.EnvPrefix rule (uppercased, every rune outside [A-Z0-9] → '_'). It is
+// the single source of truth for the mangle; Validate's collision guard calls it,
+// so a runtime lookup and the load-time check can never diverge. The mangle is
+// many-to-one, which is why Validate rejects agent names that collide on it.
+func PasswordEnv(name string) string {
+	return "DARBAAN_AGENT_" + inboxcfg.EnvPrefix(name) + "_PASSWORD"
+}
+
+// HasAccess reports whether the grant includes the given direction.
+func (g Grant) HasAccess(dir string) bool {
+	for _, a := range g.Access {
+		if a == dir {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate checks an agent list against the configured inbox names: unique agent
+// names, unique password-env names (the many-to-one mangle must not silently
+// share a secret), and, per agent, a non-empty well-formed grant set whose
+// inboxes all exist, plus exactly one resolvable default_inbox with read access
+// (ADR 0027). inboxNames is the set of configured inbox names (ADR 0023).
+func Validate(agents []Agent, inboxNames map[string]bool) error {
+	if len(agents) == 0 {
+		return fmt.Errorf("agentcfg: no agents configured")
+	}
+	seen := make(map[string]bool, len(agents))
+	envSeen := make(map[string]string, len(agents)) // password-env → first agent name
+	for i, a := range agents {
+		name := strings.TrimSpace(a.Name)
+		if name == "" {
+			return fmt.Errorf("agentcfg: agent %d: name is required", i+1)
+		}
+		if seen[name] {
+			return fmt.Errorf("agentcfg: duplicate agent name %q", name)
+		}
+		seen[name] = true
+		// The password env binding is many-to-one (e.g. "a-b" and "a_b" both mangle
+		// to DARBAAN_AGENT_A_B_PASSWORD), so a collision would silently share one
+		// secret — reject it at load (ADR 0027).
+		env := PasswordEnv(name)
+		if other, dup := envSeen[env]; dup {
+			return fmt.Errorf("agentcfg: agents %q and %q map to the same password env %q", other, name, env)
+		}
+		envSeen[env] = name
+		if err := validateGrants(name, a.Grants, inboxNames); err != nil {
+			return err
+		}
+		if _, err := DefaultInbox(a); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateGrants checks one agent's grant list: non-empty, each inbox configured
+// and granted at most once, each access set non-empty and drawn from {read,send}.
+func validateGrants(agent string, grants []Grant, inboxNames map[string]bool) error {
+	if len(grants) == 0 {
+		return fmt.Errorf("agentcfg: agent %q: at least one grant is required", agent)
+	}
+	grantSeen := make(map[string]bool, len(grants))
+	for _, g := range grants {
+		inbox := strings.TrimSpace(g.Inbox)
+		if inbox == "" {
+			return fmt.Errorf("agentcfg: agent %q: a grant has an empty inbox", agent)
+		}
+		if !inboxNames[inbox] {
+			return fmt.Errorf("agentcfg: agent %q: grant references unknown inbox %q", agent, inbox)
+		}
+		if grantSeen[inbox] {
+			return fmt.Errorf("agentcfg: agent %q: duplicate grant for inbox %q", agent, inbox)
+		}
+		grantSeen[inbox] = true
+		if len(g.Access) == 0 {
+			return fmt.Errorf("agentcfg: agent %q: grant for inbox %q has empty access", agent, inbox)
+		}
+		accessSeen := make(map[string]bool, len(g.Access))
+		for _, dir := range g.Access {
+			switch dir {
+			case AccessRead, AccessSend:
+			default:
+				return fmt.Errorf("agentcfg: agent %q: grant for inbox %q has unknown access %q (want read/send)", agent, inbox, dir)
+			}
+			if accessSeen[dir] {
+				return fmt.Errorf("agentcfg: agent %q: grant for inbox %q repeats access %q", agent, inbox, dir)
+			}
+			accessSeen[dir] = true
+		}
+	}
+	return nil
+}
+
+// DefaultInbox resolves an agent's default inbox — the mailbox it sees as IMAP
+// INBOX and the target of its send catch-all (ADR 0027). Resolution order:
+//   - the explicit `default_inbox` field, if set;
+//   - else the single grant marked `default: true`;
+//   - else, if the agent has exactly one read grant, that inbox (inferred).
+//
+// The resolved default must be a granted inbox with read access; two or more read
+// grants with no explicit default is ambiguous and rejected, as is an explicit
+// default that conflicts with a `default: true` grant. Assumes grants are already
+// well-formed (see validateGrants).
+func DefaultInbox(a Agent) (string, error) {
+	name := strings.TrimSpace(a.Name)
+
+	// A `default: true` grant is sugar for the field; if both are given they must
+	// agree.
+	marked := ""
+	for _, g := range a.Grants {
+		if g.Default {
+			if marked != "" {
+				return "", fmt.Errorf("agentcfg: agent %q: more than one grant marked default", name)
+			}
+			marked = strings.TrimSpace(g.Inbox)
+		}
+	}
+	want := strings.TrimSpace(a.DefaultInbox)
+	switch {
+	case want != "" && marked != "" && want != marked:
+		return "", fmt.Errorf("agentcfg: agent %q: default_inbox %q conflicts with the grant marked default (%q)", name, want, marked)
+	case want == "" && marked != "":
+		want = marked
+	}
+
+	if want == "" {
+		// Infer from a lone read grant; ambiguous with two or more.
+		var readable []string
+		for _, g := range a.Grants {
+			if g.HasAccess(AccessRead) {
+				readable = append(readable, strings.TrimSpace(g.Inbox))
+			}
+		}
+		switch len(readable) {
+		case 1:
+			return readable[0], nil
+		case 0:
+			return "", fmt.Errorf("agentcfg: agent %q: no read grant to serve as default_inbox (INBOX)", name)
+		default:
+			sort.Strings(readable)
+			return "", fmt.Errorf("agentcfg: agent %q: default_inbox is required (has read on %s)", name, strings.Join(readable, ", "))
+		}
+	}
+
+	// Explicit (or marked) default must be a granted inbox with read access.
+	for _, g := range a.Grants {
+		if strings.TrimSpace(g.Inbox) != want {
+			continue
+		}
+		if !g.HasAccess(AccessRead) {
+			return "", fmt.Errorf("agentcfg: agent %q: default_inbox %q must have read access (it is send-only)", name, want)
+		}
+		return want, nil
+	}
+	return "", fmt.Errorf("agentcfg: agent %q: default_inbox %q is not a granted inbox", name, want)
+}

--- a/internal/agentcfg/agentcfg_test.go
+++ b/internal/agentcfg/agentcfg_test.go
@@ -1,0 +1,192 @@
+package agentcfg_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/agentcfg"
+)
+
+func inboxSet(names ...string) map[string]bool {
+	m := make(map[string]bool, len(names))
+	for _, n := range names {
+		m[n] = true
+	}
+	return m
+}
+
+func TestParseAgents(t *testing.T) {
+	agents, err := agentcfg.Parse([]byte(`
+inboxes:
+  - name: inbox-a
+agents:
+  - name: agent-a
+    default_inbox: inbox-a
+    grants:
+      - { inbox: inbox-a, access: [read, send] }
+      - { inbox: inbox-b, access: [read] }
+`))
+	require.NoError(t, err)
+	require.Len(t, agents, 1)
+	assert.Equal(t, "agent-a", agents[0].Name)
+	assert.Equal(t, "inbox-a", agents[0].DefaultInbox)
+	require.Len(t, agents[0].Grants, 2)
+	assert.Equal(t, []string{"read", "send"}, agents[0].Grants[0].Access)
+}
+
+// An absent agents: list yields nil — the caller substitutes the implicit agent.
+func TestParseNoAgents(t *testing.T) {
+	agents, err := agentcfg.Parse([]byte("inboxes:\n  - name: inbox-a\n"))
+	require.NoError(t, err)
+	assert.Nil(t, agents)
+}
+
+func TestPasswordEnv(t *testing.T) {
+	assert.Equal(t, "DARBAAN_AGENT_AGENT_A_PASSWORD", agentcfg.PasswordEnv("agent-a"))
+	// The mangle is many-to-one: '-' and '_' both fold to '_'.
+	assert.Equal(t, agentcfg.PasswordEnv("a-b"), agentcfg.PasswordEnv("a_b"))
+}
+
+func TestValidateOK(t *testing.T) {
+	agents := []agentcfg.Agent{{
+		Name:         "agent-a",
+		DefaultInbox: "inbox-a",
+		Grants: []agentcfg.Grant{
+			{Inbox: "inbox-a", Access: []string{"read", "send"}},
+			{Inbox: "inbox-b", Access: []string{"read"}},
+		},
+	}}
+	require.NoError(t, agentcfg.Validate(agents, inboxSet("inbox-a", "inbox-b")))
+}
+
+func TestValidateEmpty(t *testing.T) {
+	require.Error(t, agentcfg.Validate(nil, inboxSet("inbox-a")))
+}
+
+func TestValidateDuplicateName(t *testing.T) {
+	agents := []agentcfg.Agent{
+		{Name: "agent-a", Grants: []agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"read"}}}},
+		{Name: "agent-a", Grants: []agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"read"}}}},
+	}
+	err := agentcfg.Validate(agents, inboxSet("inbox-a"))
+	require.ErrorContains(t, err, "duplicate agent name")
+}
+
+// Names that mangle to the same password env must be rejected even though the raw
+// names differ, or two agents would silently share one secret.
+func TestValidateEnvCollision(t *testing.T) {
+	agents := []agentcfg.Agent{
+		{Name: "a-b", Grants: []agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"read"}}}},
+		{Name: "a_b", Grants: []agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"read"}}}},
+	}
+	err := agentcfg.Validate(agents, inboxSet("inbox-a"))
+	require.ErrorContains(t, err, "same password env")
+}
+
+func TestValidateGrantErrors(t *testing.T) {
+	cases := map[string]struct {
+		grants []agentcfg.Grant
+		want   string
+	}{
+		"no grants":       {nil, "at least one grant"},
+		"unknown inbox":   {[]agentcfg.Grant{{Inbox: "nope", Access: []string{"read"}}}, "unknown inbox"},
+		"empty access":    {[]agentcfg.Grant{{Inbox: "inbox-a", Access: nil}}, "empty access"},
+		"bad access":      {[]agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"write"}}}, "unknown access"},
+		"repeat access":   {[]agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"read", "read"}}}, "repeats access"},
+		"duplicate grant": {[]agentcfg.Grant{{Inbox: "inbox-a", Access: []string{"read"}}, {Inbox: "inbox-a", Access: []string{"send"}}}, "duplicate grant"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			agents := []agentcfg.Agent{{Name: "agent-a", DefaultInbox: "inbox-a", Grants: tc.grants}}
+			require.ErrorContains(t, agentcfg.Validate(agents, inboxSet("inbox-a")), tc.want)
+		})
+	}
+}
+
+func TestDefaultInboxExplicit(t *testing.T) {
+	got, err := agentcfg.DefaultInbox(agentcfg.Agent{
+		Name:         "agent-a",
+		DefaultInbox: "inbox-a",
+		Grants: []agentcfg.Grant{
+			{Inbox: "inbox-a", Access: []string{"read"}},
+			{Inbox: "inbox-b", Access: []string{"read"}},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inbox-a", got)
+}
+
+// `default: true` on a grant is sugar for the field.
+func TestDefaultInboxMarkedGrant(t *testing.T) {
+	got, err := agentcfg.DefaultInbox(agentcfg.Agent{
+		Name: "agent-a",
+		Grants: []agentcfg.Grant{
+			{Inbox: "inbox-a", Access: []string{"read"}},
+			{Inbox: "inbox-b", Access: []string{"read"}, Default: true},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inbox-b", got)
+}
+
+// A lone read grant is inferred as the default.
+func TestDefaultInboxInferred(t *testing.T) {
+	got, err := agentcfg.DefaultInbox(agentcfg.Agent{
+		Name: "agent-a",
+		Grants: []agentcfg.Grant{
+			{Inbox: "inbox-a", Access: []string{"read", "send"}},
+			{Inbox: "inbox-b", Access: []string{"send"}}, // send-only, not a default candidate
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "inbox-a", got)
+}
+
+func TestDefaultInboxErrors(t *testing.T) {
+	cases := map[string]struct {
+		agent agentcfg.Agent
+		want  string
+	}{
+		"ambiguous two read grants": {
+			agentcfg.Agent{Name: "agent-a", Grants: []agentcfg.Grant{
+				{Inbox: "inbox-a", Access: []string{"read"}},
+				{Inbox: "inbox-b", Access: []string{"read"}},
+			}},
+			"default_inbox is required",
+		},
+		// A send-only default_inbox would be an un-SELECTable INBOX.
+		"send-only default": {
+			agentcfg.Agent{Name: "agent-a", DefaultInbox: "inbox-a", Grants: []agentcfg.Grant{
+				{Inbox: "inbox-a", Access: []string{"send"}},
+			}},
+			"must have read access",
+		},
+		"default not granted": {
+			agentcfg.Agent{Name: "agent-a", DefaultInbox: "inbox-z", Grants: []agentcfg.Grant{
+				{Inbox: "inbox-a", Access: []string{"read"}},
+			}},
+			"not a granted inbox",
+		},
+		"no read grant at all": {
+			agentcfg.Agent{Name: "agent-a", Grants: []agentcfg.Grant{
+				{Inbox: "inbox-a", Access: []string{"send"}},
+			}},
+			"no read grant",
+		},
+		"conflicting field and marked grant": {
+			agentcfg.Agent{Name: "agent-a", DefaultInbox: "inbox-a", Grants: []agentcfg.Grant{
+				{Inbox: "inbox-a", Access: []string{"read"}},
+				{Inbox: "inbox-b", Access: []string{"read"}, Default: true},
+			}},
+			"conflicts with the grant marked default",
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := agentcfg.DefaultInbox(tc.agent)
+			require.ErrorContains(t, err, tc.want)
+		})
+	}
+}

--- a/internal/listener/auth.go
+++ b/internal/listener/auth.go
@@ -1,0 +1,56 @@
+package listener
+
+import "crypto/subtle"
+
+// Principal is an authenticated agent identity: the Darbaan login it presents
+// (ADR 0002 — the agent never holds upstream credentials). The grants that gate a
+// principal's access are added to the session in a later increment (ADR 0027);
+// this increment establishes identity and per-agent authentication.
+type Principal struct {
+	Name     string
+	Password string
+}
+
+// Auth resolves a presented (username, password) to a configured Principal. The
+// password comparison is constant-time, and an unknown username still runs a
+// comparison against a fixed value, so authentication fails identically whether
+// the username or the password was wrong — no username-enumeration oracle
+// (ADR 0027). v1 ran a single credential; this generalizes it to a map of agents.
+type Auth struct {
+	byName map[string]Principal
+}
+
+// dummyPassword equalizes the compare path for an unknown username.
+const dummyPassword = "x-darbaan-no-such-principal"
+
+// NewAuth builds an Auth over the given principals, keyed by name. Name
+// uniqueness is validated upstream (agentcfg.Validate).
+func NewAuth(principals []Principal) *Auth {
+	byName := make(map[string]Principal, len(principals))
+	for _, p := range principals {
+		byName[p.Name] = p
+	}
+	return &Auth{byName: byName}
+}
+
+// SingleAuth builds an Auth for one principal — the back-compat implicit agent
+// and the single-agent path.
+func SingleAuth(name, password string) *Auth {
+	return NewAuth([]Principal{{Name: name, Password: password}})
+}
+
+// Verify authenticates a presented (username, password), returning the matched
+// principal's name; ok is false on any miss.
+func (a *Auth) Verify(username, password string) (name string, ok bool) {
+	p, found := a.byName[username]
+	if !found {
+		// Compare against a fixed value so an unknown username takes a similar path
+		// to a wrong password (no username-enumeration oracle).
+		subtle.ConstantTimeCompare([]byte(password), []byte(dummyPassword))
+		return "", false
+	}
+	if subtle.ConstantTimeCompare([]byte(password), []byte(p.Password)) != 1 {
+		return "", false
+	}
+	return p.Name, true
+}

--- a/internal/listener/auth_test.go
+++ b/internal/listener/auth_test.go
@@ -1,0 +1,53 @@
+package listener_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/listener"
+)
+
+func TestSingleAuth(t *testing.T) {
+	a := listener.SingleAuth("agent", "pw")
+
+	name, ok := a.Verify("agent", "pw")
+	assert.True(t, ok)
+	assert.Equal(t, "agent", name)
+
+	_, ok = a.Verify("agent", "wrong")
+	assert.False(t, ok, "wrong password")
+
+	_, ok = a.Verify("nobody", "pw")
+	assert.False(t, ok, "unknown username")
+}
+
+// Each agent authenticates with its own credential; one agent's password never
+// works for another (ADR 0027 per-agent auth).
+func TestAuthPerAgent(t *testing.T) {
+	a := listener.NewAuth([]listener.Principal{
+		{Name: "agent-a", Password: "pw-a"},
+		{Name: "agent-b", Password: "pw-b"},
+	})
+
+	name, ok := a.Verify("agent-a", "pw-a")
+	assert.True(t, ok)
+	assert.Equal(t, "agent-a", name)
+
+	name, ok = a.Verify("agent-b", "pw-b")
+	assert.True(t, ok)
+	assert.Equal(t, "agent-b", name)
+
+	_, ok = a.Verify("agent-a", "pw-b")
+	assert.False(t, ok, "agent-b's password must not authenticate agent-a")
+
+	_, ok = a.Verify("agent-b", "pw-a")
+	assert.False(t, ok, "agent-a's password must not authenticate agent-b")
+}
+
+// An empty Auth authenticates no one (no panic on the miss path).
+func TestAuthEmpty(t *testing.T) {
+	a := listener.NewAuth(nil)
+	_, ok := a.Verify("agent", "pw")
+	assert.False(t, ok)
+}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -64,7 +64,7 @@ type IMAPServer struct {
 // The keys are the configured inboxes (ADR 0023); each is exposed as an IMAP
 // mailbox (the default inbox as INBOX). A single-inbox deploy passes one entry
 // keyed DefaultInbox.
-func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool) (*IMAPServer, error) {
+func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -76,7 +76,7 @@ func NewIMAPServer(cfg IMAPServerConfig, cred Credential, store inbound.InboundS
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{cred: cred, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof}, nil, nil
+			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -97,7 +97,7 @@ func (s *IMAPServer) Close() error { return s.imap.Close() }
 // authenticated agent (owner). Every store access is owner-keyed, so a session
 // can only ever see the agent's own messages.
 type imapSession struct {
-	cred          Credential
+	auth          *Auth
 	store         inbound.InboundStore
 	fetch         ContentFetch              // resolves message content on demand (per-FETCH)
 	writeKeywords KeywordWriter             // replicates a keyword change upstream (nil = local-only)
@@ -232,10 +232,11 @@ func uidNext(full []inbound.Message) imap.UID {
 func (s *imapSession) Close() error { return nil }
 
 func (s *imapSession) Login(username, password string) error {
-	if !constEqual(username, s.cred.Username) || !constEqual(password, s.cred.Password) {
+	name, ok := s.auth.Verify(username, password)
+	if !ok {
 		return imapserver.ErrAuthFailed
 	}
-	s.owner = username
+	s.owner = name
 	s.authed = true
 	return nil
 }

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -45,7 +45,7 @@ func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false)
+		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -57,7 +57,7 @@ func startIMAPMulti(t *testing.T, store inbound.InboundStore, filters map[string
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.Credential{Username: "agent", Password: "pw"}, store, nil, nil, filters, nil, false)
+		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -565,6 +565,6 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.Credential{Username: "agent", Password: "pw"}, seedInbound(t), nil, nil, nil, nil, false)
+		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false)
 	require.Error(t, err)
 }

--- a/internal/listener/smtp.go
+++ b/internal/listener/smtp.go
@@ -1,7 +1,6 @@
 package listener
 
 import (
-	"crypto/subtle"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -14,14 +13,6 @@ import (
 
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
-
-// Credential is a single agent's Darbaan SMTP credential. The agent
-// authenticates to Darbaan with this and never holds upstream credentials
-// (ADR 0002). v1 is single-agent; the mechanism generalizes to many (ADR 0010).
-type Credential struct {
-	Username string
-	Password string
-}
 
 // Enqueuer is the sink an authenticated submission is trapped into. The sluice
 // implements it; the SMTP face never sends upstream (ADR 0003).
@@ -37,16 +28,16 @@ type Router func(from string) (inbox string, ok bool)
 
 // Backend is the go-smtp backend for the submission face.
 type Backend struct {
-	cred  Credential
+	auth  *Auth
 	queue Enqueuer
 	route Router
 }
 
-// NewBackend builds a Backend that authenticates against cred, routes each
+// NewBackend builds a Backend that authenticates against auth, routes each
 // submission's From to an inbox via route (nil = always the default inbox), and
 // traps every accepted submission into queue.
-func NewBackend(cred Credential, queue Enqueuer, route Router) *Backend {
-	return &Backend{cred: cred, queue: queue, route: route}
+func NewBackend(auth *Auth, queue Enqueuer, route Router) *Backend {
+	return &Backend{auth: auth, queue: queue, route: route}
 }
 
 // resolveInbox routes a From to its inbox (ADR 0023); ok=false means refuse.
@@ -66,6 +57,7 @@ func (b *Backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
 type session struct {
 	backend *Backend
 	authed  bool
+	agent   string // the authenticated agent's name, stamped on the submission
 	from    string
 	inbox   string // the inbox From routed to (ADR 0023)
 	rcpt    []string
@@ -78,10 +70,11 @@ func (s *session) Auth(mech string) (sasl.Server, error) {
 		return nil, smtp.ErrAuthUnsupported
 	}
 	return sasl.NewPlainServer(func(_, username, password string) error {
-		if !constEqual(username, s.backend.cred.Username) ||
-			!constEqual(password, s.backend.cred.Password) {
+		name, ok := s.backend.auth.Verify(username, password)
+		if !ok {
 			return smtp.ErrAuthFailed
 		}
+		s.agent = name
 		s.authed = true
 		return nil
 	}), nil
@@ -126,7 +119,7 @@ func (s *session) Data(r io.Reader) error {
 		return err
 	}
 	if _, err := s.backend.queue.Enqueue(sluice.Submission{
-		Agent: s.backend.cred.Username,
+		Agent: s.agent,
 		Inbox: s.inbox,
 		From:  s.from,
 		Rcpt:  s.rcpt,
@@ -144,10 +137,6 @@ func (s *session) Reset() {
 }
 
 func (s *session) Logout() error { return nil }
-
-func constEqual(a, b string) bool {
-	return subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
-}
 
 // ServerConfig configures the SMTP submission listener.
 type ServerConfig struct {
@@ -168,11 +157,11 @@ type Server struct {
 // start a plaintext listener that would carry credentials in the clear unless
 // AllowInsecure is explicitly set (local/testing). route maps each submission's
 // From to an inbox (ADR 0023; nil = always the default inbox).
-func NewServer(cfg ServerConfig, cred Credential, queue Enqueuer, route Router) (*Server, error) {
+func NewServer(cfg ServerConfig, auth *Auth, queue Enqueuer, route Router) (*Server, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
-	srv := smtp.NewServer(NewBackend(cred, queue, route))
+	srv := smtp.NewServer(NewBackend(auth, queue, route))
 	srv.Addr = cfg.Addr
 	srv.Domain = cfg.Domain
 	srv.TLSConfig = cfg.TLSConfig

--- a/internal/listener/smtp_test.go
+++ b/internal/listener/smtp_test.go
@@ -24,7 +24,12 @@ import (
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
-var testCred = listener.Credential{Username: "agent", Password: "s3cret"}
+const (
+	testUser = "agent"
+	testPass = "s3cret"
+)
+
+var testAuth = listener.SingleAuth(testUser, testPass)
 
 func newSluice(t *testing.T) sluice.MessageStore {
 	t.Helper()
@@ -42,7 +47,7 @@ func startServer(t *testing.T, cfg listener.ServerConfig, q listener.Enqueuer) s
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	srv, err := listener.NewServer(cfg, testCred, q, nil)
+	srv, err := listener.NewServer(cfg, testAuth, q, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -53,7 +58,7 @@ func startServerRoute(t *testing.T, cfg listener.ServerConfig, q listener.Enqueu
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	srv, err := listener.NewServer(cfg, testCred, q, route)
+	srv, err := listener.NewServer(cfg, testAuth, q, route)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -92,7 +97,7 @@ func TestSubmitOverTLSEnqueuesOnePending(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 
-	require.NoError(t, c.Auth(sasl.NewPlainClient("", testCred.Username, testCred.Password)))
+	require.NoError(t, c.Auth(sasl.NewPlainClient("", testUser, testPass)))
 
 	const raw = "From: agent@local\r\nTo: dest@example.test\r\nSubject: Trapped\r\n\r\nbody-marker-42\r\n"
 	require.NoError(t, c.SendMail("agent@local", []string{"dest@example.test"}, strings.NewReader(raw)))
@@ -102,7 +107,7 @@ func TestSubmitOverTLSEnqueuesOnePending(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, metas, 1)
 	assert.Equal(t, sluice.StatusPending, metas[0].Status)
-	assert.Equal(t, testCred.Username, metas[0].Agent)
+	assert.Equal(t, testUser, metas[0].Agent)
 
 	full, err := q.Get(metas[0].ID)
 	require.NoError(t, err)
@@ -129,7 +134,7 @@ func TestSubmitRoutesFromToInbox(t *testing.T) {
 	c, err := smtp.DialStartTLS(addr, &tls.Config{InsecureSkipVerify: true})
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
-	require.NoError(t, c.Auth(sasl.NewPlainClient("", testCred.Username, testCred.Password)))
+	require.NoError(t, c.Auth(sasl.NewPlainClient("", testUser, testPass)))
 
 	// Matched From → the routed inbox is stamped on the queued message.
 	const raw = "From: work@company.test\r\nTo: d@x.test\r\nSubject: s\r\n\r\nbody\r\n"
@@ -172,14 +177,14 @@ func TestBadCredentialRejected(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 
-	require.Error(t, c.Auth(sasl.NewPlainClient("", testCred.Username, "wrong")))
+	require.Error(t, c.Auth(sasl.NewPlainClient("", testUser, "wrong")))
 }
 
 func TestNewServerRequiresTLS(t *testing.T) {
 	q := newSluice(t)
-	_, err := listener.NewServer(listener.ServerConfig{}, testCred, q, nil)
+	_, err := listener.NewServer(listener.ServerConfig{}, testAuth, q, nil)
 	require.Error(t, err)
 
-	_, err = listener.NewServer(listener.ServerConfig{AllowInsecure: true}, testCred, q, nil)
+	_, err = listener.NewServer(listener.ServerConfig{AllowInsecure: true}, testAuth, q, nil)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Slice 1 of 4 implementing ADR 0027 (multi-agent tenancy). Schema + authentication + backward-compat only; grant enforcement lands in later slices.

## What this slice does
- **New `agentcfg` package**: parses the `agents:` list beside `inboxes:`. Each agent = a login name, a `grants:` list of `{inbox, access:[read,send]}`, and a `default_inbox`. Passwords are never in config — read from `DARBAAN_AGENT_<NAME>_PASSWORD` (ADR 0012).
- **Validation** (mirrors the `inboxcfg` pattern):
  - unique agent names;
  - unique password-env names — the many-to-one mangle (`a-b` and `a_b` both fold to `..._A_B_...`) must not silently share a secret, so a collision is rejected at load;
  - well-formed grants: non-empty, each inbox configured, granted at most once, access ⊆ {read, send};
  - exactly one resolvable `default_inbox` **with read access** — explicit field, or a `default: true` grant, or inferred from a lone read grant; ambiguous (≥2 read grants, no default) is rejected, and a send-only default is rejected (an un-`SELECT`able INBOX).
- **Per-agent authentication**: a new `Auth`/`Principal` type in the listener replaces the single `Credential`. IMAP `LOGIN` and SMTP `AUTH` resolve the presented username to an agent and compare its password constant-time; an unknown username still runs a fixed comparison, so auth fails identically whether the username or password was wrong (no enumeration oracle). The authenticated agent name is stamped on the submission (`Submission.Agent`).
- **Backward compat**: with no `agents:` list, a single implicit agent (`DARBAAN_AGENT_PASS`) is granted every inbox read+send — the current single-agent path, unchanged.

## What this slice deliberately does NOT do
- No grant **enforcement** yet: `LIST`/`SELECT` are not grant-gated and send is not scoped (slices 2/3).
- No principal / mail-owner decoupling and no per-agent `INBOX` (slice 2).
- No audit acting-agent id (slice 4).

A multi-agent config authenticates per-agent but is not yet isolated; the feature is not deployed until all four slices land + a release is cut, so the intermediate state never ships.

## Tests
- `agentcfg`: parse, all validation error paths (dup name, env collision, grant errors), and every `default_inbox` resolution + error case.
- `listener`: per-agent `Verify` (own creds only), wrong-password, unknown-username, empty-auth; the existing SMTP acceptance test now asserts the authenticated agent name is stamped on the queued message.

Local: `go test -race ./...`, gofmt, golangci-lint v2.11.4 all clean.

Cross-package touch: `cmd/darbaan/main.go` wiring (build principals from config / implicit agent, pass `Auth` to both faces) and the two `listener` test files updated for the `Credential`→`Auth` signature change.