### PR TITLE
feat(agents): audit inbox + docs + finalize ADR 0027 (slice 4)

### DIFF
--- a/adr/0027-multi-agent-tenancy.md
+++ b/adr/0027-multi-agent-tenancy.md
@@ -1,6 +1,6 @@
 # ADR 0027: Multi-agent tenancy — per-agent logins, grants, and per-principal mailbox naming
 
-**Status:** Proposed (2026-07-01)
+**Status:** Accepted (2026-07-01)
 
 ## Context
 
@@ -223,12 +223,14 @@ Fresh deployments and the single-agent path never hit this.
 
 ### Audit
 
-ADR 0023 pre-provisioned the audit schema with an inbox id; ADR 0011's log gains
-the **acting agent id** alongside it, so every held/approved/sent/rejected row
-records *which principal* acted, not just which inbox. The **implicit agent's id
-is the configured agent username** (the value SMTP already stamps as the
-submission `Agent` today), so audit rows are consistent across the upgrade rather
-than switching to a synthetic sentinel.
+ADR 0011's audit `Record` already carries the acting **agent id**, written on
+enqueue / send-attempt / verdict — and once authentication resolves the login to
+an agent (above), that id is the authenticated principal, so "which agent acted"
+is already recorded. This ADR adds the **inbox id** alongside it, so every row
+records *which agent acted, as which inbox* — the full tuple for a multi-agent
+deployment. The implicit agent's id is the configured agent username (the value
+SMTP already stamps as the submission `Agent`), so rows stay consistent across the
+upgrade rather than switching to a synthetic sentinel.
 
 ## Boundaries / non-goals
 

--- a/adr/README.md
+++ b/adr/README.md
@@ -5,7 +5,9 @@ its context, the decision, and the consequences. ADRs are immutable once
 Accepted — to change one, add a new ADR that supersedes it.
 
 These records (0001–0016) capture the v1 design, locked 2026-06-25 and amended
-through 2026-06-26 (maintainer review).
+through 2026-06-26 (maintainer review). Later records (0017–0027) extend it —
+labeling, the inbound filter, multi-inbox, reconciliation, and multi-agent
+tenancy.
 
 | ADR | Title |
 |---|---|
@@ -29,3 +31,11 @@ through 2026-06-26 (maintainer review).
 | [0017](0017-interfaces-as-clients-over-local-api.md) | Admin and approval interfaces are separate host processes over the local API |
 | [0018](0018-tiered-storage-metadata-kv-content-filesystem.md) | Tiered storage: metadata in the KV store, message content on the filesystem |
 | [0019](0019-inbound-sync-store-canonical-lazy-no-filter.md) | Inbound mailbox sync: store-canonical incremental pull, lazy content, no filter (v1) |
+| [0020](0020-agent-labeling-gmail-x-gm-labels.md) | Agent labeling via IMAP keywords (with Gmail X-GM-LABELS mapping) |
+| [0021](0021-inbound-filter-rule-schema-serve-time.md) | Inbound filter: rule schema, operators, and serve-time evaluation |
+| [0022](0022-per-inbox-default-visibility.md) | Per-inbox default visibility: match-only rules over a default disposition |
+| [0023](0023-multi-inbox.md) | Multi-inbox: N inboxes in one Darbaan, each with its own backend, filters, visibility, and identity |
+| [0024](0024-inbound-bounce-spoof-guard.md) | Inbound bounce-spoof guard: hide unsigned DSN-shaped mail by default |
+| [0025](0025-approval-gate-long-body-fidelity.md) | Approval gate: full-body fidelity for long messages (.txt attachment) |
+| [0026](0026-upstream-reconciliation-retract-local-copy.md) | Upstream reconciliation: retract the local copy when a message leaves the source |
+| [0027](0027-multi-agent-tenancy.md) | Multi-agent tenancy: per-agent logins, grants, and per-principal mailbox naming |

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,3 +71,38 @@ agent-username: ""
 # Approval chains: ordered approver names. v1 ships the manual (human) approver.
 approval-strict: [manual]
 approval-light: [manual]
