### PR TITLE
feat(sync): STATUS triggers debounced on-demand inbound sync (ADR 0028)

### DIFF
--- a/adr/0028-on-demand-inbound-sync-on-status.md
+++ b/adr/0028-on-demand-inbound-sync-on-status.md
@@ -1,0 +1,138 @@
+# ADR 0028: On-demand inbound sync — pull the queried inbox on STATUS
+
+**Status:** Proposed (2026-07-04)
+
+## Context
+
+Inbound sync is store-canonical and forward-only (ADR 0019): a per-inbox loop
+polls the upstream mailbox on a fixed interval (`inbound-imap-poll-interval`,
+default 60s) and pulls new mail into the store, which the IMAP read face
+(ADR 0016) then serves. The interval is deliberately coarse — a steady
+background poll, not a tight loop.
+
+That coarseness is a latency floor the agent cannot cross. After the agent does
+something that produces a reply — sends a message and expects an answer, has a
+held submission approved, or runs a test round-trip — the new mail is not
+visible on its IMAP face until the next scheduled poll lands it in the store.
+The agent has no way to say "pull now"; it can only wait out the interval.
+
+The natural IMAP verb for this is not `NOOP`. `NOOP` is a keep-alive clients
+spam every few seconds while idle-polling, so tying an upstream pull to it —
+even debounced — invites needless load and surprises. IMAP's explicit
+"tell me about this mailbox" verb is `STATUS`: a low-frequency, deliberate
+command a client issues to ask a named mailbox's message/unseen/uidnext counts,
+typically for a mailbox it does not have selected. "Give me current status" is
+an honest place to refresh first and then report.
+
+`STATUS` is already implemented (`Status(mailbox, options)`): it resolves the
+mailbox to an inbox the agent may read, re-lists that inbox from the store
+**fresh on every call**, and reports the counts. It is a query — the selected
+mailbox is untouched.
+
+## Decision
+
+Make `STATUS` the agent's **"sync now"**: when a client issues `STATUS` for an
+inbox that has on-demand sync enabled, run an immediate, **debounced** on-demand
+upstream pull of that inbox **before** computing the reply, so the returned
+counts already include mail that arrived since the last background poll.
+
+Because `Status` already re-lists the store fresh per call, the only change to
+it is to trigger the pull up front; the existing `MESSAGES` / `UNSEEN` /
+`UIDNEXT` computation then reports the grown set. `NOOP`/`CHECK` (`Poll`) stay a
+true no-op — no keep-alive triggers an upstream dial.
+
+### Trigger
+
+`Status` runs on the connection's own goroutine (go-imap serializes commands per
+connection), so a bounded upstream pull inline is safe. For the resolved inbox
+it calls a debounced trigger that runs one incremental `Syncer.Sync` (the same
+forward pull the background loop runs), then the fresh re-list reports the
+result. It needs no SELECT — `STATUS` names its own mailbox — so an agent can
+refresh a mailbox it is not currently reading.
+
+The trigger is a clean no-op when:
+
+- the queried inbox has no upstream syncer (a bounce-only / sync-disabled inbox
+  — nothing to pull);
+- on-demand sync is not enabled for the inbox; or
+- the inbox's debounce window has not elapsed.
+
+A sync error never fails the `STATUS`: the pull is best-effort, the error is
+logged, and `STATUS` reports the store's current counts anyway. A failed
+on-demand pull is no worse than waiting for the next background poll.
+
+### Debounce (mandatory per-inbox rate-limit)
+
+`STATUS` is far less frequent than `NOOP`, but a client (or several agents
+sharing one inbox in a multi-agent deployment, ADR 0027) can still issue it in
+bursts. So on-demand sync is **coalesced per inbox**: after an on-demand pull
+completes, further triggers for that inbox are suppressed until a configurable
+window elapses. Within the window a `STATUS` does **no** upstream work — it still
+reports whatever is already in the store (so a background poll's mail is
+surfaced), but it does not dial.
+
+The debounce is **per inbox and shared across sessions**, not per connection —
+otherwise N connected agents would each get their own window and multiply the
+upstream load by N. It also refuses to start a second pull for an inbox while
+one is already in flight (a single-flight guard), so a burst collapses to one
+dial. The window is measured from pull **completion**, so a slow pull does not
+immediately re-trigger.
+
+### Counts, not unsolicited updates (v1 boundary)
+
+`STATUS` reports fresh counts computed after the pull; it pushes **no**
+unsolicited `EXISTS`/`EXPUNGE` into a concurrently-selected session (`STATUS`
+carries no update channel — it returns a status reply). An agent that sees a
+higher `MESSAGES`/`UIDNEXT` count then `SELECT`s (or re-examines) the inbox to
+fetch the new mail — the honest, standard flow.
+
+This keeps the change append-safe by construction: new synced mail carries
+strictly higher store ids than everything present, so it appends at the tail; a
+**shrink or reorder** — a reconcile retraction (ADR 0026) removing a message, or
+a filter now hiding one — simply surfaces as a changed count and is picked up on
+the client's next `SELECT`, never as a mid-session sequence-number desync. v1
+sends no unsolicited `EXPUNGE`; convergent in-session update signalling is a
+possible follow-up, out of scope here.
+
+### Config
+
+On-demand sync is **opt-in per inbox**, matching the `reconcile_enabled` idiom
+(ADR 0026) and reflecting that it changes what `STATUS` costs (a bounded upstream
+round-trip) — an operator turns it on deliberately, not by upgrade surprise. Two
+per-inbox fields under the `inboxes:` schema (ADR 0023):
+
+- `sync_on_status` (bool, default false) — enable the on-demand pull on `STATUS`
+  for this inbox.
+- `sync_on_status_interval` (duration, empty → runtime default) — the debounce
+  window: the minimum gap between on-demand upstream pulls of this inbox. The
+  runtime default is 60s. Only meaningful when `sync_on_status` is set.
+
+An inbox with no upstream syncer ignores the setting (nothing to pull). The
+background poll loop (ADR 0019) is unchanged and runs regardless; on-demand sync
+only lets the agent skip the wait between its cycles.
+
+## Boundaries
+
+- **No new IMAP verb.** This reuses `STATUS` — a standard client "tell me about
+  this mailbox" query — rather than inventing an extension. Any IMAP client gets
+  it for free; no client change is needed.
+- **`NOOP`/`CHECK` are unchanged** — a true no-op. No keep-alive triggers an
+  upstream dial, so idle-polling clients impose no on-demand load.
+- **Read-only upstream is unchanged** (ADR 0002): the on-demand pull is the same
+  read-only forward `Sync` the background loop runs.
+- **No push / IDLE.** This is pull-on-STATUS, not server-initiated push. `IDLE`
+  stays a park (it blocks until the client stops); a client wanting timely mail
+  issues `STATUS`.
+- **Counts only**, no unsolicited `EXISTS`/`EXPUNGE` (above).
+
+## Consequences
+
+- An agent that wants its reply now issues a `STATUS` and the returned counts
+  already reflect it, bounded only by the upstream fetch — no longer by the poll
+  interval. It then `SELECT`s to read.
+- Upstream load is bounded by the per-inbox debounce window regardless of how
+  often clients `STATUS` or how many share an inbox, so the "sync now" path
+  cannot be turned into an amplification vector.
+- `NOOP` stays cheap and dial-free, so idle keep-alives cost nothing upstream.
+- The change is inert until an operator opts an inbox in, so existing
+  deployments are unaffected.

