### PR TITLE
feat(agents): SMTP send-scoping + per-agent send catch-all (ADR 0027 slice 3)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -857,8 +857,10 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// (outbound trap) and IMAP read (the agent reads its bounces). The submission
 	// face routes each From to an inbox (ADR 0023): matched Identity → that inbox,
 	// else the default catch-all, else refused at MAIL FROM.
-	route := func(from string) (string, bool) {
-		return inboxcfg.Route(inboxes, from, inbound.DefaultInbox)
+	// The catch-all target is chosen per-agent by the submission face (ADR 0027):
+	// the connecting agent's default_inbox, or the global default at N=1.
+	route := func(from, catchAll string) (string, bool) {
+		return inboxcfg.Route(inboxes, from, catchAll)
 	}
 	smtpSrv, err := listener.NewServer(listener.ServerConfig{
 		Addr:          cli.ListenerAddr,

--- a/internal/listener/smtp.go
+++ b/internal/listener/smtp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/emersion/go-sasl"
 	"github.com/emersion/go-smtp"
 
+	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -21,10 +22,12 @@ type Enqueuer interface {
 }
 
 // Router resolves which inbox an authenticated submission's From routes to (ADR
-// 0023), reporting false when the From matches no inbox and there is no default —
-// the submission is then refused at MAIL FROM. nil routes every From to the
-// default inbox (single-inbox / back-compat).
-type Router func(from string) (inbox string, ok bool)
+// 0023): the inbox whose identity matches From, else the catchAll inbox if it
+// exists (the catch-all target — the connecting agent's default_inbox in
+// multi-agent mode, ADR 0027, or the global default at N=1), else false — the
+// submission is then refused at MAIL FROM. nil routes every From to the default
+// inbox (single-inbox / back-compat).
+type Router func(from, catchAll string) (inbox string, ok bool)
 
 // Backend is the go-smtp backend for the submission face.
 type Backend struct {
@@ -41,11 +44,11 @@ func NewBackend(auth *Auth, queue Enqueuer, route Router) *Backend {
 }
 
 // resolveInbox routes a From to its inbox (ADR 0023); ok=false means refuse.
-func (b *Backend) resolveInbox(from string) (string, bool) {
+func (b *Backend) resolveInbox(from, catchAll string) (string, bool) {
 	if b.route == nil {
 		return "", true // back-compat: any From → default inbox
 	}
-	return b.route(from)
+	return b.route(from, catchAll)
 }
 
 // NewSession starts a new SMTP session.
@@ -55,12 +58,13 @@ func (b *Backend) NewSession(_ *smtp.Conn) (smtp.Session, error) {
 
 // session implements smtp.Session and smtp.AuthSession for one connection.
 type session struct {
-	backend *Backend
-	authed  bool
-	agent   string // the authenticated agent's name, stamped on the submission
-	from    string
-	inbox   string // the inbox From routed to (ADR 0023)
-	rcpt    []string
+	backend   *Backend
+	authed    bool
+	principal *Principal // the authenticated agent + its grants (ADR 0027)
+	agent     string     // the authenticated agent's name, stamped on the submission
+	from      string
+	inbox     string // the inbox From routed to (ADR 0023)
+	rcpt      []string
 }
 
 func (s *session) AuthMechanisms() []string { return []string{sasl.Plain} }
@@ -74,6 +78,7 @@ func (s *session) Auth(mech string) (sasl.Server, error) {
 		if !ok {
 			return smtp.ErrAuthFailed
 		}
+		s.principal = p
 		s.agent = p.Name
 		s.authed = true
 		return nil
@@ -84,14 +89,31 @@ func (s *session) Mail(from string, _ *smtp.MailOptions) error {
 	if !s.authed {
 		return smtp.ErrAuthRequired
 	}
-	// Route the From to an inbox (ADR 0023); refuse a From that matches no inbox
-	// and has no default catch-all, fail-fast at MAIL FROM.
-	inbox, ok := s.backend.resolveInbox(from)
+	// Route the From to an inbox (ADR 0023): its matching identity, else the
+	// catch-all — the connecting agent's default_inbox (per-agent, ADR 0027), or
+	// the global default at N=1 (empty DefaultInbox). Refuse a From that matches no
+	// inbox and has no catch-all, fail-fast at MAIL FROM.
+	catchAll := inbound.DefaultInbox
+	if s.principal != nil && s.principal.DefaultInbox != "" {
+		catchAll = s.principal.DefaultInbox
+	}
+	inbox, ok := s.backend.resolveInbox(from, catchAll)
 	if !ok {
 		return &smtp.SMTPError{
 			Code:         550,
 			EnhancedCode: smtp.EnhancedCode{5, 7, 1},
 			Message:      "sender address is not configured for any inbox",
+		}
+	}
+	// Send-scoping (ADR 0027): the connecting agent must be granted send on the
+	// resolved inbox. A read-only grant cannot originate mail — reject at submit,
+	// fail-closed (ADR 0003), before the message is ever trapped. An unrestricted
+	// principal (single-agent / back-compat) may send as any inbox.
+	if !s.principal.CanSend(inbox) {
+		return &smtp.SMTPError{
+			Code:         550,
+			EnhancedCode: smtp.EnhancedCode{5, 7, 1},
+			Message:      "not authorized to send as this inbox",
 		}
 	}
 	s.from = from

--- a/internal/listener/smtp_test.go
+++ b/internal/listener/smtp_test.go
@@ -65,6 +65,75 @@ func startServerRoute(t *testing.T, cfg listener.ServerConfig, q listener.Enqueu
 	return l.Addr().String()
 }
 
+func startServerAuth(t *testing.T, cfg listener.ServerConfig, q listener.Enqueuer, route listener.Router, auth *listener.Auth) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewServer(cfg, auth, q, route)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+// ADR 0027 send-scoping: an agent may originate mail only as an inbox it has send
+// on; a read-only inbox is rejected at MAIL FROM (fail-closed). An unmatched From
+// routes to the agent's own default_inbox (per-agent catch-all).
+func TestSubmitSendScoping(t *testing.T) {
+	q := newSluice(t)
+	route := func(from, catchAll string) (string, bool) {
+		switch from {
+		case "work@x.test":
+			return "work", true
+		case "personal@x.test":
+			return "personal", true
+		}
+		if catchAll != "" {
+			return catchAll, true // per-agent catch-all
+		}
+		return "", false
+	}
+	// agent-a reads work+personal but may send only as work; default_inbox = work.
+	auth := listener.NewAuth([]listener.Principal{{
+		Name: "agent-a", Password: "pw", DefaultInbox: "work",
+		Reads: map[string]bool{"work": true, "personal": true},
+		Sends: map[string]bool{"work": true},
+	}})
+	addr := startServerAuth(t, listener.ServerConfig{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{selfSigned(t)}},
+	}, q, route, auth)
+
+	dial := func() *smtp.Client {
+		c, err := smtp.DialStartTLS(addr, &tls.Config{InsecureSkipVerify: true})
+		require.NoError(t, err)
+		require.NoError(t, c.Auth(sasl.NewPlainClient("", "agent-a", "pw")))
+		return c
+	}
+
+	// A sendable identity is accepted.
+	c := dial()
+	require.NoError(t, c.Mail("work@x.test", nil))
+	_ = c.Close()
+
+	// An identity the agent may read but not send is rejected at MAIL FROM.
+	c = dial()
+	require.Error(t, c.Mail("personal@x.test", nil), "read-only inbox cannot originate mail")
+	_ = c.Close()
+
+	// An unmatched From routes to the agent's default_inbox (work), which it may
+	// send as → accepted and stamped with that inbox.
+	c = dial()
+	const raw = "From: stranger@elsewhere.test\r\nTo: d@y.test\r\n\r\nbody\r\n"
+	require.NoError(t, c.SendMail("stranger@elsewhere.test", []string{"d@y.test"}, strings.NewReader(raw)))
+	_ = c.Quit()
+	metas, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	full, err := q.Get(metas[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, "work", full.Inbox, "unmatched From routed to the agent's default inbox")
+}
+
 func selfSigned(t *testing.T) tls.Certificate {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -121,7 +190,7 @@ func TestSubmitOverTLSEnqueuesOnePending(t *testing.T) {
 // at MAIL FROM.
 func TestSubmitRoutesFromToInbox(t *testing.T) {
 	q := newSluice(t)
-	route := func(from string) (string, bool) {
+	route := func(from, _ string) (string, bool) {
 		if from == "work@company.test" {
 			return "work", true
 		}


### PR DESCRIPTION
Slice 3 of 4 implementing ADR 0027. SMTP send authorization + the per-agent send catch-all. Builds on 2b (#165, merged).

## Send-scoping
An authenticated submission's From is routed to an inbox (identity match, else the catch-all), and the connecting agent must be granted **send** on that inbox — otherwise the submission is **rejected at MAIL FROM**, fail-closed (ADR 0003), before the message is ever trapped in the sluice. A read-only grant cannot originate mail even for an inbox the agent can read.

An unrestricted principal (the implicit single agent / back-compat) may send as any inbox — unchanged.

## Per-agent send catch-all
A From matching no configured identity now routes to the **connecting agent's `default_inbox`** rather than a single global default (ADR 0027). The `Router` takes the catch-all target, chosen per-agent by the submission face; at N=1 it stays the global default inbox, so single-agent behaviour is unchanged. (This completes the per-agent-mailbox-naming addition; the read-side landed in 2a.)

The authenticated principal is threaded onto the SMTP session (mirroring the IMAP face in 2a) so both the send grant and the per-agent default are available at MAIL FROM.

## Tests
- `TestSubmitSendScoping`: an agent with send only on `work` — MAIL FROM as `work` accepted, as read-only `personal` rejected, and an unmatched From routed to its default (`work`) and accepted, stamped with that inbox.
- Existing submission/routing tests pass unchanged (back-compat).

Local: `go test -race ./...`, gofmt, golangci-lint v2.11.4 all clean.

## Cross-package touch
`cmd/darbaan/main.go`: the route closure takes the per-agent catch-all target (still `inboxcfg.Route`, now with the caller-supplied default).

## Remaining
Slice 4: audit acting-agent id + docs + ADR finalize (status → Accepted, README), then release + deploy.