### PR TITLE
fix(telegram): retry Change-sender identity fetch in the poll loop (#160)

### DIFF
--- a/internal/telegram/identity_retry_internal_test.go
+++ b/internal/telegram/identity_retry_internal_test.go
@@ -1,0 +1,96 @@
+package telegram
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+// newClientForAdmin builds a bare Client pointed at a test admin server, with the
+// bot/handler machinery omitted (these tests exercise only the identity fetch).
+func newClientForAdmin(url string) *Client {
+	return &Client{
+		admin:  admin.NewClient(strings.TrimPrefix(url, "http://"), "tok"),
+		logger: slog.Default(),
+	}
+}
+
+// #160: the Change-sender identity fetch is retried by the poll loop until it
+// succeeds. A co-start race where serve's admin endpoint isn't listening yet
+// leaves Change-sender off for that cycle but self-recovers on the next, instead
+// of staying off until a manual restart.
+func TestEnsureIdentitiesRetriesUntilReady(t *testing.T) {
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		// First cycle: serve not ready yet (stands in for connection-refused).
+		if calls.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`[{"name":"work","identity":"w@x"},{"name":"personal","identity":"p@x"}]`))
+	}))
+	defer srv.Close()
+	c := newClientForAdmin(srv.URL)
+
+	// Cycle 1: serve not ready → nothing loaded, Change-sender omitted from the
+	// decision keyboard (Approve + Reject rows only).
+	c.ensureIdentities(context.Background())
+	assert.False(t, c.identitiesLoaded)
+	assert.Empty(t, c.inboxIdentities())
+	assert.Len(t, c.decisionKeyboard("42").InlineKeyboard, 2)
+
+	// Cycle 2: serve ready → identities loaded, Change-sender now offered (Approve +
+	// Change + Reject rows).
+	c.ensureIdentities(context.Background())
+	assert.True(t, c.identitiesLoaded)
+	require.Len(t, c.inboxIdentities(), 2)
+	assert.Len(t, c.decisionKeyboard("42").InlineKeyboard, 3)
+
+	// Cycle 3: already loaded → no further upstream fetch (call count stays at 2).
+	c.ensureIdentities(context.Background())
+	assert.Equal(t, int32(2), calls.Load(), "no re-fetch after the first success")
+}
+
+// The identities are written by the poll goroutine (ensureIdentities) and read by
+// the callback goroutine (decisionKeyboard / identityKeyboard), so the access must
+// be race-clean under -race (#160 retires the old "read-only after startup" lock
+// exemption).
+func TestInboxIdentitiesRaceClean(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`[{"name":"a","identity":"a@x"},{"name":"b","identity":"b@x"}]`))
+	}))
+	defer srv.Close()
+	c := newClientForAdmin(srv.URL)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // poll-loop side: writes identities
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			c.ensureIdentities(context.Background())
+		}
+	}()
+	for r := 0; r < 4; r++ {
+		wg.Add(1)
+		go func() { // callback side: reads identities
+			defer wg.Done()
+			for i := 0; i < 50; i++ {
+				_ = c.inboxIdentities()
+				_ = c.decisionKeyboard("1")
+				_ = c.identityKeyboard("1")
+			}
+		}()
+	}
+	wg.Wait()
+	assert.True(t, c.identitiesLoaded)
+}

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -56,10 +56,16 @@ type Client struct {
 
 	logger *slog.Logger // structured logger; defaults to slog.Default(), injectable via SetLogger
 
-	// identities are the configured inbox send identities (ADR 0023 slice 5),
-	// fetched from serve at startup; the Change-sender picker offers them. Read-only
-	// after Run's initial fetch, so no lock is needed.
-	identities []admin.InboxIdentity
+	// identities are the configured inbox send identities (ADR 0023 slice 5) that the
+	// Change-sender picker offers. They are fetched from serve lazily by the poll
+	// loop (retry-until-success, #160) rather than once at startup, so a co-start
+	// race where serve's admin endpoint isn't up yet self-recovers instead of
+	// leaving Change-sender permanently off. idMu guards them because the poll
+	// goroutine now writes them while the callback goroutine (identityKeyboard)
+	// reads them; identitiesLoaded stops the loop re-fetching once it has succeeded.
+	idMu             sync.RWMutex
+	identities       []admin.InboxIdentity
+	identitiesLoaded bool
 
 	mu          sync.Mutex
 	posted      map[string]bool     // sluice message ids already sent to the operator
@@ -145,14 +151,8 @@ func (c *Client) Run(ctx context.Context) error {
 	}
 	c.logger.Info("telegram client ready", "bot", me.Username, "operator", c.operatorID, "poll_interval", c.pollInterval.String())
 
-	// Fetch the configured inbox identities for the Change-sender picker (ADR 0023
-	// slice 5); best-effort — without them the gate simply omits Change.
-	if ids, ierr := c.admin.Inboxes(ctx); ierr != nil {
-		c.logger.Warn("telegram fetch inbox identities failed; change-sender disabled", "err", ierr)
-	} else {
-		c.identities = ids
-	}
-
+	// The Change-sender identities are fetched by the poll loop (#160), not here, so
+	// a not-yet-ready serve at co-start is retried rather than fatal to Change-sender.
 	go c.pollLoop(ctx)
 	c.bot.Start(ctx) // long-poll loop; returns when ctx is cancelled
 	return nil
@@ -161,17 +161,55 @@ func (c *Client) Run(ctx context.Context) error {
 func (c *Client) pollLoop(ctx context.Context) {
 	t := time.NewTicker(c.pollInterval)
 	defer t.Stop()
-	c.poll(ctx) // post anything already pending at startup
+	c.ensureIdentities(ctx) // fetch the Change-sender identities (retries next tick if serve isn't up yet)
+	c.poll(ctx)             // post anything already pending at startup
 	c.pollHolds(ctx)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+			c.ensureIdentities(ctx)
 			c.poll(ctx)
 			c.pollHolds(ctx)
 		}
 	}
+}
+
+// ensureIdentities fetches the configured inbox send identities for the
+// Change-sender picker (ADR 0023 slice 5) once, from the poll loop. It is a no-op
+// after the first success; before that, every poll cycle retries — mirroring how
+// poll/pollHolds already tolerate a not-yet-listening serve — so a co-start race
+// (telegram up before serve's admin endpoint) self-recovers on the next tick
+// instead of leaving Change-sender off until a manual restart (#160). A failed
+// fetch logs at debug (the loop retries) rather than warning every cycle.
+func (c *Client) ensureIdentities(ctx context.Context) {
+	c.idMu.RLock()
+	loaded := c.identitiesLoaded
+	c.idMu.RUnlock()
+	if loaded {
+		return
+	}
+	ids, err := c.admin.Inboxes(ctx)
+	if err != nil {
+		c.logger.Debug("telegram inbox identities not ready yet; will retry", "err", err)
+		return
+	}
+	c.idMu.Lock()
+	c.identities = ids
+	c.identitiesLoaded = true
+	c.idMu.Unlock()
+	c.logger.Info("telegram change-sender identities loaded", "count", len(ids))
+}
+
+// inboxIdentities returns the fetched Change-sender identities under the read lock
+// (the poll loop writes them, the callback goroutine reads them, #160). The slice
+// is replaced wholesale on load and never mutated in place, so the returned header
+// is safe to range without holding the lock.
+func (c *Client) inboxIdentities() []admin.InboxIdentity {
+	c.idMu.RLock()
+	defer c.idMu.RUnlock()
+	return c.identities
 }
 
 // poll lists the queue and notifies the operator of each new pending message.