--- a/adr/README.md
+++ b/adr/README.md
@@ -5,9 +5,9 @@ its context, the decision, and the consequences. ADRs are immutable once
 Accepted — to change one, add a new ADR that supersedes it.
 
 These records (0001–0016) capture the v1 design, locked 2026-06-25 and amended
-through 2026-06-26 (maintainer review). Later records (0017–0027) extend it —
-labeling, the inbound filter, multi-inbox, reconciliation, and multi-agent
-tenancy.
+through 2026-06-26 (maintainer review). Later records (0017–0028) extend it —
+labeling, the inbound filter, multi-inbox, reconciliation, multi-agent tenancy,
+and on-demand sync.
 
 | ADR | Title |
 |---|---|
@@ -39,3 +39,4 @@ tenancy.
 | [0025](0025-approval-gate-long-body-fidelity.md) | Approval gate: full-body fidelity for long messages (.txt attachment) |
 | [0026](0026-upstream-reconciliation-retract-local-copy.md) | Upstream reconciliation: retract the local copy when a message leaves the source |
 | [0027](0027-multi-agent-tenancy.md) | Multi-agent tenancy: per-agent logins, grants, and per-principal mailbox naming |
+| [0028](0028-on-demand-inbound-sync-on-status.md) | On-demand inbound sync: STATUS triggers a debounced upstream pull of the queried inbox |

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -504,6 +504,39 @@ func runSync(ctx context.Context, inbox string, s *imapsync.Syncer) {
 	}
 }
 