+
+# --- Multi-inbox + multi-agent (optional; ADR 0023 / ADR 0027) ---------------
+# The flat fields above define ONE inbox and ONE implicit agent. To front several
+# inboxes and/or several agent principals, add `inboxes:` and `agents:` lists.
+# Both are opt-in; omitting them keeps the single-agent behaviour above unchanged.
+#
+# Each inbox is a named mailbox with its own backend, send identity, and filter
+# (ADR 0023). Each agent is a login with a per-inbox grant list — {read, send}
+# per inbox — and its password comes from DARBAAN_AGENT_<NAME>_PASSWORD (name
+# uppercased, non-alphanumerics -> '_'), never inlined (ADR 0012). Sharing an
+# inbox = listing it under more than one agent; an inbox an agent is not granted
+# is invisible to it (privacy by omission). default_inbox is the inbox that agent
+# sees as IMAP INBOX and the target of its send catch-all; it must be a granted
+# inbox with read access. An agent name may not equal an inbox name.
+#
+# inboxes:
+#   - name: inbox-a
+#     identity: a@inbox-a.example      # the From/envelope Darbaan sends as
+#     backend: { imap_host: "imap.example:993", imap_username: "a@inbox-a.example" }
+#   - name: inbox-b
+#     identity: b@inbox-b.example
+#     backend: { imap_host: "imap.example:993", imap_username: "b@inbox-b.example" }
+#
+# agents:
+#   - name: agent-a
+#     # password from DARBAAN_AGENT_AGENT_A_PASSWORD
+#     default_inbox: inbox-a
+#     grants:
+#       - { inbox: inbox-a, access: [read, send] }
+#       - { inbox: inbox-b, access: [read] }       # read-only on the shared inbox
+#   - name: agent-b
+#     # password from DARBAAN_AGENT_AGENT_B_PASSWORD
+#     default_inbox: inbox-b
+#     grants:
+#       - { inbox: inbox-b, access: [read, send] }

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -16,10 +16,13 @@ import (
 	"sort"
 )
 
-// Record is the caller-supplied content of an audit entry.
+// Record is the caller-supplied content of an audit entry. Agent + Inbox are the
+// acting principal and the inbox it acted as (ADR 0027): every row answers "which
+// agent did what, as which inbox".
 type Record struct {
 	Event     string `json:"event"`
 	Agent     string `json:"agent"`
+	Inbox     string `json:"inbox,omitempty"` // the inbox the action was scoped to (ADR 0023/0027)
 	MessageID string `json:"message_id"`
 	Detail    string `json:"detail,omitempty"` // e.g. reject reason, send-attempt result
 }

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -57,6 +57,23 @@ func TestBboltTamperDetected(t *testing.T) {
 	require.Error(t, l.Verify())
 }
 
+// ADR 0027: an audit entry records both the acting agent and the inbox it acted
+// as; both persist through the hash-chained entry.
+func TestBboltRecordsAgentAndInbox(t *testing.T) {
+	l := newBboltLog(t)
+	require.NoError(t, l.Append(Record{Event: "enqueue", Agent: "agent-a", Inbox: "work", MessageID: "1"}))
+	require.NoError(t, l.Verify())
+
+	var got Entry
+	bl := l.(*bboltLog)
+	require.NoError(t, bl.db.View(func(tx *bbolt.Tx) error {
+		_, v := tx.Bucket(bucketName).Cursor().First()
+		return json.Unmarshal(v, &got)
+	}))
+	require.Equal(t, "agent-a", got.Record.Agent)
+	require.Equal(t, "work", got.Record.Inbox)
+}
+
 func TestUnknownTypeErrors(t *testing.T) {
 	_, err := New("does-not-exist", "")
 	require.Error(t, err)

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -221,6 +221,7 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 			_ = opts.Audit.Append(audit.Record{
 				Event:     "retract",
 				Agent:     s.owner,
+				Inbox:     inbound.NormInbox(s.inbox),
 				MessageID: m.ID,
 				Detail:    fmt.Sprintf("inbox=%s upstream_uid=%d left source", inbound.NormInbox(s.inbox), m.UpstreamUID),
 			})

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -147,7 +147,7 @@ func (s *bboltStore) Enqueue(sub Submission) (Message, error) {
 	if err != nil {
 		return Message{}, fmt.Errorf("sluice: enqueue: %w", err)
 	}
-	s.writeAudit(audit.Record{Event: "enqueue", Agent: msg.Agent, MessageID: msg.ID})
+	s.writeAudit(audit.Record{Event: "enqueue", Agent: msg.Agent, Inbox: msg.Inbox, MessageID: msg.ID})
 	return msg, nil
 }
 
@@ -242,7 +242,7 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 	if sendErr != nil {
 		detail = sendErr.Error()
 	}
-	s.writeAudit(audit.Record{Event: "send_attempt", Agent: out.Agent, MessageID: id, Detail: detail})
+	s.writeAudit(audit.Record{Event: "send_attempt", Agent: out.Agent, Inbox: out.Inbox, MessageID: id, Detail: detail})
 	return out, nil
 }
 
