### PR TITLE
feat(agents): principal/mail-owner decoupling + bounce two-key-space (ADR 0027 slice 2b)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -221,45 +221,62 @@ func (c *CLI) resolveInboxes() ([]inboxcfg.Inbox, error) {
 	return inboxes, nil
 }
 
+// principalWiring is the resolved multi-agent auth for the serve loop (ADR 0027):
+// the login principals, the synced-mail owner key per inbox, and whether the
+// mail-owner is decoupled from the login (multi-agent mode).
+type principalWiring struct {
+	principals []listener.Principal
+	// mailOwner is an inbox's synced-mail store owner: its own name in multi-agent
+	// mode (so agents sharing an inbox read the same records), or the single
+	// implicit agent in back-compat mode (unchanged store keys).
+	mailOwner func(inbox string) string
+	// decoupled is true in multi-agent mode, where synced mail is keyed by inbox
+	// name and existing records are rekeyed once at startup.
+	decoupled bool
+}
+
 // resolvePrincipals resolves the configured agent principals (ADR 0027): the
 // `agents:` list, each a login with per-inbox grants and a password read from
 // DARBAAN_AGENT_<NAME>_PASSWORD (ADR 0012). With no `agents:` list it returns a
 // single implicit agent authenticated by DARBAAN_AGENT_PASS, granted every inbox
-// read+send — the back-compat single-agent path, unchanged. Grants are validated
-// here; their enforcement (read/send scoping) lands in a later increment.
-func (c *CLI) resolvePrincipals(inboxes []inboxcfg.Inbox) ([]listener.Principal, error) {
+// read+send — the back-compat single-agent path, whose store keys are unchanged.
+func (c *CLI) resolvePrincipals(inboxes []inboxcfg.Inbox) (principalWiring, error) {
 	data, err := c.configBytes()
 	if err != nil {
-		return nil, err
+		return principalWiring{}, err
 	}
 	agents, err := agentcfg.Parse(data)
 	if err != nil {
-		return nil, err
+		return principalWiring{}, err
 	}
 	if len(agents) == 0 {
 		pass := os.Getenv("DARBAAN_AGENT_PASS")
 		if c.AgentUsername == "" || pass == "" {
-			return nil, errors.New("set agent-username (config/flag/DARBAAN_AGENT_USERNAME) and DARBAAN_AGENT_PASS")
+			return principalWiring{}, errors.New("set agent-username (config/flag/DARBAAN_AGENT_USERNAME) and DARBAAN_AGENT_PASS")
 		}
-		return []listener.Principal{{Name: c.AgentUsername, Password: pass}}, nil
+		owner := c.AgentUsername
+		return principalWiring{
+			principals: []listener.Principal{{Name: owner, Password: pass}},
+			mailOwner:  func(string) string { return owner },
+		}, nil
 	}
 	inboxNames := make(map[string]bool, len(inboxes))
 	for _, in := range inboxes {
 		inboxNames[in.Name] = true
 	}
 	if err := agentcfg.Validate(agents, inboxNames); err != nil {
-		return nil, err
+		return principalWiring{}, err
 	}
 	principals := make([]listener.Principal, 0, len(agents))
 	for _, a := range agents {
 		env := agentcfg.PasswordEnv(a.Name)
 		pass := os.Getenv(env)
 		if pass == "" {
-			return nil, fmt.Errorf("agent %q: set %s (the password is supplied out-of-band, never in config — ADR 0012)", a.Name, env)
+			return principalWiring{}, fmt.Errorf("agent %q: set %s (the password is supplied out-of-band, never in config — ADR 0012)", a.Name, env)
 		}
 		def, err := agentcfg.DefaultInbox(a)
 		if err != nil {
-			return nil, err
+			return principalWiring{}, err
 		}
 		reads := make(map[string]bool, len(a.Grants))
 		sends := make(map[string]bool, len(a.Grants))
@@ -276,7 +293,11 @@ func (c *CLI) resolvePrincipals(inboxes []inboxcfg.Inbox) ([]listener.Principal,
 			DefaultInbox: def, Reads: reads, Sends: sends,
 		})
 	}
-	return principals, nil
+	return principalWiring{
+		principals: principals,
+		mailOwner:  func(inbox string) string { return inbound.NormInbox(inbox) },
+		decoupled:  true,
+	}, nil
 }
 
 // openInbound opens the inbound (served mailbox) store per config.
@@ -358,7 +379,7 @@ func (cli *CLI) newSenders(inboxes []inboxcfg.Inbox) (map[string]backend.Sender,
 // backend host are skipped (no sync). The syncers share one sync-state store
 // (keyed per inbox internally); the returned stop func closes it. An empty map
 // means no inbox syncs (gated off, like the stub sender).
-func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore) (map[string]*imapsync.Syncer, func(), error) {
+func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore, mailOwner func(inbox string) string) (map[string]*imapsync.Syncer, func(), error) {
 	syncers := map[string]*imapsync.Syncer{}
 	var state imapsync.StateStore
 	stop := func() {
@@ -388,7 +409,7 @@ func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore)
 		}
 		pass := inboxIMAPPassword(in.Name)
 		dial := imapsync.Dialer(in.Backend.IMAPHost, in.Backend.IMAPUsername, pass)