+// DefaultSyncOnStatusInterval is the on-demand-sync debounce window for an inbox
+// that enables sync_on_status without setting one (ADR 0028): the minimum gap
+// between STATUS-triggered upstream pulls. A minute is coarse enough that STATUS
+// stays cheap under bursty polling, fine enough that "sync now" feels immediate
+// after the first call.
+const DefaultSyncOnStatusInterval = time.Minute
+
+// newOnDemandSync builds the STATUS-triggered on-demand sync coordinator
+// (ADR 0028): it registers each inbox that opted in (sync_on_status) AND has an
+// upstream syncer, with its debounce window (sync_on_status_interval, or the
+// runtime default). An inbox with no syncer is skipped (nothing to pull). The
+// returned coordinator is empty when no inbox opted in — Trigger is then a pure
+// no-op — so it is always safe to wire onto the read face.
+func newOnDemandSync(inboxes []inboxcfg.Inbox, syncers map[string]*imapsync.Syncer) *imapsync.OnDemandSync {
+	od := imapsync.NewOnDemandSync()
+	for _, in := range inboxes {
+		if !in.SyncOnStatus {
+			continue
+		}
+		syn, ok := syncers[in.Name]
+		if !ok {
+			slog.Warn("sync_on_status enabled but inbox has no upstream; ignoring", "inbox", in.Name)
+			continue
+		}
+		iv, _ := in.SyncOnStatusDuration() // validated at load; 0 ⇒ default
+		if iv <= 0 {
+			iv = DefaultSyncOnStatusInterval
+		}
+		od.Register(in.Name, syn, iv)
+	}
+	return od
+}
+
 // DefaultReconcileInterval is the reconcile-pass period for an inbox that enables
 // reconciliation without setting one (ADR 0026). A full UID listing is heavier
 // than the incremental forward poll, so the default is deliberately coarse.
@@ -881,6 +914,17 @@ func (*ServeCmd) Run(cli *CLI) error {
 	}
 	defer stopSync()
 
+	// On-demand sync (ADR 0028): STATUS for an opted-in inbox triggers a debounced
+	// upstream pull before the counts are computed, so the agent can "sync now"
+	// instead of waiting out the background poll interval. Empty (no inbox opted
+	// in) ⇒ the trigger is a no-op. It runs the same read-only forward Sync as the
+	// background loop, on the connection's goroutine.
+	onDemand := newOnDemandSync(inboxes, syncers)
+	syncNow := func(inbox string) error {
+		_, _, terr := onDemand.Trigger(context.Background(), inbox)
+		return terr
+	}
+
 	// Wire the reconcile safety-cap controls onto the admin surface (ADR 0026):
 	// release a latched inbox (clear + cap-bypassed purge once) and report each
 	// inbox's latch. Only when an inbox has an upstream — otherwise the endpoints
@@ -931,7 +975,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner)
+	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner, syncNow)
 	if err != nil {
 		return err
 	}

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -86,10 +86,20 @@ approval-light: [manual]
 # sees as IMAP INBOX and the target of its send catch-all; it must be a granted
 # inbox with read access. An agent name may not equal an inbox name.
 #
+# On-demand sync (ADR 0028, opt-in per inbox): when sync_on_status is set, an IMAP
+# STATUS for that inbox triggers an immediate upstream pull before the counts are
+# returned, so an agent can "sync now" instead of waiting out the background poll
+# (inbound-imap-poll-interval). It is debounced per inbox — sync_on_status_interval
+# is the minimum gap between on-demand pulls (default 60s); a STATUS inside the
+# window silently reports current counts without dialing. NOOP/CHECK never trigger
+# a pull. Ignored for an inbox with no upstream.
+#
 # inboxes:
 #   - name: inbox-a
 #     identity: a@inbox-a.example      # the From/envelope Darbaan sends as
 #     backend: { imap_host: "imap.example:993", imap_username: "a@inbox-a.example" }
+#     sync_on_status: true             # STATUS pulls upstream now (ADR 0028)
+#     sync_on_status_interval: "60s"   # debounce window (default 60s)
 #   - name: inbox-b
 #     identity: b@inbox-b.example
 #     backend: { imap_host: "imap.example:993", imap_username: "b@inbox-b.example" }