@@ -271,7 +271,7 @@ func (s *bboltStore) transitionFromPending(id, event, detail string, mutate func
 	if err != nil {
 		return Message{}, err
 	}
-	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, MessageID: id, Detail: detail})
+	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, Inbox: out.Inbox, MessageID: id, Detail: detail})
 	return out, nil
 }
 

--- a/internal/sluice/sluice_test.go
+++ b/internal/sluice/sluice_test.go
@@ -224,3 +224,25 @@ func TestUnknownStoreTypeErrors(t *testing.T) {
 	_, err = sluice.New("does-not-exist", "x.db", al)
 	require.Error(t, err)
 }
+
+type capturingAudit struct{ records []audit.Record }
+
+func (c *capturingAudit) Append(r audit.Record) error { c.records = append(c.records, r); return nil }
+func (c *capturingAudit) Verify() error               { return nil }
+func (c *capturingAudit) Close() error                { return nil }
+
+// ADR 0027: an enqueue audit row records the acting agent and the routed inbox.
+func TestEnqueueAuditRecordsAgentAndInbox(t *testing.T) {
+	cap := &capturingAudit{}
+	q, err := sluice.New("bbolt", filepath.Join(t.TempDir(), "s.db"), cap)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	_, err = q.Enqueue(sluice.Submission{Agent: "agent-a", Inbox: "work", Raw: []byte("Subject: x\r\n\r\nb")})
+	require.NoError(t, err)
+
+	require.Len(t, cap.records, 1)
+	assert.Equal(t, "enqueue", cap.records[0].Event)
+	assert.Equal(t, "agent-a", cap.records[0].Agent)
+	assert.Equal(t, "work", cap.records[0].Inbox)
+}


### PR DESCRIPTION
Slice 4 of 4 — the final slice of the multi-agent tenancy arc. Audit inbox + docs + ADR finalize. Builds on slice 3 (#166, merged).

## Audit
The audit `Record` already carries the acting **agent** id — and since the auth slice that id is the authenticated principal — written on enqueue / send-attempt / verdict / retract. This slice adds the **inbox** id alongside it, so every row records *which agent acted, as which inbox* — the full tuple for a multi-agent deployment.

(Discovery, already flagged: ADR 0023 did **not** actually pre-provision an inbox in the audit schema, and the agent was already recorded — so the change is the inverse of the 0027 draft's wording. The ADR's Audit section is corrected to match reality.)

## Docs
- `config.example.yaml`: a commented multi-inbox + multi-agent example — `agents:`/`grants:`/`default_inbox`, the `DARBAAN_AGENT_<NAME>_PASSWORD` secret convention, sharing = list an inbox under multiple agents, privacy by omission, the agent-name != inbox-name rule.
- `adr/README.md`: backfills the ADR index 0020–0027 (it had drifted to 0019).

## ADR finalize (hard-gate — `adr/*`)
`adr/0027-multi-agent-tenancy.md`: status **Proposed → Accepted**, and the Audit section rewritten to match the implementation (agent already recorded; this slice adds the inbox). Covered by the operator delegation + 2-of-N, no bypass.

## Tests
- `TestBboltRecordsAgentAndInbox`: agent + inbox both persist through the hash-chained entry.
- `TestEnqueueAuditRecordsAgentAndInbox`: enqueue records the acting agent and the routed inbox.
- All existing tests pass unchanged.

Local: `go test -race ./...`, gofmt, golangci-lint v2.11.4 all clean.

## Arc complete
After this merges: cut the release and deploy to the production darbaan (same flow as the prior release). ADR 0027 slices 1 / 2a / 2b / 3 / 4 all landed.