### PR TITLE
feat(admin): enforce per-client scopes in the auth middleware (ADR 0029 slice 2)

### DIFF
--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
@@ -8,49 +9,114 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/yaad-index/darbaan/internal/admincfg"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
+// credential is one admin-API bearer credential (ADR 0029): the SHA-256 of its
+// full "Bearer <token>" header value (fixed-width, so the constant-time compare
+// can never leak token length) and the set of scopes it grants.
+type credential struct {
+	hash   [32]byte
+	scopes map[string]bool
+}
+
 // Server is the localhost-only HTTP admin API. It is the operator's approval
 // surface; it must be bound to loopback (or kept container-internal) and is
-// reachable only with the bearer token — never by the agent (ADR 0002).
+// reachable only with a bearer credential — never by the agent (ADR 0002). Each
+// credential carries a scope set (ADR 0029): the single root token grants every
+// scope; per-client tokens grant a least-privilege subset.
 type Server struct {
 	svc   *Service
-	token string
+	creds []credential
 	http  *http.Server
 }
 
+// ScopedClient is a named admin client's token + granted scopes (ADR 0029),
+// supplied by the serve wiring from the configured admin_clients.
+type ScopedClient struct {
+	Name   string
+	Token  string
+	Scopes []string
+}
+
 // NewServer builds the admin server. It fails closed: an empty token is refused
-// rather than expose an unauthenticated admin API.
+// rather than expose an unauthenticated admin API. The token is the full-scope
+// root credential (ADR 0029) — the back-compat single-token behavior when no
+// scoped clients are added; SetScopedClients adds least-privilege clients.
 func NewServer(addr, token string, svc *Service) (*Server, error) {
 	if token == "" {
 		return nil, errors.New("admin: a token is required (no unauthenticated admin API); set DARBAAN_ADMIN_TOKEN")
 	}
-	s := &Server{svc: svc, token: token}
+	s := &Server{svc: svc}
+	s.creds = append(s.creds, credential{
+		hash:   hashBearer(token),
+		scopes: scopeSet(admincfg.AllScopes()),
+	})
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /queue", s.auth(s.handleList))
-	mux.HandleFunc("GET /queue/{id}", s.auth(s.handleShow))
-	mux.HandleFunc("POST /queue/{id}/approve", s.auth(s.handleApprove))
-	mux.HandleFunc("POST /queue/{id}/approve-as/{inbox}", s.auth(s.handleApproveAs))
-	mux.HandleFunc("POST /queue/{id}/reject", s.auth(s.handleReject))
+	s.register(mux, "GET /queue", s.handleList)
+	s.register(mux, "GET /queue/{id}", s.handleShow)
+	s.register(mux, "POST /queue/{id}/approve", s.handleApprove)
+	s.register(mux, "POST /queue/{id}/approve-as/{inbox}", s.handleApproveAs)
+	s.register(mux, "POST /queue/{id}/reject", s.handleReject)
 
 	// Configured inbox identities for the Change-sender picker (ADR 0023 slice 5).
-	mux.HandleFunc("GET /inboxes", s.auth(s.handleInboxes))
+	s.register(mux, "GET /inboxes", s.handleInboxes)
 
 	// Inbound hold-for-human queue (ADR 0021): expose = show to the agent, drop =
 	// keep hidden.
-	mux.HandleFunc("GET /holds", s.auth(s.handleHeldList))
-	mux.HandleFunc("POST /holds/{id}/expose", s.auth(s.handleExpose))
-	mux.HandleFunc("POST /holds/{id}/drop", s.auth(s.handleDrop))
+	s.register(mux, "GET /holds", s.handleHeldList)
+	s.register(mux, "POST /holds/{id}/expose", s.handleExpose)
+	s.register(mux, "POST /holds/{id}/drop", s.handleDrop)
 
 	// Reconcile safety-cap controls (ADR 0026): list held inboxes, release one.
-	mux.HandleFunc("GET /reconcile", s.auth(s.handleReconcileStatus))
-	mux.HandleFunc("POST /reconcile/{inbox}/release", s.auth(s.handleReconcileRelease))
+	s.register(mux, "GET /reconcile", s.handleReconcileStatus)
+	s.register(mux, "POST /reconcile/{inbox}/release", s.handleReconcileRelease)
 
 	s.http = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	return s, nil
+}
+
+// SetScopedClients registers the configured per-client scoped credentials
+// (ADR 0029). It is called once at setup, before serving; the root token stays as
+// break-glass. A client whose token is empty (its secret was not supplied) is
+// skipped.
+func (s *Server) SetScopedClients(clients []ScopedClient) {
+	for _, c := range clients {
+		if c.Token == "" {
+			continue
+		}
+		s.creds = append(s.creds, credential{
+			hash:   hashBearer(c.Token),
+			scopes: scopeSet(c.Scopes),
+		})
+	}
+}
+
+// hashBearer is the fixed-width hash of a token's full Authorization header value.
+func hashBearer(token string) [32]byte { return sha256.Sum256([]byte("Bearer " + token)) }
+
+// scopeSet builds a lookup set from a scope list.
+func scopeSet(scopes []string) map[string]bool {
+	m := make(map[string]bool, len(scopes))
+	for _, sc := range scopes {
+		m[sc] = true
+	}
+	return m
+}
+
+// register wires a route with the required scope from the authoritative
+// route→scope map (ADR 0029). It panics if the route has no mapped scope — a
+// build-wiring error (a new admin route must ship with its scope in
+// admincfg.RouteScopes), which enforces the map↔routes invariant.
+func (s *Server) register(mux *http.ServeMux, pattern string, h http.HandlerFunc) {
+	scope, ok := admincfg.RouteScopes[pattern]
+	if !ok {
+		panic("admin: route " + pattern + " has no required scope in admincfg.RouteScopes")
+	}
+	mux.HandleFunc(pattern, s.scoped(scope, h))
 }
 
 // ListenAndServe binds Addr and serves until Close.