--- a/internal/imapsync/ondemand.go
+++ b/internal/imapsync/ondemand.go
@@ -1,0 +1,80 @@
+package imapsync
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// OnDemandSync coalesces caller-triggered ("sync now") upstream pulls per inbox
+// (ADR 0028). An IMAP STATUS for an enabled inbox calls Trigger; Trigger runs one
+// incremental Syncer.Sync, but at most once per the inbox's debounce window and
+// never concurrently with itself — so a burst of STATUS commands, or several
+// agents sharing one inbox (ADR 0027), collapse to a single upstream dial.
+//
+// The debounce is per inbox and shared across every session (it lives here, not
+// on a connection): N connected agents share one window rather than each getting
+// their own and multiplying upstream load by N. Only inboxes an operator opted in
+// (with an upstream syncer) are registered; Trigger is a cheap no-op for any
+// other inbox.
+type OnDemandSync struct {
+	mu      sync.Mutex
+	inboxes map[string]*onDemandInbox
+}
+
+// onDemandInbox is one registered inbox's syncer, debounce window, and the
+// coalescing state guarded by OnDemandSync.mu.
+type onDemandInbox struct {
+	syncer      *Syncer
+	minInterval time.Duration
+	last        time.Time // completion time of the last on-demand pull
+	inflight    bool      // a pull is running now (single-flight guard)
+}
+
+// NewOnDemandSync returns an empty coordinator; register inboxes with Register.
+func NewOnDemandSync() *OnDemandSync {
+	return &OnDemandSync{inboxes: map[string]*onDemandInbox{}}
+}
+
+// Register enables on-demand sync for an inbox with its syncer and debounce
+// window. It is called once per opted-in inbox at wiring time (not concurrently),
+// before any Trigger. A non-positive minInterval is treated as "no debounce"
+// (every Trigger that is not already in flight pulls); callers pass a sane
+// default instead.
+func (o *OnDemandSync) Register(inbox string, syncer *Syncer, minInterval time.Duration) {
+	o.inboxes[inbox] = &onDemandInbox{syncer: syncer, minInterval: minInterval}
+}
+
+// Trigger runs one incremental upstream pull for inbox if one is due — the
+// debounce window since the last on-demand pull has elapsed and no pull is
+// already in flight — and returns the count stored and whether a pull actually
+// ran. It is a no-op (0, false, nil) for an unregistered inbox, or when the pull
+// is debounced or coalesced away.
+//
+// The syncer dial is done WITHOUT holding the lock (it is a network round-trip),
+// so concurrent Triggers for other inboxes proceed and a slow pull does not block
+// the coordinator. The window is stamped from the pull's COMPLETION, so a slow
+// pull does not immediately re-trigger.
+func (o *OnDemandSync) Trigger(ctx context.Context, inbox string) (int, bool, error) {
+	o.mu.Lock()
+	in := o.inboxes[inbox]
+	if in == nil {
+		o.mu.Unlock()
+		return 0, false, nil // not opted in / no upstream — nothing to pull
+	}
+	now := time.Now()
+	if in.inflight || (!in.last.IsZero() && now.Sub(in.last) < in.minInterval) {
+		o.mu.Unlock()
+		return 0, false, nil // a pull is running, or the window has not elapsed
+	}
+	in.inflight = true
+	o.mu.Unlock()
+
+	n, err := in.syncer.Sync(ctx)
+
+	o.mu.Lock()
+	in.inflight = false
+	in.last = time.Now() // start the window from completion, not from entry
+	o.mu.Unlock()
+	return n, true, err
+}

--- a/internal/imapsync/ondemand_test.go
+++ b/internal/imapsync/ondemand_test.go
@@ -1,0 +1,87 @@
+package imapsync_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// A registered inbox pulls on the first Trigger, then coalesces further triggers
+// within the debounce window (silent-skip: ran=false, no error, no upstream dial),
+// and pulls again once the window elapses (ADR 0028).
+func TestOnDemandSyncDebounces(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\nbody one")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+
+	od := imapsync.NewOnDemandSync()
+	od.Register(inbound.DefaultInbox, syncer, 50*time.Millisecond)
+
+	// First trigger pulls the one message.
+	n, ran, err := od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.True(t, ran, "first trigger runs a pull")
+	assert.Equal(t, 1, n)
+
+	// A second message lands upstream, but a trigger inside the window is coalesced:
+	// silent-skip, no pull, so the new message is NOT pulled yet.
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\nbody two")
+	n, ran, err = od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.False(t, ran, "trigger within the debounce window is skipped")
+	assert.Equal(t, 0, n)
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.Len(t, msgs, 1, "coalesced trigger did not pull the second message")
+
+	// After the window elapses, a trigger pulls again and picks up the second.
+	time.Sleep(60 * time.Millisecond)
+	n, ran, err = od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.True(t, ran, "trigger after the window runs a pull")
+	assert.Equal(t, 1, n)
+	msgs, err = store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2)
+}
+
+// An inbox that was never registered (not opted in, or bounce-only with no
+// syncer) is a pure no-op: no pull, no error.
+func TestOnDemandSyncNoOpForUnregisteredInbox(t *testing.T) {
+	od := imapsync.NewOnDemandSync()
+	n, ran, err := od.Trigger(context.Background(), "not-registered")
+	require.NoError(t, err)
+	assert.False(t, ran)
+	assert.Zero(t, n)
+}
+
+// A zero/negative window means "no debounce": every trigger that is not already
+// in flight pulls (there is no minimum gap).
+func TestOnDemandSyncNoDebounceWindow(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\nbody one")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+
+	od := imapsync.NewOnDemandSync()
+	od.Register(inbound.DefaultInbox, syncer, 0) // no debounce
+
+	_, ran, err := od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.True(t, ran)
+
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\nbody two")
+	n, ran, err := od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.True(t, ran, "with no window every trigger pulls")
+	assert.Equal(t, 1, n)
+}

