### PR TITLE
feat(telegram): push a proactive alert on reconcile cap-latch (#149)

### DIFF
--- a/internal/telegram/reconcile.go
+++ b/internal/telegram/reconcile.go
@@ -1,0 +1,94 @@
+package telegram
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-telegram/bot"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+// pollReconcile lists each inbox's reconciliation latch (ADR 0026) and pushes a
+// proactive alert for each inbox the safety cap has newly suspended, so the
+// operator learns of a latch without polling the status surface (#149). It is the
+// reconcile mirror of pollHolds: alert once per latch, and prune the dedup set
+// when an inbox is no longer suspended so a re-latch after an operator release
+// notifies again.
+//
+// Reconciliation is opt-in and off by default (ADR 0026), so the status call is
+// unavailable (503) in the common config; a poll failure is logged at debug — not
+// error — so it never spams every cycle when reconcile is off. A genuine serve
+// outage is already surfaced loudly by poll/pollHolds.
+func (c *Client) pollReconcile(ctx context.Context) {
+	statuses, err := c.admin.ReconcileStatus(ctx)
+	if err != nil {
+		c.logger.Debug("telegram poll reconcile status failed", "err", err)
+		return
+	}
+	c.pruneLatched(statuses)
+	for _, st := range statuses {
+		if !st.Suspended || c.seenLatch(st.Inbox) {
+			continue
+		}
+		if err := c.notifyLatch(ctx, st); err != nil {
+			c.logger.Warn("telegram notify reconcile latch failed", "inbox", st.Inbox, "err", err)
+			continue
+		}
+		c.markPostedLatch(st.Inbox)
+	}
+}
+
+func (c *Client) notifyLatch(ctx context.Context, st admin.ReconcileStatus) error {
+	_, err := c.bot.SendMessage(ctx, &bot.SendMessageParams{
+		ChatID: c.operatorID,
+		Text:   formatLatch(st),
+	})
+	return err
+}
+
+// formatLatch is the operator-facing latch alert. It names the inbox and the
+// held-count and points at the CLI release — deliberately NOT a one-tap button,
+// since releasing runs a cap-bypassed purge the operator should decide only after
+// checking why the inbox latched (a legitimate source removal vs. an anomaly);
+// the latch exists to force that deliberation (ADR 0026).
+func formatLatch(st admin.ReconcileStatus) string {
+	return fmt.Sprintf(
+		"⚠️ Reconciliation held — inbox %q\n"+
+			"The safety cap suspended reconciliation: %d message(s) would be retracted "+
+			"(a possible source-side mass removal). Retraction is paused for this inbox "+
+			"until you release it — nothing has been purged.\n"+
+			"Check the source, then run:  darbaan reconcile release %s",
+		st.Inbox, st.HeldCount, st.Inbox)
+}
+
+// pruneLatched drops dedup entries for inboxes that are no longer suspended, so a
+// release followed by a fresh latch re-notifies (the reconcile mirror of
+// prunePostedHolds).
+func (c *Client) pruneLatched(statuses []admin.ReconcileStatus) {
+	suspended := make(map[string]bool, len(statuses))
+	for _, st := range statuses {
+		if st.Suspended {
+			suspended[st.Inbox] = true
+		}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for inbox := range c.postedLatches {
+		if !suspended[inbox] {
+			delete(c.postedLatches, inbox)
+		}
+	}
+}
+
+func (c *Client) seenLatch(inbox string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.postedLatches[inbox]
+}
+
+func (c *Client) markPostedLatch(inbox string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.postedLatches[inbox] = true
+}

--- a/internal/telegram/reconcile_internal_test.go
+++ b/internal/telegram/reconcile_internal_test.go
@@ -1,0 +1,64 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+func TestFormatLatch(t *testing.T) {
+	s := formatLatch(admin.ReconcileStatus{Inbox: "work", Suspended: true, HeldCount: 42})
+	assert.Contains(t, s, "Reconciliation held")
+	assert.Contains(t, s, `"work"`)
+	assert.Contains(t, s, "42 message(s)")
+	assert.Contains(t, s, "nothing has been purged") // the latch is non-destructive
+	assert.Contains(t, s, "darbaan reconcile release work")
+	// Notification-only: no inline keyboard / one-tap release is offered (#149).
+	assert.NotContains(t, s, "button")
+}
+
+// The dedup/re-notify cycle that matters most (#149): a latched inbox is alerted
+// once; when it is no longer suspended (released) the dedup entry is cleared, so a
+// fresh latch re-notifies. This exercises seenLatch / markPostedLatch /
+// pruneLatched exactly as pollReconcile drives them across poll cycles.
+func TestLatchDedupReNotifyCycle(t *testing.T) {
+	c := &Client{postedLatches: map[string]bool{}}
+	latched := []admin.ReconcileStatus{{Inbox: "work", Suspended: true, HeldCount: 5}}
+	released := []admin.ReconcileStatus{{Inbox: "work", Suspended: false}}
+
+	// Cycle 1 — first latch: not yet seen → alert, then mark.
+	c.pruneLatched(latched)
+	assert.False(t, c.seenLatch("work"), "first latch is unseen → alerts")
+	c.markPostedLatch("work")
+
+	// Cycle 2 — still latched: already seen → no re-alert (post-once).
+	c.pruneLatched(latched)
+	assert.True(t, c.seenLatch("work"), "still-latched inbox stays deduped")
+
+	// Cycle 3 — released (no longer suspended): dedup entry is pruned.
+	c.pruneLatched(released)
+	assert.False(t, c.seenLatch("work"), "release clears the dedup entry")
+
+	// Cycle 4 — fresh latch after the release: unseen again → re-alerts.
+	c.pruneLatched(latched)
+	assert.False(t, c.seenLatch("work"), "a re-latch after release notifies again")
+	c.markPostedLatch("work")
+	assert.True(t, c.seenLatch("work"))
+}
+
+// pruneLatched keeps still-suspended inboxes and drops only the ones that have
+// dropped out of the suspended set, independent of other inboxes.
+func TestPruneLatchedIsPerInbox(t *testing.T) {
+	c := &Client{postedLatches: map[string]bool{"work": true, "personal": true}}
+	// work still suspended, personal released; a third inbox not previously alerted.
+	c.pruneLatched([]admin.ReconcileStatus{
+		{Inbox: "work", Suspended: true, HeldCount: 3},
+		{Inbox: "personal", Suspended: false},
+		{Inbox: "team", Suspended: true, HeldCount: 9},
+	})
+	assert.True(t, c.seenLatch("work"), "still-suspended inbox kept")
+	assert.False(t, c.seenLatch("personal"), "released inbox pruned")
+	assert.False(t, c.seenLatch("team"), "prune never adds entries")
+}

--- a/internal/telegram/telegram.go
+++ b/internal/telegram/telegram.go
@@ -9,9 +9,12 @@
 // immediately; either Reject first prompts (force-reply) for a reason that
 // becomes the DSN bounce reason. It also polls the INBOUND hold-for-human queue
 // (ADR 0021) and posts each held message with an [Expose] / [Drop] keyboard —
-// Expose reveals it to the agent, Drop keeps it hidden (see holds.go). Only the
-// configured operator may decide (ADR 0002) — every tap and reply is gated to
-// them.
+// Expose reveals it to the agent, Drop keeps it hidden (see holds.go). It also
+// pushes a proactive alert when the reconcile safety cap latches an inbox
+// (ADR 0026, #149), so a suspended inbox — reconciliation paused pending an
+// operator release — is not missed on the pull-only status surface (see
+// reconcile.go). Only the configured operator may decide (ADR 0002) — every tap
+// and reply is gated to them.
 package telegram
 
 import (
@@ -67,10 +70,11 @@ type Client struct {
 	identities       []admin.InboxIdentity
 	identitiesLoaded bool
 
-	mu          sync.Mutex
-	posted      map[string]bool     // sluice message ids already sent to the operator
-	postedHolds map[string]bool     // inbound-hold ids already sent (separate id space)
-	pending     map[int]rejectState // reject reason prompts awaiting the operator's reply, keyed by prompt message id
+	mu            sync.Mutex
+	posted        map[string]bool     // sluice message ids already sent to the operator
+	postedHolds   map[string]bool     // inbound-hold ids already sent (separate id space)
+	postedLatches map[string]bool     // reconcile-latched inbox names already alerted (#149); cleared on un-suspend so a re-latch re-notifies
+	pending       map[int]rejectState // reject reason prompts awaiting the operator's reply, keyed by prompt message id
 }
 
 // SetLogger injects the structured logger for the Telegram client (#151);
@@ -117,14 +121,15 @@ func New(token string, operatorID int64, pollInterval time.Duration, adminClient
 		return nil, fmt.Errorf("telegram: init bot: %w", err)
 	}
 	c := &Client{
-		bot:          b,
-		admin:        adminClient,
-		operatorID:   operatorID,
-		pollInterval: pollInterval,
-		logger:       slog.Default(),
-		posted:       make(map[string]bool),
-		postedHolds:  make(map[string]bool),
-		pending:      make(map[int]rejectState),
+		bot:           b,
+		admin:         adminClient,
+		operatorID:    operatorID,
+		pollInterval:  pollInterval,
+		logger:        slog.Default(),
+		posted:        make(map[string]bool),
+		postedHolds:   make(map[string]bool),
+		postedLatches: make(map[string]bool),
+		pending:       make(map[int]rejectState),
 	}
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbApprove, bot.MatchTypePrefix, c.handleApprove)
 	b.RegisterHandler(bot.HandlerTypeCallbackQueryData, cbRejectPerm, bot.MatchTypePrefix, c.handleRejectPermanent)
@@ -164,6 +169,7 @@ func (c *Client) pollLoop(ctx context.Context) {
 	c.ensureIdentities(ctx) // fetch the Change-sender identities (retries next tick if serve isn't up yet)
 	c.poll(ctx)             // post anything already pending at startup
 	c.pollHolds(ctx)
+	c.pollReconcile(ctx)
 	for {
 		select {
 		case <-ctx.Done():
@@ -172,6 +178,7 @@ func (c *Client) pollLoop(ctx context.Context) {
 			c.ensureIdentities(ctx)
 			c.poll(ctx)
 			c.pollHolds(ctx)
+			c.pollReconcile(ctx)
 		}
 	}
 }


### PR DESCRIPTION
Closes #149. Fast-follow to #140 / ADR 0026.

## Problem

When the reconcile safety cap latches an inbox (suspends reconciliation until an operator release), the operator learned of it only by **polling** — `reconcile status` / `GET /reconcile` + the serve-log warning. A latch sitting unnoticed means retraction is silently off for that inbox (benign — nothing purged, upstream untouched — but timely notification matters, especially for an enabled personal inbox).

## Fix — `pollReconcile`, the reconcile mirror of `pollHolds`

Add `pollReconcile` to the telegram poll loop: list the reconcile status via the admin API (the `reconcile held` warn-log in `reconcile.go` was already the documented hook for this), and push a Telegram alert for each inbox the cap has **newly** suspended. This is the ADR-0017-consistent shape — telegram is a client-over-API that polls; serve doesn't push to it — reusing the exact `poll`/`pollHolds`/`prunePosted*` structure.

**Dedup / re-notify (the case that matters most):** per-inbox dedup via `postedLatches`, pruned when an inbox is no longer suspended — so a latch alerts **once**, a release clears the entry, and a **fresh latch after release re-notifies**. Covered directly in `TestLatchDedupReNotifyCycle`.

## Notification-only, by design

The alert names the inbox + held-count and points at `darbaan reconcile release <inbox>`, but offers **no one-tap release button**. Releasing runs a cap-bypassed purge the operator should decide only after checking *why* the inbox latched (legitimate source removal vs. anomaly). The latch exists to force that deliberation; a one-tap release would undercut it. (Reviewers concurred on notification-only before implementation.)

## Impl note

Reconciliation is opt-in / off by default (ADR 0026), so `ReconcileStatus` returns 503 (unavailable) in the common config. `pollReconcile` logs a poll failure at **debug**, not error, so it never spams every cycle when reconcile is off — same reasoning as #160 (a genuine serve-down is already loud via `poll`/`pollHolds`).

## Testing

- `TestFormatLatch`: message carries inbox, held-count, "nothing has been purged", the CLI release pointer; no button.
- `TestLatchDedupReNotifyCycle`: post-once → clear-on-release → re-notify-on-re-latch.
- `TestPruneLatchedIsPerInbox`: keeps still-suspended, prunes released, never adds entries.
- Full `go build` / `go vet` / `gofmt -l` / `go test -race ./...` green.

Single-package (telegram) change; no `adr/*` — standard 2-of-N.