### PR TITLE
feat(agents): IMAP read-scoping + per-agent INBOX (ADR 0027 slice 2a)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -257,7 +257,24 @@ func (c *CLI) resolvePrincipals(inboxes []inboxcfg.Inbox) ([]listener.Principal,
 		if pass == "" {
 			return nil, fmt.Errorf("agent %q: set %s (the password is supplied out-of-band, never in config — ADR 0012)", a.Name, env)
 		}
-		principals = append(principals, listener.Principal{Name: a.Name, Password: pass})
+		def, err := agentcfg.DefaultInbox(a)
+		if err != nil {
+			return nil, err
+		}
+		reads := make(map[string]bool, len(a.Grants))
+		sends := make(map[string]bool, len(a.Grants))
+		for _, g := range a.Grants {
+			if g.HasAccess(agentcfg.AccessRead) {
+				reads[g.Inbox] = true
+			}
+			if g.HasAccess(agentcfg.AccessSend) {
+				sends[g.Inbox] = true
+			}
+		}
+		principals = append(principals, listener.Principal{
+			Name: a.Name, Password: pass,
+			DefaultInbox: def, Reads: reads, Sends: sends,
+		})
 	}
 	return principals, nil
 }

--- a/internal/listener/auth.go
+++ b/internal/listener/auth.go
@@ -2,13 +2,29 @@ package listener
 
 import "crypto/subtle"
 
-// Principal is an authenticated agent identity: the Darbaan login it presents
-// (ADR 0002 — the agent never holds upstream credentials). The grants that gate a
-// principal's access are added to the session in a later increment (ADR 0027);
-// this increment establishes identity and per-agent authentication.
+// Principal is an authenticated agent (ADR 0002 — the agent never holds upstream
+// credentials): its Darbaan login plus the grants that gate its access (ADR 0027).
+// DefaultInbox is the inbox this agent sees as IMAP INBOX; Reads/Sends are the
+// inboxes it may read / send as. A principal with nil Reads/Sends is unrestricted
+// — the single-agent / back-compat case, where the one agent sees every inbox.
 type Principal struct {
-	Name     string
-	Password string
+	Name         string
+	Password     string
+	DefaultInbox string
+	Reads        map[string]bool
+	Sends        map[string]bool
+}
+
+// CanRead reports whether the principal may read the inbox. Nil Reads means
+// unrestricted (single-agent / back-compat).
+func (p *Principal) CanRead(inbox string) bool {
+	return p != nil && (p.Reads == nil || p.Reads[inbox])
+}
+
+// CanSend reports whether the principal may send as the inbox. Nil Sends means
+// unrestricted (single-agent / back-compat).
+func (p *Principal) CanSend(inbox string) bool {
+	return p != nil && (p.Sends == nil || p.Sends[inbox])
 }
 
 // Auth resolves a presented (username, password) to a configured Principal. The
@@ -40,17 +56,17 @@ func SingleAuth(name, password string) *Auth {
 }
 
 // Verify authenticates a presented (username, password), returning the matched