--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -59,6 +59,18 @@ type Inbox struct {
 	// set value must be >= 1. The latch rule is the conjunction of both —
 	// retract-count >= floor AND retract-count > fraction * synced-set.
 	ReconcileCapFloor int `yaml:"reconcile_cap_floor"`
+
+	// On-demand inbound sync (ADR 0028): when set, an IMAP STATUS for this inbox
+	// triggers an immediate, debounced upstream pull before the counts are computed,
+	// so "give me current status" reflects mail that arrived since the last
+	// background poll (ADR 0019) instead of waiting out the interval. It is OPT-IN
+	// and OFF unless SyncOnStatus is set — STATUS stays a cheap query by default;
+	// NOOP/CHECK never trigger a pull. SyncOnStatusInterval is the debounce window:
+	// the minimum gap between on-demand pulls of this inbox (empty uses the runtime
+	// default). It is only meaningful when enabled and ignored for an inbox with no
+	// upstream syncer.
+	SyncOnStatus         bool   `yaml:"sync_on_status"`
+	SyncOnStatusInterval string `yaml:"sync_on_status_interval"`
 }
 
 // Backend is an inbox's upstream account coordinates (ADR 0009). Secrets
@@ -140,6 +152,14 @@ func Validate(inboxes []Inbox) error {
 			}
 			if fl := in.ReconcileCapFloor; fl != 0 && fl < 1 {
 				return fmt.Errorf("inboxcfg: inbox %q: reconcile_cap_floor must be >= 1, got %d", name, fl)
+			}
+		}
+		// Fail-fast on a malformed on-demand-sync debounce window for an enabled
+		// inbox, so a bad duration is caught at load, not at the first STATUS
+		// (ADR 0028).
+		if in.SyncOnStatus {
+			if _, err := in.SyncOnStatusDuration(); err != nil {
+				return fmt.Errorf("inboxcfg: inbox %q: %w", name, err)
 			}
 		}
 	}
@@ -232,6 +252,26 @@ func (in Inbox) ReconcileDuration() (time.Duration, error) {
 	}
 	if d <= 0 {
 		return 0, fmt.Errorf("reconcile_interval must be positive, got %q", s)
+	}
+	return d, nil
+}
+
+// SyncOnStatusDuration parses the inbox's on-demand-sync debounce window
+// (ADR 0028). An empty interval returns (0, nil) — the caller substitutes the
+// runtime default. A set interval must be a positive Go duration (e.g. "15s",
+// "1m"); zero or negative is an error. It is only meaningful when SyncOnStatus is
+// set.
+func (in Inbox) SyncOnStatusDuration() (time.Duration, error) {
+	s := strings.TrimSpace(in.SyncOnStatusInterval)
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid sync_on_status_interval %q: %w", s, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("sync_on_status_interval must be positive, got %q", s)
 	}
 	return d, nil
 }