@@ -62,16 +128,41 @@ func (s *Server) Serve(l net.Listener) error { return s.http.Serve(l) }
 // Close stops the server.
 func (s *Server) Close() error { return s.http.Close() }
 
-func (s *Server) auth(next http.HandlerFunc) http.HandlerFunc {
-	want := []byte("Bearer " + s.token)
+// scoped gates a handler on a required scope (ADR 0029): it resolves the
+// presented bearer to a credential, then authorizes the scope. An unrecognized
+// token is 401 Unauthorized; a recognized token lacking the scope is 403
+// Forbidden — a distinct, clearer signal than a blanket 401.
+func (s *Server) scoped(required string, next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		got := []byte(r.Header.Get("Authorization"))
-		if subtle.ConstantTimeCompare(got, want) != 1 {
+		cred, ok := s.resolve(r.Header.Get("Authorization"))
+		if !ok {
 			writeErr(w, http.StatusUnauthorized, errors.New("unauthorized"))
+			return
+		}
+		if !cred.scopes[required] {
+			writeErr(w, http.StatusForbidden, errors.New("forbidden: missing scope "+required))
 			return
 		}
 		next(w, r)
 	}
+}
+
+// resolve matches a presented Authorization header value to a configured
+// credential (ADR 0029). It hashes the value to a fixed width and constant-time-
+// compares against every credential with NO early exit, so timing reveals neither
+// which credential matched nor whether one did — the same no-oracle discipline as
+// the ADR 0027 agent Verify.
+func (s *Server) resolve(authHeader string) (credential, bool) {
+	got := sha256.Sum256([]byte(authHeader))
+	var found credential
+	matched := 0
+	for _, c := range s.creds {
+		if subtle.ConstantTimeCompare(got[:], c.hash[:]) == 1 {
+			found = c
+			matched = 1
+		}
+	}
+	return found, matched == 1
 }
 
 func (s *Server) handleList(w http.ResponseWriter, _ *http.Request) {

--- a/internal/admin/scoped_test.go
+++ b/internal/admin/scoped_test.go
@@ -1,0 +1,106 @@
+package admin_test
+
+import (
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/admincfg"
+)
+
+// startScopedServer builds a server with a root token plus zero or more scoped
+// clients (ADR 0029).
+func startScopedServer(t *testing.T, svc *admin.Service, rootToken string, clients ...admin.ScopedClient) string {
+	t.Helper()
+	srv, err := admin.NewServer("", rootToken, svc)
+	require.NoError(t, err)
+	srv.SetScopedClients(clients)
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+func doReq(t *testing.T, method, url, token string) int {
+	t.Helper()
+	req, err := http.NewRequest(method, url, nil)
+	require.NoError(t, err)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+	return resp.StatusCode
+}
+
+// ADR 0029: a scoped client reaches only its granted routes; the root token
+// reaches all; an unrecognized token is 401 and a recognized token lacking the
+// route's scope is 403.
+func TestScopedEnforcement(t *testing.T) {
+	svc, _, id := newSvc(t)
+	addr := startScopedServer(t, svc, "root-tok",
+		admin.ScopedClient{Name: "reader", Token: "reader-tok", Scopes: []string{admincfg.ScopeQueueRead, admincfg.ScopeHoldsRead}},
+	)
+	base := "http://" + addr
+
+	// Root token: full-scope — read AND decide both pass the auth layer.
+	assert.Equal(t, http.StatusOK, doReq(t, "GET", base+"/queue", "root-tok"))
+	st := doReq(t, "POST", base+"/queue/"+id+"/approve", "root-tok")
+	assert.NotEqual(t, http.StatusUnauthorized, st, "root is authenticated")
+	assert.NotEqual(t, http.StatusForbidden, st, "root has queue:decide")
+
+	// Reader: queue:read grants GET /queue; it lacks queue:decide → 403 on approve,
+	// and lacks reconcile:read → 403 on GET /reconcile (scope denied before the
+	// handler, so it's 403 not the handler's 503).
+	assert.Equal(t, http.StatusOK, doReq(t, "GET", base+"/queue", "reader-tok"))
+	assert.Equal(t, http.StatusForbidden, doReq(t, "POST", base+"/queue/"+id+"/approve", "reader-tok"))
+	assert.Equal(t, http.StatusForbidden, doReq(t, "GET", base+"/reconcile", "reader-tok"))
+
+	// Unrecognized / missing token → 401 (distinct from the 403 scope denial).
+	assert.Equal(t, http.StatusUnauthorized, doReq(t, "GET", base+"/queue", "nope"))
+	assert.Equal(t, http.StatusUnauthorized, doReq(t, "GET", base+"/queue", ""))
+}
+
+// The single-token deploy (no scoped clients) is unchanged: the root token
+// reaches every route (back-compat).
+func TestRootTokenFullAccess(t *testing.T) {
+	svc, _, id := newSvc(t)
+	addr := startScopedServer(t, svc, "only-tok")
+	base := "http://" + addr
+	for _, r := range []struct{ method, path string }{
+		{"GET", "/queue"}, {"GET", "/holds"}, {"GET", "/reconcile"}, {"GET", "/inboxes"},
+	} {
+		assert.NotEqual(t, http.StatusForbidden, doReq(t, r.method, base+r.path, "only-tok"), "%s %s", r.method, r.path)
+		assert.NotEqual(t, http.StatusUnauthorized, doReq(t, r.method, base+r.path, "only-tok"), "%s %s", r.method, r.path)
+	}
+	assert.NotEqual(t, http.StatusForbidden, doReq(t, "POST", base+"/queue/"+id+"/approve", "only-tok"))
+}
+
+// A client whose token is empty (secret not supplied) is skipped, not registered
+// as a zero-token credential.
+func TestEmptyScopedClientTokenSkipped(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	addr := startScopedServer(t, svc, "root-tok",
+		admin.ScopedClient{Name: "unset", Token: "", Scopes: []string{admincfg.ScopeQueueRead}},
+	)
+	// An empty Authorization header must not match the skipped empty-token client.
+	assert.Equal(t, http.StatusUnauthorized, doReq(t, "GET", "http://"+addr+"/queue", ""))
+}
+
+// NewServer registers every route with a scope from admincfg.RouteScopes — a
+// missing binding panics (the map↔routes invariant), so a clean build is the
+// cross-check.
+func TestNewServerScopesEveryRoute(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	require.NotPanics(t, func() {
+		srv, err := admin.NewServer("", "tok", svc)
+		require.NoError(t, err)
+		_ = srv.Close()
+	})
+}

--- a/internal/admincfg/admincfg.go
+++ b/internal/admincfg/admincfg.go
@@ -60,16 +60,17 @@ var RouteScopes = map[string]string{
 	"GET /inboxes":                        ScopeInboxesRead,
 }
 
-// allScopes is the set of valid scopes, derived once from the vocabulary.
-var allScopes = map[string]bool{
-	ScopeQueueRead:        true,
-	ScopeQueueDecide:      true,
-	ScopeHoldsRead:        true,
-	ScopeHoldsDecide:      true,
-	ScopeReconcileRead:    true,
-	ScopeReconcileRelease: true,
-	ScopeInboxesRead:      true,
-}
+// allScopes is the set of valid scopes, derived from the RouteScopes values so it
+// cannot drift from the routes it gates: a scope is valid iff some route requires
+// it. RouteScopes is therefore the single hand-maintained list; the Scope*
+// constants only name the values it (and callers) use.
+var allScopes = func() map[string]bool {
+	m := make(map[string]bool, len(RouteScopes))
+	for _, s := range RouteScopes {
+		m[s] = true
+	}
+	return m
+}()
 
 // AllScopes returns every scope in the vocabulary, sorted — the full-scope set an
 // implicit or explicit root client is granted.


### PR DESCRIPTION
Slice 2 of 3 for ADR 0029 (#59). The enforcement layer — builds on slice 1's `admincfg` (#185).

## What

Replace the single-token check in the admin `auth` middleware with **scoped credential resolution**:

- **`Server.creds`** — a set of credentials, each = `SHA-256` of the full `"Bearer <token>"` header value + a scope set. **The token is hashed to a fixed width before `subtle.ConstantTimeCompare`** (per the slice-1 review note): `ConstantTimeCompare` short-circuits on unequal length, so a raw per-token compare would leak token length; 32-byte hashes equalize every comparison.
- **`resolve()`** — hashes the presented header and constant-time-compares against every credential with **no early exit** and no which/whether-matched oracle (ADR 0027 `Verify` discipline).
- **`scoped(required)`** — authorizes the route's scope: unrecognized token → **401**, recognized-but-missing-scope → **403** (the distinct diagnostic split).
- **`register()`** — wires each route with its scope from `admincfg.RouteScopes` and **panics on an unmapped route** — the map↔routes invariant (a new admin route must ship its scope), enforced at startup.
- **`SetScopedClients`** — adds least-privilege per-client credentials; called by the serve wiring in slice 3. **`NewServer`'s signature is unchanged**, so a single-token deploy is byte-for-byte the same behavior (the root credential has every scope). Break-glass root retained.

## Also — closes the slice-1 review nit

`admincfg.allScopes` is now **derived from `RouteScopes`** (a scope is valid iff some route requires it), so the vocabulary has one hand-maintained list and the const-block/allScopes drift raised in slice-1 review is gone.

## Testing

- `TestScopedEnforcement`: reader client reaches `GET /queue` (200) but not `POST approve` (403) or `GET /reconcile` (403 — scope denied *before* the handler's 503); root full access; unknown/missing token → 401.
- `TestRootTokenFullAccess`: single-token deploy reaches every route (back-compat).
- `TestEmptyScopedClientTokenSkipped`; `TestNewServerScopesEveryRoute` (map↔routes, no panic).
- Existing admin/telegram/cmd tests pass unchanged. Full `go build` / `go vet` / `gofmt -l` / `go test -race ./...` green.

Slice 3 next: `serve` wiring (`SetScopedClients` from config) + config example + README + ADR finalize (+ the CLI-credential doc clarity note). No `adr/*` here — standard 2-of-N.