### PR TITLE
docs(adr): note anti-storm stamp-on-failure in ADR 0028

### DIFF
--- a/adr/0028-on-demand-inbound-sync-on-status.md
+++ b/adr/0028-on-demand-inbound-sync-on-status.md
@@ -78,6 +78,14 @@ one is already in flight (a single-flight guard), so a burst collapses to one
 dial. The window is measured from pull **completion**, so a slow pull does not
 immediately re-trigger.
 
+A **failed** pull starts the window too — the completion timestamp is stamped
+whether the pull succeeded or errored. This is deliberate anti-storm behavior: a
+persistently unreachable or erroring upstream cannot be turned into a dial-storm
+by repeated `STATUS`, since each failed attempt still opens a fresh debounce
+window. The background poll loop (ADR 0019) is the fallback that keeps retrying
+and eventually recovers, so suppressing on-demand retries within the window
+loses nothing.
+
 ### Counts, not unsolicited updates (v1 boundary)
 
 `STATUS` reports fresh counts computed after the pull; it pushes **no**


### PR DESCRIPTION
Non-blocking follow-up from the #174 review.

Adds one paragraph to ADR 0028's Debounce section: a **failed** on-demand pull also stamps the debounce completion time, so a persistently unreachable or erroring upstream cannot be turned into a dial-storm by repeated `STATUS` — each failed attempt still opens a fresh window. The background poll loop (ADR 0019) is the recovery fallback that keeps retrying.

Documents existing behavior; **no code change**. Deferred out of #174 to avoid invalidating the gate approval on that HEAD.

## Gate

Touches `adr/*` → hard-gate: the maintainer's APPROVE on HEAD, plus 2-of-N and green CI.