--- a/internal/inboxcfg/sync_on_status_test.go
+++ b/internal/inboxcfg/sync_on_status_test.go
@@ -1,0 +1,76 @@
+package inboxcfg_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/inboxcfg"
+)
+
+// The sync_on_status fields parse from the inboxes: doc, and default OFF when
+// absent (opt-in, so an upgrade never changes what STATUS costs by surprise —
+// ADR 0028).
+func TestSyncOnStatusConfigParse(t *testing.T) {
+	doc := []byte(`
+inboxes:
+  - name: work
+    sync_on_status: true
+    sync_on_status_interval: "30s"
+  - name: personal
+`)
+	inboxes, err := inboxcfg.Parse(doc)
+	require.NoError(t, err)
+	require.Len(t, inboxes, 2)
+
+	assert.True(t, inboxes[0].SyncOnStatus)
+	assert.Equal(t, "30s", inboxes[0].SyncOnStatusInterval)
+
+	assert.False(t, inboxes[1].SyncOnStatus, "absent sync_on_status defaults OFF")
+	assert.Empty(t, inboxes[1].SyncOnStatusInterval)
+}
+
+func TestSyncOnStatusDuration(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"", 0, false}, // empty → runtime default (60s)
+		{"15s", 15 * time.Second, false},
+		{"1m", time.Minute, false},
+		{"nope", 0, true}, // unparseable
+		{"0s", 0, true},   // zero rejected
+		{"-5s", 0, true},  // negative rejected
+	}
+	for _, c := range cases {
+		d, err := inboxcfg.Inbox{SyncOnStatusInterval: c.in}.SyncOnStatusDuration()
+		if c.wantErr {
+			assert.Error(t, err, "interval %q", c.in)
+			continue
+		}
+		require.NoError(t, err, "interval %q", c.in)
+		assert.Equal(t, c.want, d, "interval %q", c.in)
+	}
+}
+
+// Validate fail-fasts on a bad debounce window only for an ENABLED inbox; a
+// disabled inbox's interval is meaningless and not validated.
+func TestValidateSyncOnStatusInterval(t *testing.T) {
+	enabledBad := []inboxcfg.Inbox{{Name: "work", SyncOnStatus: true, SyncOnStatusInterval: "nope"}}
+	assert.Error(t, inboxcfg.Validate(enabledBad), "enabled + bad interval is rejected at load")
+
+	enabledZero := []inboxcfg.Inbox{{Name: "work", SyncOnStatus: true, SyncOnStatusInterval: "0s"}}
+	assert.Error(t, inboxcfg.Validate(enabledZero), "enabled + zero interval is rejected")
+
+	enabledOK := []inboxcfg.Inbox{{Name: "work", SyncOnStatus: true, SyncOnStatusInterval: "15s"}}
+	assert.NoError(t, inboxcfg.Validate(enabledOK))
+
+	enabledEmpty := []inboxcfg.Inbox{{Name: "work", SyncOnStatus: true}}
+	assert.NoError(t, inboxcfg.Validate(enabledEmpty), "enabled + empty interval uses the runtime default")
+
+	disabledBad := []inboxcfg.Inbox{{Name: "work", SyncOnStatusInterval: "nope"}}
+	assert.NoError(t, inboxcfg.Validate(disabledBad), "a disabled inbox's interval is not validated")
+}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -48,6 +48,14 @@ type ContentFetch func(owner, inbox, id string) (inbound.Message, error)
 // disabled).
 type KeywordWriter func(owner, inbox, id string, add, remove []string) error
 
+// SyncTrigger runs a debounced on-demand upstream pull of an inbox (ADR 0028),
+// invoked when a client issues STATUS for an inbox the operator opted in. It is
+// best-effort: a returned error is logged, never surfaced to the client (STATUS
+// still reports the store's current counts). nil disables on-demand sync (the
+// back-compat / no-opted-in-inbox path), and it is a no-op for an inbox that is
+// not opted in or whose debounce window has not elapsed.
+type SyncTrigger func(inbox string) error
+
 // IMAPServer serves the agent's mailbox (the InboundStore) over IMAP as a
 // translation adapter (ADR 0016): the store is canonical. SELECT snapshots
 // metadata only; a body FETCH resolves content per-message via a ContentFetch.
