### PR TITLE
feat(sync): log successful on-demand inbound sync pulls (ADR 0028)

### DIFF
--- a/internal/imapsync/ondemand.go
+++ b/internal/imapsync/ondemand.go
@@ -2,6 +2,7 @@ package imapsync
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -76,5 +77,14 @@ func (o *OnDemandSync) Trigger(ctx context.Context, inbox string) (int, bool, er
 	in.inflight = false
 	in.last = time.Now() // start the window from completion, not from entry
 	o.mu.Unlock()
+
+	// Log the fire path (only when a pull actually ran, not the silent-skip) so an
+	// on-demand pull is unambiguous in the logs — distinct from the background
+	// poll's "inbound sync pulled messages" and from a skip that logged nothing. A
+	// failed pull is left to the caller to log (the STATUS handler warns); here we
+	// record the successful fire and its count.
+	if err == nil {
+		slog.Info("on-demand inbound sync ran", "inbox", inbox, "pulled", n)
+	}
 	return n, true, err
 }

--- a/internal/imapsync/ondemand_test.go
+++ b/internal/imapsync/ondemand_test.go
@@ -1,7 +1,9 @@
 package imapsync_test
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -51,6 +53,39 @@ func TestOnDemandSyncDebounces(t *testing.T) {
 	msgs, err = store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
 	assert.Len(t, msgs, 2)
+}
+
+// A fired pull logs an unambiguous "on-demand inbound sync ran" line with the
+// inbox and pulled count, so a prod log can distinguish an on-demand pull from an
+// early background poll; a silent-skip within the window logs nothing.
+func TestOnDemandSyncLogsOnFire(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\nbody one")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	od := imapsync.NewOnDemandSync()
+	od.Register(inbound.DefaultInbox, syncer, time.Hour) // long window: only the first fires
+
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(old)
+
+	_, ran, err := od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.True(t, ran)
+	logged := buf.String()
+	assert.Contains(t, logged, "on-demand inbound sync ran")
+	assert.Contains(t, logged, "inbox=default")
+	assert.Contains(t, logged, "pulled=1")
+
+	// A silent-skip within the (1h) window logs nothing.
+	buf.Reset()
+	_, ran, err = od.Trigger(context.Background(), inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.False(t, ran)
+	assert.Empty(t, buf.String(), "a debounced skip logs nothing")
 }
 
 // An inbox that was never registered (not opted in, or bounce-only with no


### PR DESCRIPTION
Follow-up (b) from the v0.9.0 sync_on_status verification — closes an observability gap.

`OnDemandSync.Trigger` now emits an Info log **`on-demand inbound sync ran`** (with `inbox` + `pulled` count) when a pull actually fires, and only then — a debounced silent-skip logs nothing.

### Why

The on-demand **success** path was silent: `Syncer.Sync` logs the pull count only through the background loop's `runSync` wrapper, which the on-demand trigger bypasses; only a *failed* pull logged (the STATUS handler warns). So from prod logs you couldn't answer "did the on-demand path fire, or did the 5m background poll just run early?" — this line makes an on-demand pull unambiguous and distinct from the background `inbound sync pulled messages`.

Placed in `Trigger` after the `Sync` call (per review suggestion), logged only on the fire path (`err == nil`), so it never fires on the debounced skip.

### Testing

- New `TestOnDemandSyncLogsOnFire`: a fired pull logs `on-demand inbound sync ran` with `inbox=…` + `pulled=…`; a debounced skip logs nothing.
- Local `go build` / `go vet` / `gofmt -l` / `go test -race ./...` green.

No `adr/*` touch — standard 2-of-N.