-		syn := imapsync.New(dial, mailbox, cli.AgentUsername, in.Name, store, state, maxAge)
+		syn := imapsync.New(dial, mailbox, mailOwner(in.Name), in.Name, store, state, maxAge)
 		// Per-inbox structured logger (#151): every sync/reconcile record this
 		// syncer emits is tagged with its inbox.
 		syn.SetLogger(slog.Default().With("inbox", in.Name))
@@ -794,11 +815,24 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// inbox — the back-compat single-agent path. The secret is kept in memory only
 	// (ADR 0012). Grants are validated here; their enforcement lands in a later
 	// increment.
-	principals, err := cli.resolvePrincipals(inboxes)
+	pw, err := cli.resolvePrincipals(inboxes)
 	if err != nil {
 		return err
 	}
-	auth := listener.NewAuth(principals)
+	auth := listener.NewAuth(pw.principals)
+
+	// Multi-agent mode keys synced mail by inbox name (ADR 0027 mail-owner
+	// decoupling), so agents sharing an inbox read the same records. Rekey existing
+	// synced records once at startup; bounces (UpstreamUID==0) keep their
+	// originating-agent owner and are never touched. The rekey is idempotent, so it
+	// is safe to run every start.
+	if pw.decoupled {
+		if n, rerr := inbox.RekeyOwnersToInbox(); rerr != nil {
+			return fmt.Errorf("rekey inbound owners: %w", rerr)
+		} else if n > 0 {
+			slog.Info("rekeyed inbound owners to inbox name (multi-agent)", "count", n)
+		}
+	}
 
 	// One upstream sender per inbox (ADR 0023): an approved message is delivered
 	// via the sender of the inbox it was submitted as. At N=1 this is the legacy
@@ -839,7 +873,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// One inbound syncer per inbox with an upstream (ADR 0019/0023), built before
 	// the read face so per-inbox FetchContent serves pending bodies on demand. An
 	// empty map = no inbox syncs.
-	syncers, stopSync, err := cli.newSyncers(inboxes, inbox)
+	syncers, stopSync, err := cli.newSyncers(inboxes, inbox, pw.mailOwner)
 	if err != nil {
 		return err
 	}
@@ -886,15 +920,16 @@ func (*ServeCmd) Run(cli *CLI) error {
 		slog.Warn("bounce-spoof guard disabled", "reason", "bounce-guard-enabled=false")
 	}
 	holdSpoof := cli.BounceGuardOnSpoof == "hold-for-human"
-	// The admin hold-for-human queue and the read face share one filter + owner +
-	// guard (ADR 0021/0024): the read face hides held/spoof mail, the admin surface
-	// decides it.
-	svc.SetInboundHolds(filters, cli.AgentUsername, guard, holdSpoof)
+	// The admin hold-for-human queue and the read face share one filter + mail-owner
+	// + guard (ADR 0021/0024/0027): the read face hides held/spoof mail, the admin
+	// surface decides it. The held queue is synced mail, keyed by the inbox
+	// mail-owner (per-inbox in multi-agent mode).
+	svc.SetInboundHolds(filters, pw.mailOwner, guard, holdSpoof)
 	imapSrv, err := listener.NewIMAPServer(listener.IMAPServerConfig{
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof)
+	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner)
 	if err != nil {
 		return err
 	}

--- a/cmd/darbaan/sync_test.go
+++ b/cmd/darbaan/sync_test.go
@@ -18,7 +18,7 @@ func TestNewSyncersPerInbox(t *testing.T) {
 		{Name: "personal", Backend: inboxcfg.Backend{IMAPHost: "imap.b.example:993"}},
 		{Name: "local-only"}, // no upstream host → skipped (no syncer)
 	}
-	syncers, stop, err := cli.newSyncers(inboxes, nil)
+	syncers, stop, err := cli.newSyncers(inboxes, nil, func(inbox string) string { return inbox })
 	require.NoError(t, err)
 	defer stop()
 	require.Len(t, syncers, 2)
