### PR TITLE
feat(admincfg): admin_clients schema + scope vocabulary (ADR 0029 slice 1)

### DIFF
--- a/internal/admincfg/admincfg.go
+++ b/internal/admincfg/admincfg.go
@@ -1,0 +1,180 @@
+// Package admincfg is the admin-API scoped-token config schema (ADR 0029): the
+// `admin_clients:` list that sits beside `inboxes:` (ADR 0023) and `agents:`
+// (ADR 0027). Each admin client is a named credential with a least-privilege set
+// of scopes; its token is supplied out-of-band via env, never in config
+// (ADR 0012), and gates only the admin API (ADR 0017) — it is unrelated to the
+// ADR 0027 agent grants that gate mail read/send.
+//
+// A config with no `admin_clients:` list yields the back-compat behavior: the
+// single DARBAAN_ADMIN_TOKEN is an implicit full-scope root, so an existing
+// single-token deployment is unchanged (opt-in, exactly like `inboxes:`).
+//
+// This increment is schema + validation + the scope vocabulary and the
+// authoritative route→scope map. ENFORCEMENT — resolving a presented token to a
+// client and authorizing the route's required scope in the admin auth middleware
+// — lands in the next increment; here the schema is parsed and validated, but
+// access is not yet gated.
+package admincfg
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/yaad-index/darbaan/internal/inboxcfg"
+)
+
+// The scope vocabulary (ADR 0029): capability-based, coarse, one required scope
+// per admin route. A read scope grants the list/show endpoints of a resource; a
+// decide/release scope grants its state-changing endpoints.
+const (
+	ScopeQueueRead        = "queue:read"
+	ScopeQueueDecide      = "queue:decide"
+	ScopeHoldsRead        = "holds:read"
+	ScopeHoldsDecide      = "holds:decide"
+	ScopeReconcileRead    = "reconcile:read"
+	ScopeReconcileRelease = "reconcile:release"
+	ScopeInboxesRead      = "inboxes:read"
+)
+
+// RouteScopes is the authoritative route→required-scope map (ADR 0029): every
+// admin route (ADR 0017), keyed by its net/http ServeMux pattern, mapped to the
+// single scope a client's token must carry to reach it. The enforcement
+// increment registers each route against this map; a test pins it complete and
+// consistent (every route present, every value a known scope). Note reconcile
+// has read but the Telegram cap-latch alert (#149) reads GET /reconcile — so a
+// client needs only reconcile:read for it, never reconcile:release.
+var RouteScopes = map[string]string{
+	"GET /queue":                          ScopeQueueRead,
+	"GET /queue/{id}":                     ScopeQueueRead,
+	"POST /queue/{id}/approve":            ScopeQueueDecide,
+	"POST /queue/{id}/approve-as/{inbox}": ScopeQueueDecide,
+	"POST /queue/{id}/reject":             ScopeQueueDecide,
+	"GET /holds":                          ScopeHoldsRead,
+	"POST /holds/{id}/expose":             ScopeHoldsDecide,
+	"POST /holds/{id}/drop":               ScopeHoldsDecide,
+	"GET /reconcile":                      ScopeReconcileRead,
+	"POST /reconcile/{inbox}/release":     ScopeReconcileRelease,
+	"GET /inboxes":                        ScopeInboxesRead,
+}
+
+// allScopes is the set of valid scopes, derived once from the vocabulary.
+var allScopes = map[string]bool{
+	ScopeQueueRead:        true,
+	ScopeQueueDecide:      true,
+	ScopeHoldsRead:        true,
+	ScopeHoldsDecide:      true,
+	ScopeReconcileRead:    true,
+	ScopeReconcileRelease: true,
+	ScopeInboxesRead:      true,
+}
+
+// AllScopes returns every scope in the vocabulary, sorted — the full-scope set an
+// implicit or explicit root client is granted.
+func AllScopes() []string {
+	out := make([]string, 0, len(allScopes))
+	for s := range allScopes {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ValidScope reports whether s is a known scope.
+func ValidScope(s string) bool { return allScopes[s] }
+
+// Client is one named admin credential (ADR 0029). The token is never a field —
+// it is read from the env var named by TokenEnv(Name), per ADR 0012.
+type Client struct {
+	Name   string   `yaml:"name"`
+	Scopes []string `yaml:"scopes"`
+}
+
+type fileConfig struct {
+	Clients []Client `yaml:"admin_clients"`
+}
+
+// Parse reads the `admin_clients:` list from a config document. An absent or
+// empty list yields nil — the caller substitutes the implicit full-scope root.
+func Parse(data []byte) ([]Client, error) {
+	var fc fileConfig
+	if err := yaml.Unmarshal(data, &fc); err != nil {
+		return nil, fmt.Errorf("admincfg: parse: %w", err)
+	}
+	return fc.Clients, nil
+}
+
+// TokenEnv is the env var an admin client's token is read from (ADR 0012):
+// DARBAAN_ADMIN_TOKEN_<NAME>, where <NAME> is mangled by the shared
+// inboxcfg.EnvPrefix rule (uppercased, every rune outside [A-Z0-9] → '_'). It is
+// the single source of truth for the mangle; Validate's collision guard calls it,
+// so a runtime lookup and the load-time check can never diverge. The mangle is
+// many-to-one, which is why Validate rejects client names that collide on it.
+func TokenEnv(name string) string {
+	return "DARBAAN_ADMIN_TOKEN_" + inboxcfg.EnvPrefix(name)
+}
+
+// HasScope reports whether the client is granted scope.
+func (c Client) HasScope(scope string) bool {
+	for _, s := range c.Scopes {
+		if s == scope {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate checks an admin-client list: unique names, unique token-env names (the
+// many-to-one mangle must not silently share a token), and, per client, a
+// non-empty scope set drawn from the known vocabulary with no duplicates
+// (ADR 0029).
+func Validate(clients []Client) error {
+	if len(clients) == 0 {
+		return fmt.Errorf("admincfg: no admin clients configured")
+	}
+	seen := make(map[string]bool, len(clients))
+	envSeen := make(map[string]string, len(clients)) // token-env → first client name
+	for i, c := range clients {
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			return fmt.Errorf("admincfg: admin client %d: name is required", i+1)
+		}
+		if seen[name] {
+			return fmt.Errorf("admincfg: duplicate admin client name %q", name)
+		}
+		seen[name] = true
+		// The token env binding is many-to-one (e.g. "a-b" and "a_b" both mangle to
+		// DARBAAN_ADMIN_TOKEN_A_B), so a collision would silently share one token —
+		// reject it at load (ADR 0029).
+		env := TokenEnv(name)
+		if other, dup := envSeen[env]; dup {
+			return fmt.Errorf("admincfg: admin clients %q and %q map to the same token env %q", other, name, env)
+		}
+		envSeen[env] = name
+		if err := validateScopes(name, c.Scopes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateScopes checks one client's scope set: non-empty, each scope known and
+// granted at most once.
+func validateScopes(client string, scopes []string) error {
+	if len(scopes) == 0 {
+		return fmt.Errorf("admincfg: admin client %q: at least one scope is required", client)
+	}
+	scopeSeen := make(map[string]bool, len(scopes))
+	for _, s := range scopes {
+		if !ValidScope(s) {
+			return fmt.Errorf("admincfg: admin client %q: unknown scope %q (want one of %s)", client, s, strings.Join(AllScopes(), ", "))
+		}
+		if scopeSeen[s] {
+			return fmt.Errorf("admincfg: admin client %q: repeats scope %q", client, s)
+		}
+		scopeSeen[s] = true
+	}
+	return nil
+}

--- a/internal/admincfg/admincfg_test.go
+++ b/internal/admincfg/admincfg_test.go
@@ -1,0 +1,107 @@
+package admincfg_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admincfg"
+)
+
+func TestParse(t *testing.T) {
+	doc := []byte(`
+admin_clients:
+  - name: telegram
+    scopes: [queue:read, queue:decide, holds:read, holds:decide, reconcile:read]
+  - name: pre-screener
+    scopes: [queue:read, holds:read]
+`)
+	clients, err := admincfg.Parse(doc)
+	require.NoError(t, err)
+	require.Len(t, clients, 2)
+	assert.Equal(t, "telegram", clients[0].Name)
+	assert.True(t, clients[0].HasScope(admincfg.ScopeReconcileRead))
+	assert.False(t, clients[0].HasScope(admincfg.ScopeReconcileRelease))
+	assert.True(t, clients[1].HasScope(admincfg.ScopeQueueRead))
+	assert.False(t, clients[1].HasScope(admincfg.ScopeQueueDecide), "read-only client has no decide")
+}
+
+// No admin_clients: yields nil — the caller substitutes the implicit full-scope
+// root (back-compat).
+func TestParseEmpty(t *testing.T) {
+	clients, err := admincfg.Parse([]byte("inboxes:\n  - name: default\n"))
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+func TestTokenEnv(t *testing.T) {
+	assert.Equal(t, "DARBAAN_ADMIN_TOKEN_TELEGRAM", admincfg.TokenEnv("telegram"))
+	assert.Equal(t, "DARBAAN_ADMIN_TOKEN_PRE_SCREENER", admincfg.TokenEnv("pre-screener"))
+}
+
+func TestValidate(t *testing.T) {
+	ok := []admincfg.Client{
+		{Name: "telegram", Scopes: []string{admincfg.ScopeQueueDecide}},
+		{Name: "cli", Scopes: admincfg.AllScopes()},
+	}
+	assert.NoError(t, admincfg.Validate(ok))
+
+	assert.Error(t, admincfg.Validate(nil), "empty list is rejected (caller uses the implicit root instead)")
+
+	dupName := []admincfg.Client{
+		{Name: "a", Scopes: []string{admincfg.ScopeQueueRead}},
+		{Name: "a", Scopes: []string{admincfg.ScopeHoldsRead}},
+	}
+	assert.Error(t, admincfg.Validate(dupName), "duplicate name")
+
+	// "a-b" and "a_b" both mangle to the same token env → silently shared token.
+	envCollision := []admincfg.Client{
+		{Name: "a-b", Scopes: []string{admincfg.ScopeQueueRead}},
+		{Name: "a_b", Scopes: []string{admincfg.ScopeHoldsRead}},
+	}
+	assert.Error(t, admincfg.Validate(envCollision), "token-env collision")
+
+	assert.Error(t, admincfg.Validate([]admincfg.Client{{Name: "x"}}), "empty scope set")
+	assert.Error(t, admincfg.Validate([]admincfg.Client{{Name: "x", Scopes: []string{"queue:write"}}}), "unknown scope")
+	assert.Error(t, admincfg.Validate([]admincfg.Client{{Name: "x", Scopes: []string{admincfg.ScopeQueueRead, admincfg.ScopeQueueRead}}}), "duplicate scope")
+	assert.Error(t, admincfg.Validate([]admincfg.Client{{Name: "  ", Scopes: []string{admincfg.ScopeQueueRead}}}), "blank name")
+}
+
+func TestAllScopesAndValidScope(t *testing.T) {
+	all := admincfg.AllScopes()
+	assert.Len(t, all, 7)
+	for _, s := range all {
+		assert.True(t, admincfg.ValidScope(s))
+	}
+	assert.False(t, admincfg.ValidScope("queue:write"))
+	assert.False(t, admincfg.ValidScope(""))
+}
+
+// The route→scope map is complete and consistent: every value is a known scope,
+// and it covers exactly the admin routes (ADR 0029). The route set is pinned here
+// so a new/removed admin route without a scope binding fails the build's tests.
+func TestRouteScopesComplete(t *testing.T) {
+	wantRoutes := []string{
+		"GET /queue",
+		"GET /queue/{id}",
+		"POST /queue/{id}/approve",
+		"POST /queue/{id}/approve-as/{inbox}",
+		"POST /queue/{id}/reject",
+		"GET /holds",
+		"POST /holds/{id}/expose",
+		"POST /holds/{id}/drop",
+		"GET /reconcile",
+		"POST /reconcile/{inbox}/release",
+		"GET /inboxes",
+	}
+	assert.Len(t, admincfg.RouteScopes, len(wantRoutes), "no extra/missing routes")
+	for _, r := range wantRoutes {
+		scope, ok := admincfg.RouteScopes[r]
+		require.True(t, ok, "route %q has a required scope", r)
+		assert.True(t, admincfg.ValidScope(scope), "route %q maps to a known scope (%q)", r, scope)
+	}
+	// The Telegram #149 cap-latch read path needs reconcile:read, not release.
+	assert.Equal(t, admincfg.ScopeReconcileRead, admincfg.RouteScopes["GET /reconcile"])
+	assert.Equal(t, admincfg.ScopeReconcileRelease, admincfg.RouteScopes["POST /reconcile/{inbox}/release"])
+}


### PR DESCRIPTION
Slice 1 of 3 for ADR 0029 (per-client scoped admin tokens, #59). Schema + validation only — **no enforcement** (that's slice 2).

## What

New `internal/admincfg`, mirroring `internal/agentcfg`:

- **Scope vocabulary** — `queue:read`/`queue:decide`, `holds:read`/`holds:decide`, `reconcile:read`/`reconcile:release`, `inboxes:read` as constants, plus `AllScopes()` / `ValidScope()`.
- **`RouteScopes`** — the authoritative route→required-scope map for all 11 admin routes (ADR 0017), keyed by ServeMux pattern. Pinned complete + consistent by `TestRouteScopesComplete` (every route present, every value a known scope). `reconcile` splits read vs release, so the Telegram #149 cap-latch alert (`GET /reconcile`) needs only `reconcile:read`, never `reconcile:release`.
- **`Client{Name, Scopes}`** + `Parse` (the `admin_clients:` list) + `Validate` (unique names, token-env collision guard, non-empty known-scope sets, no dup scopes) + `TokenEnv` (`DARBAAN_ADMIN_TOKEN_<NAME>`, shared `inboxcfg.EnvPrefix` mangle, secret out-of-band per ADR 0012) + `HasScope`.

## Deferred to later slices (per the ADR)

- **Slice 2** — enforcement: `auth` resolves a presented token → client → scopes (constant-time, with the fixed-width-hash-before-compare refinement from review) and authorizes the route's required scope (401 vs 403); the implicit full-scope root (back-compat when `admin_clients:` is unset). A slice-2 test will also cross-check that every route registered in `admin/http.go` has a `RouteScopes` entry (this slice pins the map's contents; slice 2 pins map↔routes).
- **Slice 3** — `serve` wiring + config example + README + ADR finalize.

## Testing

- Parse (+ empty→nil back-compat), `TokenEnv` mangle, `Validate` (dup name, token-env collision, empty/unknown/dup scope, blank name), scope vocabulary, `RouteScopes` completeness.
- Full `go build` / `go vet` / `gofmt -l` / `go test ./...` green.

No `adr/*` touch (the ADR merged separately) — standard 2-of-N.