@@ -68,7 +76,9 @@ type IMAPServer struct {
 // in multi-agent mode, so agents sharing an inbox read the same records. nil (the
 // single-agent / back-compat path) keys synced mail by the connecting agent, as
 // before.
-func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool, mailOwner func(inbox string) string) (*IMAPServer, error) {
+// syncNow triggers a debounced on-demand upstream pull of an inbox on STATUS
+// (ADR 0028); nil disables on-demand sync (STATUS stays a plain query).
+func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool, mailOwner func(inbox string) string, syncNow SyncTrigger) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -80,7 +90,7 @@ func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore,
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner}, nil, nil
+			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner, syncNow: syncNow}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -112,6 +122,7 @@ type imapSession struct {
 	holdSpoof     bool                      // on_spoof=hold-for-human → held-semantics; false = hide
 	principal     *Principal                // the authenticated agent + its grants (ADR 0027)
 	mailOwner     func(inbox string) string // synced-mail owner key per inbox (ADR 0027); nil = key by the connecting agent
+	syncNow       SyncTrigger               // debounced on-demand pull on STATUS (ADR 0028); nil = disabled
 	owner         string
 	selectedInbox string // the inbox name of the SELECTed mailbox (ADR 0023)
 	authed        bool
@@ -351,6 +362,17 @@ func (s *imapSession) Status(mailbox string, options *imap.StatusOptions) (*imap
 	inbox, ok := s.resolveMailbox(mailbox)
 	if !ok {
 		return nil, fmt.Errorf("imap: no such mailbox %q", mailbox)
+	}
+	// On-demand sync (ADR 0028): STATUS is the agent's "sync now" — trigger a
+	// debounced upstream pull for this inbox BEFORE computing the counts, so the
+	// reply reflects mail that arrived since the last background poll. Best-effort:
+	// a pull error is logged, never surfaced (STATUS still reports the store's
+	// current counts); the trigger is a no-op for an inbox that is not opted in or
+	// whose debounce window has not elapsed (silent-skip).
+	if s.syncNow != nil {
+		if err := s.syncNow(inbox); err != nil {
+			slog.Warn("imap on-demand sync failed", "inbox", inbox, "err", err)
+		}
 	}
 	full, visible, err := s.listAndFilter(inbox) // a query, not a selection — selectedInbox unchanged
 	if err != nil {

--- a/internal/listener/imap_status_sync_test.go
+++ b/internal/listener/imap_status_sync_test.go
@@ -1,0 +1,118 @@
+package listener_test
+
+import (
+	"net"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/filter"
+	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/listener"
+)
+
+// startIMAPSyncTrigger serves the read face with an on-demand SyncTrigger wired in
+// (ADR 0028), so a test can observe STATUS driving the pull.
+func startIMAPSyncTrigger(t *testing.T, store inbound.InboundStore, syncNow listener.SyncTrigger) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	filters := map[string]*filter.Filter{inbound.DefaultInbox: nil}
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
+		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil, syncNow)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+func addInboundMsg(t *testing.T, store inbound.InboundStore, subject string) {
+	t.Helper()
+	_, err := store.Add(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, Subject: subject,
+		Raw: []byte("Subject: " + subject + "\r\n\r\nx"),
+	})
+	require.NoError(t, err)
+}
+
+// ADR 0028: STATUS triggers the on-demand pull for the resolved inbox BEFORE the
+// counts are computed, so the reply reflects mail the pull brought in. The trigger
+// receives the resolved inbox name (not the "INBOX" mailbox alias), and STATUS
+// needs no prior SELECT.
+func TestStatusTriggersOnDemandSync(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	addInboundMsg(t, store, "existing")
+
+	var gotInbox atomic.Value
+	var calls atomic.Int32
+	// The trigger stands in for a debounced upstream pull: it records the inbox and
+	// lands one new message in the store, exactly as a real Sync would.
+	syncNow := func(inbox string) error {
+		calls.Add(1)
+		gotInbox.Store(inbox)
+		addInboundMsg(t, store, "pulled-by-status")
+		return nil
+	}
+
+	c, err := imapclient.DialInsecure(startIMAPSyncTrigger(t, store, syncNow), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+
+	data, err := c.Status("INBOX", &imap.StatusOptions{NumMessages: true}).Wait()
+	require.NoError(t, err)
+	require.NotNil(t, data.NumMessages)
+	assert.Equal(t, uint32(2), *data.NumMessages, "STATUS count includes the message the pull brought in")
+	assert.Equal(t, int32(1), calls.Load(), "STATUS triggered exactly one pull")
+	assert.Equal(t, inbound.DefaultInbox, gotInbox.Load(), "trigger gets the resolved inbox name, not INBOX")
+}
+
+// A pull error never fails the STATUS: it is best-effort, so STATUS still reports
+// the store's current counts (ADR 0028).
+func TestStatusSurvivesSyncError(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	addInboundMsg(t, store, "existing")
+
+	syncNow := func(string) error { return assert.AnError }
+
+	c, err := imapclient.DialInsecure(startIMAPSyncTrigger(t, store, syncNow), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+
+	data, err := c.Status("INBOX", &imap.StatusOptions{NumMessages: true}).Wait()
+	require.NoError(t, err, "a pull error does not fail STATUS")
+	require.NotNil(t, data.NumMessages)
+	assert.Equal(t, uint32(1), *data.NumMessages)
+}
+
+// NOOP stays a true no-op — it never triggers an on-demand pull (ADR 0028: only
+// STATUS is the "sync now" verb).
+func TestNoopDoesNotTriggerSync(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	addInboundMsg(t, store, "existing")
+
+	var calls atomic.Int32
+	syncNow := func(string) error { calls.Add(1); return nil }
+
+	c, err := imapclient.DialInsecure(startIMAPSyncTrigger(t, store, syncNow), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	// Select then NOOP: neither may trigger the on-demand pull.
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	require.NoError(t, c.Noop().Wait())
+	assert.Equal(t, int32(0), calls.Load(), "NOOP does not trigger a pull")
+}

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -45,7 +45,7 @@ func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false, nil)
+		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false, nil, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -57,7 +57,7 @@ func startIMAPMulti(t *testing.T, store inbound.InboundStore, filters map[string
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil)
+		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -69,7 +69,7 @@ func startIMAPAuth(t *testing.T, store inbound.InboundStore, filters map[string]
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		auth, store, nil, nil, filters, nil, false, nil)
+		auth, store, nil, nil, filters, nil, false, nil, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -630,7 +630,7 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false, nil)
+		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false, nil, nil)
 	require.Error(t, err)
 }
 
@@ -639,7 +639,7 @@ func startIMAPDecoupled(t *testing.T, store inbound.InboundStore, filters map[st
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		auth, store, nil, nil, filters, nil, false, mailOwner)
+		auth, store, nil, nil, filters, nil, false, mailOwner, nil)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })


### PR DESCRIPTION
## What

Adds **on-demand inbound sync**: an IMAP `STATUS` for an opted-in inbox now runs an immediate, per-inbox **debounced** upstream pull *before* returning counts, so an agent can "sync now" — see its reply on the same round-trip — instead of waiting out the background poll interval (ADR 0019). `NOOP`/`CHECK` stay true no-ops; no keep-alive triggers a dial.

Motivation: after a send/approval or a test round-trip, new mail isn't visible on the IMAP face until the next scheduled poll. `STATUS` ("give me current status") is the honest, low-frequency place to refresh first and then report.

## Design (ADR 0028)

- **Trigger = `STATUS`, not `NOOP`.** `Status()` already re-lists the store fresh per call, so the only change is to run the pull up front; the existing MESSAGES/UNSEEN/UIDNEXT computation then reports the grown set. Works without a prior `SELECT`.
- **Mandatory per-inbox debounce.** After a pull completes, further triggers for that inbox are suppressed until a configurable window elapses (**silent-skip**: no dial, current counts returned). The debounce is **shared across sessions** (N agents sharing an inbox collapse to one dial) plus a **single-flight** guard; the window is measured from pull *completion*.
- **Best-effort.** A pull error is logged, never surfaced — `STATUS` still reports the store's current counts.
- **Counts-only (v1 boundary).** No unsolicited `EXISTS`/`EXPUNGE` into a selected session; a growth or a reconcile-retraction shrink surfaces via the count and the client's next `SELECT`, never as a mid-session sequence desync.
- **Opt-in per inbox**, default OFF, matching the `reconcile_enabled` idiom: `sync_on_status` + `sync_on_status_interval` (default **60s** window). Inert until an operator opts an inbox in; ignored for a bounce-only / sync-disabled inbox.

## Package touches

- `adr/0028-…` — the decision record (+ adr index). **hard-gate.**
- `internal/imapsync/ondemand.go` — `OnDemandSync` (per-inbox debounce + single-flight).
- `internal/inboxcfg` — `sync_on_status` / `sync_on_status_interval` schema + validation.
- `internal/listener/imap.go` — `Status()` triggers the pull; `SyncTrigger` type plumbed through `NewIMAPServer`.
- `cmd/darbaan/main.go` — builds the coordinator from opted-in inboxes + the runtime default; wires the trigger onto the read face.

## Testing

- `OnDemandSync`: pulls on first trigger, silent-skips within the window, pulls again after it; no-op for an unregistered inbox; no-window = every trigger pulls.
- `Status()`: triggers the pull (gets the resolved inbox name, not `INBOX`) and reflects the pulled mail in the count; survives a pull error; `NOOP` triggers nothing.
- inboxcfg: parse defaults-OFF, duration parsing, enabled-only validation.
- Local `go build` / `go vet` / `gofmt -l` / `go test -race ./...` all green.

## Gate

Touches `adr/*` → hard-gate: the maintainer's APPROVE on the current HEAD, on top of the standard 2-of-N reviews and green CI. The STATUS trigger, the 60s default window, and silent-skip-within-window were all settled before implementation.