@@ -444,7 +482,7 @@ func (c *Client) decisionKeyboard(id string) models.InlineKeyboardMarkup {
 	rows := [][]models.InlineKeyboardButton{
 		{{Text: "Approve", CallbackData: cbApprove + id}},
 	}
-	if len(c.identities) >= 2 {
+	if len(c.inboxIdentities()) >= 2 {
 		rows = append(rows, []models.InlineKeyboardButton{{Text: "Change sender", CallbackData: cbChange + id}})
 	}
 	rows = append(rows, []models.InlineKeyboardButton{
@@ -458,8 +496,9 @@ func (c *Client) decisionKeyboard(id string) models.InlineKeyboardMarkup {
 // identity (approve-and-send as that identity), plus a Back to the decision
 // buttons (ADR 0023 slice 5).
 func (c *Client) identityKeyboard(id string) models.InlineKeyboardMarkup {
-	rows := make([][]models.InlineKeyboardButton, 0, len(c.identities)+1)
-	for _, in := range c.identities {
+	ids := c.inboxIdentities()
+	rows := make([][]models.InlineKeyboardButton, 0, len(ids)+1)
+	for _, in := range ids {
 		rows = append(rows, []models.InlineKeyboardButton{
 			{Text: in.Identity, CallbackData: cbApproveAs + in.Name + ":" + id},
 		})


### PR DESCRIPTION
Closes #160. Fast-follow to #139 (Change-sender) / v0.7.0.

## Problem

The Telegram client fetched the configured inbox identities (for the Change-sender picker) once at startup, best-effort. If telegram came up before serve's admin endpoint was listening (a normal docker-compose co-start race — observed ~0.3s on the v0.7.0 deploy), the fetch failed with connection refused, logged a warning, and Change-sender stayed **permanently disabled** until the telegram container was manually restarted.

## Fix — Option 1 (retry in the poll loop)

Fold the fetch into `pollLoop` via `ensureIdentities`: retried each cycle until it succeeds, then a no-op. This mirrors exactly how `poll`/`pollHolds` already tolerate a not-yet-listening serve, so a co-start race self-recovers on the next tick.

**Why Option 1 over lazy-fetch-on-first-tap:** the "Change sender" button is rendered by `decisionKeyboard` at **message-post time** (poll goroutine), gated on `len(identities) >= 2`. On a co-start race the button never appears, so there is no Change tap to lazily fetch on — Option 2 would need a bigger UX change (always show the button, fetch on tap). Retry-in-poll-loop fits the existing structure. (Reviewers concurred on this before implementation.)

## Concurrency

Identities move from write-once-at-startup to written-by-the-poll-goroutine while read by the callback goroutine (`identityKeyboard`) and the poll goroutine (`decisionKeyboard`), so they are now guarded by a `sync.RWMutex`; reads go through `inboxIdentities()`. The old `telegram.go` "read-only after Run's initial fetch, no lock needed" comment is retired.

## Logging

A failed fetch now logs at **debug** (the loop retries) instead of a one-shot warning; success logs an info line. A persistent serve-down is already signalled loudly by `poll`/`pollHolds` erroring each cycle, so this avoids a duplicate per-cycle warning during the brief normal race.

## Testing

- `TestEnsureIdentitiesRetriesUntilReady`: first cycle (serve 503) → nothing loaded, decision keyboard omits Change; second cycle (serve ready) → loaded, Change offered; third cycle → no re-fetch after success.
- `TestInboxIdentitiesRaceClean`: concurrent poll-goroutine writes + callback-goroutine reads, clean under `-race`.
- Full `go build` / `go vet` / `gofmt -l` / `go test -race ./...` green.

No `adr/*` touch — standard 2-of-N.