@@ -65,7 +65,7 @@ func TestNewSendersPerInbox(t *testing.T) {
 func TestInboundSyncDisabledByDefault(t *testing.T) {
 	cli := &CLI{}
 	inboxes := []inboxcfg.Inbox{{Name: inbound.DefaultInbox}} // no backend host → no syncer
-	syncers, stop, err := cli.newSyncers(inboxes, nil)
+	syncers, stop, err := cli.newSyncers(inboxes, nil, func(inbox string) string { return inbox })
 	require.NoError(t, err)
 	require.Empty(t, syncers)
 	require.NotNil(t, stop)

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -95,7 +95,7 @@ func TestHoldsRoundtrip(t *testing.T) {
 	svc := admin.NewService(q, inbox, fakeSender{nil}, testSigner(t), strictRouter(), "darbaan.test")
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, "agent", nil, false)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, func(string) string { return "agent" }, nil, false)
 	_, held, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "review me", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
 	require.NoError(t, err)
 

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -40,7 +40,7 @@ type Service struct {
 	router     *policy.Router
 	domain     string
 	filters    map[string]*filter.Filter // per-inbox filter for the hold-for-human queue (ADR 0021/0023)
-	owner      string                    // the agent whose inbound mailbox the holds belong to
+	mailOwner  func(inbox string) string // synced-mail owner key per inbox (ADR 0027); nil until wired
 	guard      *bounceguard.Guard        // inbound bounce-spoof guard (ADR 0024; nil = off)
 	holdSpoof  bool                      // on_spoof=hold-for-human → spoofs join the held queue
 
@@ -129,12 +129,21 @@ func (s *Service) senderFor(inbox string) backend.Sender {
 }
 
 // SetInboundHolds wires the inbound hold-for-human queue (ADR 0021/0023): the
-// per-inbox filters that decide which synced messages are held, the agent (owner)
-// they belong to, and the bounce-spoof guard (ADR 0024). When the guard is set
-// with holdSpoof, spoof candidates also join the held queue. Without filters,
-// HeldList is empty.
-func (s *Service) SetInboundHolds(filters map[string]*filter.Filter, owner string, guard *bounceguard.Guard, holdSpoof bool) {
-	s.filters, s.owner, s.guard, s.holdSpoof = filters, owner, guard, holdSpoof
+// per-inbox filters that decide which synced messages are held, the per-inbox
+// mail-owner key their records live under (ADR 0027), and the bounce-spoof guard
+// (ADR 0024). When the guard is set with holdSpoof, spoof candidates also join the
+// held queue. Without filters, HeldList is empty.
+func (s *Service) SetInboundHolds(filters map[string]*filter.Filter, mailOwner func(inbox string) string, guard *bounceguard.Guard, holdSpoof bool) {
+	s.filters, s.mailOwner, s.guard, s.holdSpoof = filters, mailOwner, guard, holdSpoof
+}
+
+// inboxOwner is the store owner key for an inbox's held (synced) mail (ADR 0027):
+// the inbox mail-owner in multi-agent mode, else the single implicit agent.
+func (s *Service) inboxOwner(inbox string) string {
+	if s.mailOwner != nil {
+		return s.mailOwner(inbox)
+	}
+	return ""
 }
 
 // HeldList returns the inbound messages held for a human decision with no
@@ -148,7 +157,7 @@ func (s *Service) HeldList() ([]inbound.Message, error) {
 	now := time.Now()
 	var held []inbound.Message
 	for _, inbox := range s.inboxNames() {
-		msgs, err := s.inbox.List(s.owner, inbox)
+		msgs, err := s.inbox.List(s.inboxOwner(inbox), inbox)
 		if err != nil {
 			return nil, err
 		}
@@ -189,7 +198,7 @@ func (s *Service) guardHoldsSpoof(m inbound.Message, inbox string) bool {
 	// the two stay consistent. The error rides along with spoof=true; the read
 	// face logs it.
 	spoof, _ := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
-		fm, e := s.inbox.Get(s.owner, inbox, m.ID)
+		fm, e := s.inbox.Get(s.inboxOwner(inbox), inbox, m.ID)
 		return fm.Raw, e
 	})
 	return spoof
@@ -224,7 +233,7 @@ func (s *Service) DropHeld(id string) (inbound.Message, error) {
 // ErrNotFound. Returns ErrNotFound if no inbox holds it.
 func (s *Service) setHold(id, decision string) (inbound.Message, error) {
 	for _, inbox := range s.inboxNames() {
-		m, err := s.inbox.SetHoldDecision(s.owner, inbox, id, decision)
+		m, err := s.inbox.SetHoldDecision(s.inboxOwner(inbox), inbox, id, decision)
 		if err == nil {
 			return m, nil
 		}
@@ -408,7 +417,7 @@ func (s *Service) deliverBounce(m sluice.Message, reason string, retryable bool)
 		return fmt.Errorf("sign: %w", err)
 	}
 	if _, err := s.inbox.Add(inbound.Delivery{
-		Owner: b.Owner, From: b.From, To: b.To, Subject: b.Subject, Raw: signed,
+		Owner: b.Owner, Inbox: b.Inbox, From: b.From, To: b.To, Subject: b.Subject, Raw: signed,
 	}); err != nil {
 		return fmt.Errorf("store: %w", err)
 	}

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -98,6 +98,7 @@ func (failingInbound) Get(string, string, string) (inbound.Message, error) {
 }
 func (failingInbound) SetSeen(string, string, string, bool) error { return nil }
 func (failingInbound) RemoveSynced(string, string, string) error  { return nil }
+func (failingInbound) RekeyOwnersToInbox() (int, error)           { return 0, nil }
 func (failingInbound) Close() error                               { return nil }
 
 type senderFunc func(sluice.Message) error
@@ -251,7 +252,7 @@ func TestInboundHoldQueue(t *testing.T) {
 	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, "agent", nil, false)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, func(string) string { return "agent" }, nil, false)
 
 	_, _, err = inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1}) // allowed
 	require.NoError(t, err)
@@ -288,7 +289,7 @@ func TestInboundHoldQueueMultiInbox(t *testing.T) {
 	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
 	hold, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	svc.SetInboundHolds(map[string]*filter.Filter{"work": hold, "personal": hold}, "agent", nil, false)
+	svc.SetInboundHolds(map[string]*filter.Filter{"work": hold, "personal": hold}, func(string) string { return "agent" }, nil, false)
 
 	_, workHeld, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", Inbox: "work", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
 	require.NoError(t, err)
@@ -328,7 +329,7 @@ func TestInboundBounceGuardHold(t *testing.T) {
 	require.NoError(t, err)
 	// Verifier says "no valid Darbaan signature" → a bounce-shaped message is a spoof.
 	guard := bounceguard.New(func([]byte) (bool, error) { return false, nil })
-	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: passthrough}, "agent", guard, true /* hold-for-human */)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: passthrough}, func(string) string { return "agent" }, guard, true /* hold-for-human */)
 
 	// A bounce-shaped message from MAILER-DAEMON (envelope From hits the precheck;
 	// the stored raw is bounce-shaped) → spoof → held.

--- a/internal/agentcfg/agentcfg.go
+++ b/internal/agentcfg/agentcfg.go
@@ -102,6 +102,13 @@ func Validate(agents []Agent, inboxNames map[string]bool) error {
 			return fmt.Errorf("agentcfg: duplicate agent name %q", name)
 		}
 		seen[name] = true
+		// An agent id and an inbox name share the store's owner namespace once mail
+		// is keyed by inbox name (ADR 0027 mail-owner decoupling): an agent named the
+		// same as an inbox would collide, so a co-reader could see that agent's
+		// private bounces. Reject the overlap.
+		if inboxNames[name] {
+			return fmt.Errorf("agentcfg: agent name %q collides with an inbox name", name)
+		}
 		// The password env binding is many-to-one (e.g. "a-b" and "a_b" both mangle
 		// to DARBAAN_AGENT_A_B_PASSWORD), so a collision would silently share one
 		// secret — reject it at load (ADR 0027).

--- a/internal/agentcfg/agentcfg_test.go
+++ b/internal/agentcfg/agentcfg_test.go
@@ -190,3 +190,11 @@ func TestDefaultInboxErrors(t *testing.T) {
 		})
 	}
 }