-// principal's name; ok is false on any miss.
-func (a *Auth) Verify(username, password string) (name string, ok bool) {
+// principal; ok is false on any miss.
+func (a *Auth) Verify(username, password string) (*Principal, bool) {
 	p, found := a.byName[username]
 	if !found {
 		// Compare against a fixed value so an unknown username takes a similar path
 		// to a wrong password (no username-enumeration oracle).
 		subtle.ConstantTimeCompare([]byte(password), []byte(dummyPassword))
-		return "", false
+		return nil, false
 	}
 	if subtle.ConstantTimeCompare([]byte(password), []byte(p.Password)) != 1 {
-		return "", false
+		return nil, false
 	}
-	return p.Name, true
+	return &p, true
 }

--- a/internal/listener/auth_test.go
+++ b/internal/listener/auth_test.go
@@ -11,9 +11,9 @@ import (
 func TestSingleAuth(t *testing.T) {
 	a := listener.SingleAuth("agent", "pw")
 
-	name, ok := a.Verify("agent", "pw")
+	p, ok := a.Verify("agent", "pw")
 	assert.True(t, ok)
-	assert.Equal(t, "agent", name)
+	assert.Equal(t, "agent", p.Name)
 
 	_, ok = a.Verify("agent", "wrong")
 	assert.False(t, ok, "wrong password")
@@ -30,13 +30,13 @@ func TestAuthPerAgent(t *testing.T) {
 		{Name: "agent-b", Password: "pw-b"},
 	})
 
-	name, ok := a.Verify("agent-a", "pw-a")
+	p, ok := a.Verify("agent-a", "pw-a")
 	assert.True(t, ok)
-	assert.Equal(t, "agent-a", name)
+	assert.Equal(t, "agent-a", p.Name)
 
-	name, ok = a.Verify("agent-b", "pw-b")
+	p, ok = a.Verify("agent-b", "pw-b")
 	assert.True(t, ok)
-	assert.Equal(t, "agent-b", name)
+	assert.Equal(t, "agent-b", p.Name)
 
 	_, ok = a.Verify("agent-a", "pw-b")
 	assert.False(t, ok, "agent-b's password must not authenticate agent-a")

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -104,37 +104,64 @@ type imapSession struct {
 	filters       map[string]*filter.Filter // per-inbox serve-time filter (ADR 0021/0022/0023)
 	guard         *bounceguard.Guard        // inbound bounce-spoof guard, ahead of the filter (nil = off; ADR 0024)
 	holdSpoof     bool                      // on_spoof=hold-for-human → held-semantics; false = hide
+	principal     *Principal                // the authenticated agent + its grants (ADR 0027)
 	owner         string
 	selectedInbox string // the inbox name of the SELECTed mailbox (ADR 0023)
 	authed        bool
 	selected      []inbound.Message // metadata snapshot taken at Select (no content)
 }
 
-// mailboxName maps an inbox name to its IMAP mailbox name: the default inbox is
-// exposed as INBOX (back-compat), every other inbox by its own name (ADR 0023).
-func mailboxName(inbox string) string {
-	if inbox == inbound.DefaultInbox {
+// defaultInbox is the inbox this session sees as IMAP INBOX: the connecting
+// agent's configured default_inbox (ADR 0027), or the global default inbox for an
+// unrestricted single-agent session (back-compat).
+func (s *imapSession) defaultInbox() string {
+	if s.principal != nil && s.principal.DefaultInbox != "" {
+		return s.principal.DefaultInbox
+	}
+	return inbound.DefaultInbox
+}
+
+// canRead reports whether the connecting agent may read the inbox (ADR 0027). An
+// unrestricted principal (single-agent / back-compat) may read every inbox.
+func (s *imapSession) canRead(inbox string) bool {
+	return s.principal.CanRead(inbox)
+}
+
+// mailboxName maps an inbox name to its IMAP mailbox name for THIS session: the
+// connecting agent's default_inbox is exposed as INBOX, every other inbox by its
+// own name (per-principal naming, ADR 0027; the single global default at N=1).
+func (s *imapSession) mailboxName(inbox string) string {
+	if inbox == s.defaultInbox() {
 		return imapMailbox
 	}
 	return inbox
 }
 
-// resolveMailbox maps an IMAP mailbox name back to a configured inbox name,
-// reporting whether it exists.
+// resolveMailbox maps an IMAP mailbox name back to a configured inbox name the
+// connecting agent may read, reporting whether it exists. An inbox the agent
+// lacks read on is reported as non-existent — absence is indistinguishable from
+// non-existence (privacy by omission, ADR 0027).
 func (s *imapSession) resolveMailbox(mailbox string) (string, bool) {
 	for inbox := range s.filters {
-		if mailboxName(inbox) == mailbox {
+		if !s.canRead(inbox) {
+			continue
+		}
+		if s.mailboxName(inbox) == mailbox {
 			return inbox, true
 		}
 	}
 	return "", false
 }
 
-// mailboxNames returns the exposed IMAP mailbox names, sorted for stable LIST.
+// mailboxNames returns the IMAP mailbox names the connecting agent may read,
+// sorted for stable LIST (ADR 0027 read-scoping).
 func (s *imapSession) mailboxNames() []string {
 	names := make([]string, 0, len(s.filters))
 	for inbox := range s.filters {
-		names = append(names, mailboxName(inbox))
+		if !s.canRead(inbox) {
+			continue
+		}
+		names = append(names, s.mailboxName(inbox))
 	}
 	sort.Strings(names)
 	return names
@@ -232,11 +259,12 @@ func uidNext(full []inbound.Message) imap.UID {
 func (s *imapSession) Close() error { return nil }
 
 func (s *imapSession) Login(username, password string) error {
-	name, ok := s.auth.Verify(username, password)
+	p, ok := s.auth.Verify(username, password)
 	if !ok {
 		return imapserver.ErrAuthFailed
 	}
-	s.owner = name
+	s.principal = p
+	s.owner = p.Name
 	s.authed = true
 	return nil
 }

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -64,6 +64,71 @@ func startIMAPMulti(t *testing.T, store inbound.InboundStore, filters map[string
 	return l.Addr().String()
 }
 
+func startIMAPAuth(t *testing.T, store inbound.InboundStore, filters map[string]*filter.Filter, auth *listener.Auth) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
+		auth, store, nil, nil, filters, nil, false)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+// ADR 0027 read-scoping: LIST returns only the inboxes the agent has read on, the
+// agent's default_inbox is exposed as INBOX, and SELECT/STATUS on an ungranted
+// inbox is indistinguishable from a non-existent mailbox (privacy by omission).
+func TestIMAPReadScoping(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	// One record in each of three inboxes, all owned by the connecting agent (no
+	// owner decoupling in this slice).
+	for _, in := range []string{inbound.DefaultInbox, "work", "personal"} {
+		_, err = store.Add(inbound.Delivery{Owner: "agent-a", Inbox: in, Subject: in, Raw: []byte("Subject: " + in + "\r\n\r\nx")})
+		require.NoError(t, err)
+	}
+
+	// agent-a reads work + personal (not the default inbox) and sees work as INBOX.
+	auth := listener.NewAuth([]listener.Principal{{
+		Name: "agent-a", Password: "pw", DefaultInbox: "work",
+		Reads: map[string]bool{"work": true, "personal": true},
+		Sends: map[string]bool{"work": true},
+	}})
+	filters := map[string]*filter.Filter{inbound.DefaultInbox: nil, "work": nil, "personal": nil}
+	c, err := imapclient.DialInsecure(startIMAPAuth(t, store, filters, auth), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent-a", "pw").Wait())
+
+	boxes, err := c.List("", "*", nil).Collect()
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, b := range boxes {
+		names[b.Mailbox] = true
+	}
+	assert.Equal(t, map[string]bool{"INBOX": true, "personal": true}, names,
+		"LIST shows only granted inboxes; work (the default_inbox) is exposed as INBOX")
+
+	// INBOX resolves to the agent's default_inbox (work); the other granted inbox
+	// is reachable by name.
+	selInbox, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), selInbox.NumMessages)
+	_, err = c.Select("personal", nil).Wait()
+	require.NoError(t, err)
+
+	// The ungranted default inbox is indistinguishable from non-existent, and the
+	// default_inbox is only reachable as INBOX, never by its own name.
+	_, err = c.Select("default", nil).Wait()
+	require.Error(t, err, "ungranted inbox is no-such-mailbox")
+	_, err = c.Select("work", nil).Wait()
+	require.Error(t, err, "default_inbox is only reachable as INBOX")
+	_, err = c.Status("default", &imap.StatusOptions{NumMessages: true}).Wait()
+	require.Error(t, err, "STATUS on an ungranted inbox is no-such-mailbox")
+}
+
 // ADR 0023: each configured inbox is a named IMAP mailbox (the default inbox as
 // INBOX); SELECT serves that inbox's records, isolated from the others.
 func TestIMAPMultiInbox(t *testing.T) {

--- a/internal/listener/smtp.go
+++ b/internal/listener/smtp.go
@@ -70,11 +70,11 @@ func (s *session) Auth(mech string) (sasl.Server, error) {
 		return nil, smtp.ErrAuthUnsupported
 	}
 	return sasl.NewPlainServer(func(_, username, password string) error {
-		name, ok := s.backend.auth.Verify(username, password)
+		p, ok := s.backend.auth.Verify(username, password)
 		if !ok {
 			return smtp.ErrAuthFailed
 		}
-		s.agent = name
+		s.agent = p.Name
 		s.authed = true
 		return nil
 	}), nil


### PR DESCRIPTION
Slice 2a of 4 (slice 2 split into 2a/2b per review). Read-face grant enforcement + per-agent mailbox naming. **No stored data is touched** — that (owner decoupling + one-time rekey + bounce two-key-space union) is slice 2b.

## What this slice does
- **Grants → session**: `Principal` now carries `DefaultInbox` + read/send grant sets; `Auth.Verify` returns the matched principal so the IMAP session knows who is connected.
- **IMAP read-scoping**:
  - `LIST` returns only the inboxes the connecting agent has read on;
  - `SELECT`/`STATUS` on an inbox the agent lacks read on returns no-such-mailbox — indistinguishable from a name that doesn't exist (privacy by omission);
  - the agent's `default_inbox` is exposed as `INBOX` (per-principal naming); every other granted inbox by its own name; the `default_inbox` is reachable **only** as `INBOX`, never by its own name.
- **Back-compat**: an unrestricted principal (nil grants — the implicit single agent, and the listener tests) reads every inbox and maps the global default to `INBOX`, exactly as today.

## What this slice deliberately does NOT do
- No principal / mail-owner decoupling, no owner rekey, no bounce two-key-space union (slice 2b — the data-touching, focused-review half).
- No SMTP send-scoping (slice 3).

Because there's no owner decoupling yet, a multi-agent config's reads still key on the agent name, so shared-inbox mail isn't returned until 2b — but the gating logic (LIST/SELECT/STATUS, INBOX naming) is complete and tested here, and implicit-agent deployments are fully unaffected. The feature isn't deployed until all slices land + a release is cut.

## Tests
- `TestIMAPReadScoping`: an agent granted read on work+personal (not the default inbox), default_inbox=work — asserts LIST shows exactly {INBOX, personal}, INBOX resolves to work, `personal` reachable by name, and `default`/`work`/STATUS-on-`default` all no-such-mailbox.
- `Auth.Verify` tests updated for the principal return; the existing multi-inbox + submission tests still pass unchanged (back-compat).

Local: `go test -race ./...`, gofmt, golangci-lint v2.11.4 all clean.

Cross-package touch: `cmd/darbaan/main.go` builds each agent's grant sets + resolved default_inbox into the `Principal` (implicit path unchanged).