+
+// ADR 0027: an agent named the same as an inbox collides in the store owner
+// namespace once mail is keyed by inbox name, so it is rejected.
+func TestValidateAgentInboxNameCollision(t *testing.T) {
+	agents := []agentcfg.Agent{{Name: "work", DefaultInbox: "work", Grants: []agentcfg.Grant{{Inbox: "work", Access: []string{"read"}}}}}
+	err := agentcfg.Validate(agents, inboxSet("work"))
+	require.ErrorContains(t, err, "collides with an inbox name")
+}

--- a/internal/bounce/bounce.go
+++ b/internal/bounce/bounce.go
@@ -19,7 +19,8 @@ import (
 
 // Bounce is a generated DSN bounce, ready to deliver into the agent's mailbox.
 type Bounce struct {
-	Owner   string // the agent whose send was rejected (mailbox owner)
+	Owner   string // the agent whose send was rejected (ADR 0027: keys the bounce private to its originator)
+	Inbox   string // the inbox the failed submission was for, so the bounce surfaces in that inbox's view (ADR 0027)
 	From    string // MAILER-DAEMON@<domain>
 	To      string // the original submitter
 	Subject string
@@ -80,7 +81,7 @@ func Generate(orig sluice.Message, reason string, retryable bool, domain string)
 		return Bounce{}, fmt.Errorf("bounce: close: %w", err)
 	}
 
-	return Bounce{Owner: orig.Agent, From: from, To: to, Subject: subject, Raw: buf.Bytes()}, nil
+	return Bounce{Owner: orig.Agent, Inbox: orig.Inbox, From: from, To: to, Subject: subject, Raw: buf.Bytes()}, nil
 }
 
 func writeText(mw *message.Writer, domain, reason, disposition, status string, retryable bool) error {

--- a/internal/bounce/bounce_test.go
+++ b/internal/bounce/bounce_test.go
@@ -36,6 +36,17 @@ func parseParts(t *testing.T, raw []byte) map[string]string {
 	return parts
 }
 
+// ADR 0027: a bounce is keyed to its originating agent (Owner) AND the inbox the
+// failed submission was for (Inbox), so it surfaces in that inbox's view, private
+// to the originator.
+func TestGenerateKeysOwnerAndInbox(t *testing.T) {
+	orig := sluice.Message{Agent: "agent-a", Inbox: "work", From: "w@x.test", Rcpt: []string{"d@y.test"}, Raw: []byte("Subject: hi\r\n\r\nb\r\n")}
+	b, err := bounce.Generate(orig, "refused", false, "darbaan.test")
+	require.NoError(t, err)
+	assert.Equal(t, "agent-a", b.Owner)
+	assert.Equal(t, "work", b.Inbox)
+}
+
 func TestGeneratePermanent(t *testing.T) {
 	orig := sluice.Message{Agent: "agent", From: "sender@local", Rcpt: []string{"dest@example.test"}, Raw: []byte("Subject: hi\r\n\r\nbody-marker\r\n")}
 	b, err := bounce.Generate(orig, "refused by policy", false, "darbaan.test")

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -366,6 +366,65 @@ func (s *bboltStore) RemoveSynced(owner, inbox, id string) error {
 	return nil
 }
 
+// RekeyOwnersToInbox rewrites every synced record's owner key to its inbox name
+// (ADR 0027). Bounces and other locally-generated records (UpstreamUID == 0) are
+// left keyed to their originating agent — private to it. The synced dedup index
+// moves with each record so a later re-sync still dedups. Idempotent: a record
+// already inbox-owned is skipped.
+func (s *bboltStore) RekeyOwnersToInbox() (int, error) {
+	type item struct {
+		key []byte
+		rec stored
+	}
+	n := 0
+	err := s.db.Update(func(tx *bbolt.Tx) error {
+		inb := tx.Bucket(bucketInbound)
+		idx := tx.Bucket(bucketSynced)
+		// Collect first (copying keys); mutating a bucket during its own ForEach is
+		// unsafe.
+		var work []item
+		if err := inb.ForEach(func(k, v []byte) error {
+			var rec stored
+			if err := json.Unmarshal(v, &rec); err != nil {
+				return err
+			}
+			if rec.UpstreamUID == 0 {
+				return nil // locally-generated (e.g. bounce): keep the originating owner
+			}
+			if rec.Owner == NormInbox(rec.Inbox) {
+				return nil // already inbox-owned
+			}
+			kc := make([]byte, len(k))
+			copy(kc, k)
+			work = append(work, item{key: kc, rec: rec})
+			return nil
+		}); err != nil {
+			return err
+		}
+		for _, w := range work {
+			want := NormInbox(w.rec.Inbox)
+			oldIdx := syncedKey(w.rec.Owner, w.rec.Inbox, w.rec.UIDValidity, w.rec.UpstreamUID)
+			newIdx := syncedKey(want, w.rec.Inbox, w.rec.UIDValidity, w.rec.UpstreamUID)
+			if err := idx.Delete(oldIdx); err != nil {
+				return err
+			}
+			if err := idx.Put(newIdx, w.key); err != nil {
+				return err
+			}
+			w.rec.Owner = want
+			if err := putStored(tx, w.key, w.rec); err != nil {
+				return err
+			}
+			n++
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, fmt.Errorf("inbound: rekey owners: %w", err)
+	}
+	return n, nil
+}
+
 // SetKeywords replaces the owner's message's keyword set (ADR 0020) and marks it
 // dirty for upstream reconcile. The local store is canonical; the returned
 // message carries the new keywords (without content). Metadata-only write.

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -177,6 +177,14 @@ type InboundStore interface {
 	// have no upstream and are never reconciled. Returns ErrNotFound if the
 	// (owner, inbox) has no such message.
 	RemoveSynced(owner, inbox, id string) error
+	// RekeyOwnersToInbox rewrites every synced record's owner key to its inbox name
+	// (ADR 0027 mail-owner decoupling), so several agents sharing an inbox key into
+	// the same records. Locally-generated records (UpstreamUID == 0, e.g. bounces)
+	// keep their originating-agent owner and are never rekeyed — a bounce stays
+	// private to its originator. It is idempotent (a record already inbox-owned is
+	// skipped) and returns the number of records rewritten. Multi-agent deployments
+	// run it once at startup; the single-agent path never calls it.
+	RekeyOwnersToInbox() (int, error)
 	// Close releases the underlying resources.
 	Close() error
 }

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -222,3 +222,50 @@ func TestSetSeen(t *testing.T) {
 	require.ErrorIs(t, s.SetSeen("other", inbound.DefaultInbox, m.ID, true), inbound.ErrNotFound)
 	require.ErrorIs(t, s.SetSeen("agent", inbound.DefaultInbox, "999", true), inbound.ErrNotFound)
 }
+
+// ADR 0027 mail-owner decoupling: RekeyOwnersToInbox rewrites synced records'
+// owner to their inbox name, leaves locally-generated records (bounces) keyed to
+// their originating agent, and moves the dedup index so a re-sync still dedups.
+func TestRekeyOwnersToInbox(t *testing.T) {
+	s := newStore(t)
+
+	// Two synced records under an old login owner, in two inboxes.
+	_, _, err := s.AddSynced(inbound.Delivery{Owner: "old-login", Inbox: "work", UpstreamUID: 5, UIDValidity: 1, Raw: []byte("From: a@x\r\n\r\nw")})
+	require.NoError(t, err)
+	_, _, err = s.AddSynced(inbound.Delivery{Owner: "old-login", Inbox: "personal", UpstreamUID: 7, UIDValidity: 1, Raw: []byte("From: b@y\r\n\r\np")})
+	require.NoError(t, err)
+	// A bounce (locally-generated) owned by the originating agent.
+	_, err = s.Add(inbound.Delivery{Owner: "agent-a", Inbox: "work", Raw: []byte("From: MAILER-DAEMON\r\n\r\nbounce")})
+	require.NoError(t, err)
+
+	n, err := s.RekeyOwnersToInbox()
+	require.NoError(t, err)
+	assert.Equal(t, 2, n, "only the two synced records are rekeyed")
+
+	// Synced records are now owned by their inbox name; the old owner has none.
+	work, err := s.List("work", "work")
+	require.NoError(t, err)
+	require.Len(t, work, 1)
+	assert.Equal(t, "work", work[0].Owner)
+	old, err := s.List("old-login", "work")
+	require.NoError(t, err)
+	assert.Empty(t, old, "no synced record remains under the old owner")
+
+	// The bounce keeps its originating-agent owner — private, never rekeyed.
+	bounces, err := s.List("agent-a", "work")
+	require.NoError(t, err)
+	require.Len(t, bounces, 1)
+	assert.Equal(t, "agent-a", bounces[0].Owner)
+	assert.Zero(t, bounces[0].UpstreamUID)
+
+	// The dedup index moved with the record: a re-sync under the new (inbox) owner
+	// finds the existing record instead of duplicating it.
+	added, _, err := s.AddSynced(inbound.Delivery{Owner: "work", Inbox: "work", UpstreamUID: 5, UIDValidity: 1, Raw: []byte("re-sync")})
+	require.NoError(t, err)
+	assert.False(t, added, "re-sync under the inbox owner dedups against the moved index")
+
+	// Idempotent: a second rekey changes nothing.
+	n, err = s.RekeyOwnersToInbox()
+	require.NoError(t, err)
+	assert.Zero(t, n)
+}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -64,7 +64,11 @@ type IMAPServer struct {
 // The keys are the configured inboxes (ADR 0023); each is exposed as an IMAP
 // mailbox (the default inbox as INBOX). A single-inbox deploy passes one entry
 // keyed DefaultInbox.
-func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool) (*IMAPServer, error) {
+// mailOwner returns an inbox's synced-mail store owner (ADR 0027): the inbox name
+// in multi-agent mode, so agents sharing an inbox read the same records. nil (the
+// single-agent / back-compat path) keys synced mail by the connecting agent, as
+// before.
+func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool, mailOwner func(inbox string) string) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -76,7 +80,7 @@ func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore,
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof}, nil, nil
+			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -94,8 +98,10 @@ func (s *IMAPServer) Serve(l net.Listener) error { return s.imap.Serve(l) }
 func (s *IMAPServer) Close() error { return s.imap.Close() }
 
 // imapSession is one IMAP connection, hard-scoped after Login to the
-// authenticated agent (owner). Every store access is owner-keyed, so a session
-// can only ever see the agent's own messages.
+// authenticated agent (ADR 0027). The read face is grant-gated (only inboxes the
+// agent may read) and, per selected inbox, unions the inbox's shared synced mail
+// (keyed by the inbox mail-owner) with the agent's own private bounces (keyed by
+// the agent), so a co-reader never sees another agent's bounce.
 type imapSession struct {
 	auth          *Auth
 	store         inbound.InboundStore
@@ -105,6 +111,7 @@ type imapSession struct {
 	guard         *bounceguard.Guard        // inbound bounce-spoof guard, ahead of the filter (nil = off; ADR 0024)
 	holdSpoof     bool                      // on_spoof=hold-for-human → held-semantics; false = hide
 	principal     *Principal                // the authenticated agent + its grants (ADR 0027)
+	mailOwner     func(inbox string) string // synced-mail owner key per inbox (ADR 0027); nil = key by the connecting agent
 	owner         string
 	selectedInbox string // the inbox name of the SELECTed mailbox (ADR 0023)
 	authed        bool
@@ -167,16 +174,42 @@ func (s *imapSession) mailboxNames() []string {
 	return names
 }
 
-// listAndFilter returns the owner's full message list and the filtered-visible
+// syncedOwner is the store owner key for an inbox's synced upstream mail
+// (ADR 0027): the inbox's mail-owner in multi-agent mode, or the connecting agent
+// when unset (single-agent / back-compat), where it coincides with s.owner.
+func (s *imapSession) syncedOwner(inbox string) string {
+	if s.mailOwner != nil {
+		return s.mailOwner(inbox)
+	}
+	return s.owner
+}
+
+// listAndFilter returns the inbox's full message list and the filtered-visible
 // subset (ADR 0021). The full list is kept so UIDNEXT can be derived from the
 // highest UID overall — deriving it from the visible subset would under-report
 // when the highest-UID messages are hidden, breaking client sync. allow is
 // visible; hide and undecided/rejected hold are omitted. Evaluated fresh each
 // call (no cache).
+//
+// The inbox's mail is the union of two owner key-spaces (ADR 0027): its synced
+// upstream mail (owned by the inbox's mail-owner, shared by every reader) and the
+// connecting agent's OWN bounces (owned by the agent, private to it). When the
+// two owners coincide (single-agent / back-compat) one List already holds both.
 func (s *imapSession) listAndFilter(inbox string) (full, visible []inbound.Message, err error) {
-	full, err = s.store.List(s.owner, inbox)
+	syncedOwner := s.syncedOwner(inbox)
+	full, err = s.store.List(syncedOwner, inbox)
 	if err != nil {
 		return nil, nil, err
+	}
+	if s.owner != syncedOwner {
+		bounces, berr := s.store.List(s.owner, inbox)
+		if berr != nil {
+			return nil, nil, berr
+		}
+		full = append(full, bounces...)
+		// Keep UIDs strictly ascending across the merged set (store ids are globally
+		// increasing), so the mailbox view stays well-ordered for the client.
+		sort.Slice(full, func(i, j int) bool { return uidOf(full[i]) < uidOf(full[j]) })
 	}
 	flt := s.filters[inbox] // per-inbox filter (ADR 0023); nil = allow-all
 	now := time.Now()
@@ -216,7 +249,7 @@ func (s *imapSession) listAndFilter(inbox string) (full, visible []inbound.Messa
 // it is logged and the message is hidden.
 func (s *imapSession) guardHides(m inbound.Message, inbox string) bool {
 	spoof, err := s.guard.Verdict(envelopeFromLocals(m), m.Raw, func() ([]byte, error) {
-		fm, e := s.fetch(s.owner, inbox, m.ID)
+		fm, e := s.fetch(m.Owner, inbox, m.ID)
 		return fm.Raw, e
 	})
 	if err != nil {
@@ -375,7 +408,7 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 			return
 		}
 		if markSeen && !m.Seen {
-			if err := s.store.SetSeen(s.owner, s.selectedInbox, m.ID, true); err != nil {
+			if err := s.store.SetSeen(m.Owner, s.selectedInbox, m.ID, true); err != nil {
 				ferr = err
 				return
 			}
@@ -408,7 +441,7 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 		if !done {
 			done = true
 			var full inbound.Message
-			if full, err = s.fetch(s.owner, s.selectedInbox, m.ID); err == nil {
+			if full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); err == nil {
 				raw = full.Raw
 			}
 		}
@@ -427,7 +460,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 			return
 		}
 		if touchesSeen && m.Seen != seen {
-			if err := s.store.SetSeen(s.owner, s.selectedInbox, m.ID, seen); err != nil {
+			if err := s.store.SetSeen(m.Owner, s.selectedInbox, m.ID, seen); err != nil {
 				serr = err
 				return
 			}
@@ -438,7 +471,7 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 		if flags.Op == imap.StoreFlagsSet || len(kw) > 0 {
 			next, added, removed := applyKeywordOp(m.Keywords, flags.Op, kw)
 			if len(added) > 0 || len(removed) > 0 {
-				if _, err := s.store.SetKeywords(s.owner, s.selectedInbox, m.ID, next); err != nil {
+				if _, err := s.store.SetKeywords(m.Owner, s.selectedInbox, m.ID, next); err != nil {
 					serr = err
 					return
 				}
@@ -448,10 +481,10 @@ func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags
 				// Skip records with no upstream (locally-generated, e.g. bounces) —
 				// their labels are local-only, nothing to replicate.
 				if s.writeKeywords != nil && m.UpstreamUID != 0 {
-					if err := s.writeKeywords(s.owner, s.selectedInbox, m.ID, added, removed); err != nil {
+					if err := s.writeKeywords(m.Owner, s.selectedInbox, m.ID, added, removed); err != nil {
 						slog.Warn("imap keyword write-through deferred", "id", m.ID, "err", err)
 					} else {
-						_ = s.store.ClearKeywordsDirty(s.owner, s.selectedInbox, m.ID)
+						_ = s.store.ClearKeywordsDirty(m.Owner, s.selectedInbox, m.ID)
 					}
 				}
 			}

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -45,7 +45,7 @@ func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false)
+		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -57,7 +57,7 @@ func startIMAPMulti(t *testing.T, store inbound.InboundStore, filters map[string
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false)
+		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -69,7 +69,7 @@ func startIMAPAuth(t *testing.T, store inbound.InboundStore, filters map[string]
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		auth, store, nil, nil, filters, nil, false)
+		auth, store, nil, nil, filters, nil, false, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -630,6 +630,73 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false)
+		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false, nil)
 	require.Error(t, err)
+}
+
+func startIMAPDecoupled(t *testing.T, store inbound.InboundStore, filters map[string]*filter.Filter, auth *listener.Auth, mailOwner func(string) string) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
+		auth, store, nil, nil, filters, nil, false, mailOwner)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+// ADR 0027 bounce privacy on a shared inbox: two agents share inbox "work". Its
+// synced mail is owned by the inbox and visible to both; each agent's own bounce
+// is owned by the agent and visible ONLY to that agent — a co-reader never sees
+// it. This is the two-key-space read union.
+func TestIMAPBouncePrivacyOnSharedInbox(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	// Shared synced mail owned by the inbox name (post-decoupling).
+	_, _, err = store.AddSynced(inbound.Delivery{Owner: "work", Inbox: "work", UpstreamUID: 1, UIDValidity: 1, Raw: []byte("Subject: synced-w\r\n\r\nx")})
+	require.NoError(t, err)
+	// Each agent's private bounce (locally-generated, owned by the agent).
+	_, err = store.Add(inbound.Delivery{Owner: "agent-a", Inbox: "work", Raw: []byte("Subject: bounce-a\r\n\r\nx")})
+	require.NoError(t, err)
+	_, err = store.Add(inbound.Delivery{Owner: "agent-b", Inbox: "work", Raw: []byte("Subject: bounce-b\r\n\r\nx")})
+	require.NoError(t, err)
+
+	principal := func(name string) listener.Principal {
+		return listener.Principal{Name: name, Password: "pw", DefaultInbox: "work",
+			Reads: map[string]bool{"work": true}, Sends: map[string]bool{"work": true}}
+	}
+	auth := listener.NewAuth([]listener.Principal{principal("agent-a"), principal("agent-b")})
+	filters := map[string]*filter.Filter{"work": nil}
+	mailOwner := func(inbox string) string { return inbox } // agents mode: owner = inbox name
+	addr := startIMAPDecoupled(t, store, filters, auth, mailOwner)
+
+	subjects := func(agent string) map[string]bool {
+		c, err := imapclient.DialInsecure(addr, nil)
+		require.NoError(t, err)
+		defer func() { _ = c.Close() }()
+		require.NoError(t, c.Login(agent, "pw").Wait())
+		sel, err := c.Select("INBOX", nil).Wait()
+		require.NoError(t, err)
+		got := map[string]bool{}
+		if sel.NumMessages == 0 {
+			return got
+		}
+		seqs := make([]uint32, sel.NumMessages)
+		for i := range seqs {
+			seqs[i] = uint32(i) + 1
+		}
+		msgs, err := c.Fetch(imap.SeqSetNum(seqs...), &imap.FetchOptions{Envelope: true}).Collect()
+		require.NoError(t, err)
+		for _, m := range msgs {
+			got[m.Envelope.Subject] = true
+		}
+		return got
+	}
+
+	assert.Equal(t, map[string]bool{"synced-w": true, "bounce-a": true}, subjects("agent-a"),
+		"agent-a sees shared synced mail + its own bounce, never agent-b's")
+	assert.Equal(t, map[string]bool{"synced-w": true, "bounce-b": true}, subjects("agent-b"),
+		"agent-b sees shared synced mail + its own bounce, never agent-a's")
 }


### PR DESCRIPTION
Slice 2b of 4 — the data-touching half of read scoping. Builds on 2a (#164, merged). Owner decoupling + one-time rekey + the bounce two-key-space union.

## Owner decoupling
In multi-agent mode an inbox's **synced upstream mail is keyed by the inbox name** (its mail-owner), not a login — so several agents sharing an inbox read the same records. The single-agent / back-compat path is **unchanged** (mail stays keyed by the implicit agent; no rekey).

Wired through a `mailOwner(inbox)` resolver: the syncer owner, the IMAP read face, and the admin held queue all key synced mail by it.

## Migration (one-time rekey)
`InboundStore.RekeyOwnersToInbox()` rewrites each **synced** record's owner to `NormInbox(inbox)`, **only** for `UpstreamUID != 0`. Locally-generated records (bounces, `UpstreamUID == 0`) keep their originating-agent owner. The synced **dedup index moves with each record**, so a later re-sync still dedups instead of duplicating. Idempotent (a record already inbox-owned is skipped), so it runs safely at every multi-agent startup; the single-agent path never calls it.

## Bounce two-key-space (the privacy contract)
A bounce is keyed to its **originating agent** (Owner) AND the **inbox the failed submission was for** (bounce now carries `Inbox`, threaded from the submission). The read face unions, per selected inbox X:
- **synced mail** — `List(mailOwner(X), X)`, shared by every reader of X;
- **the connecting agent's own bounces** — `List(agent, X)`, private to that agent.

So a read-only co-agent on a shared inbox **never** sees another agent's bounce. When the two owners coincide (single-agent) one List already holds both. Per-message store operations (SetSeen, keyword writes, content fetch) key on **each message's own `m.Owner`**, since a selected inbox now mixes the two owner spaces.

## Guard
An agent name may not equal an inbox name — they share the store's owner namespace once mail is keyed by inbox, so an overlap could leak an agent's bounces to co-readers. Rejected at config load.

## Tests
- `TestRekeyOwnersToInbox`: synced rekeyed to inbox owner, bounce left at its agent owner, dedup index moved (re-sync dedups), idempotent second run.
- `TestGenerateKeysOwnerAndInbox`: a bounce carries both owner and submission-inbox.
- `TestIMAPBouncePrivacyOnSharedInbox`: two agents share inbox "work" — each sees the shared synced message + only its own bounce, never the other's.
- `TestValidateAgentInboxNameCollision`: agent-name == inbox-name rejected.
- All existing tests pass unchanged (back-compat: single-owner path, no rekey).

Local: `go test -race ./...`, gofmt, golangci-lint v2.11.4 all clean.

## Cross-package touch
- `internal/inbound` (store): new `RekeyOwnersToInbox` on the interface + bbolt.
- `internal/bounce`: `Bounce.Inbox` threaded from the submission.
- `internal/admin`: held queue keys by the per-inbox mail-owner (`SetInboundHolds` takes a resolver).
- `cmd/darbaan/main.go`: builds the `mailOwner` resolver, runs the startup rekey in multi-agent mode, threads it to sync / read / held-queue.

## Not in this slice
SMTP send-scoping (slice 3), audit acting-agent id + docs + ADR finalize (slice 4).