### PR TITLE
feat(admin): wire scoped admin clients + docs + finalize ADR 0029 (#59)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,11 @@ into the core:
 - **CLI** — `darbaan queue …` lists and decides held messages.
 - **Telegram** — approve or reject from your phone (setup in [INSTALL.md](INSTALL.md)).
 
+Each client authenticates with a bearer token. By default that's a single shared
+`DARBAAN_ADMIN_TOKEN`; optionally, give each client its own least-privilege,
+independently-revocable token via `admin_clients:` (see `config.example.yaml` and
+adr/0029).
+
 ## Install / run
 
 Darbaan is a single Go binary; the easiest deployment is Docker Compose. See

--- a/adr/0029-admin-per-client-scoped-tokens.md
+++ b/adr/0029-admin-per-client-scoped-tokens.md
@@ -1,6 +1,6 @@
 # ADR 0029: Admin API — per-client scoped, independently-revocable tokens
 
-**Status:** Proposed (2026-07-09)
+**Status:** Accepted (2026-07-09)
 
 ## Context
 
@@ -85,11 +85,13 @@ A client's token grants exactly its listed scopes. Least-privilege examples:
 
 The `auth` middleware resolves `Bearer <token>` to a client + scopes, then
 authorizes the route's required scope. Resolution is **constant-time**: the
-presented token is compared against every configured token with
-`subtle.ConstantTimeCompare` and no early exit, and the same comparison work runs
-on an unknown token (the miss path is equalized), so timing never reveals which —
-or whether — a token matched. This is the same no-oracle discipline as ADR 0027's
-`Verify`. An unrecognized token is `401 Unauthorized`; a recognized token that
+presented header value is hashed to a **fixed width** (SHA-256) and compared
+against every configured credential's hash with `subtle.ConstantTimeCompare` and
+no early exit. Hashing first is load-bearing — `ConstantTimeCompare` short-
+circuits on unequal lengths, so comparing raw tokens would leak length; equal-
+width hashes remove that. The full loop runs on an unknown token too (the miss
+path is equalized), so timing never reveals which — or whether — a token matched.
+This is the same no-oracle discipline as ADR 0027's `Verify`. An unrecognized token is `401 Unauthorized`; a recognized token that
 **lacks** the route's scope is `403 Forbidden` (a distinct, clearer signal than a
 blanket 401).
 

--- a/cmd/darbaan/admin_clients_test.go
+++ b/cmd/darbaan/admin_clients_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admincfg"
+)
+
+func TestResolveAdminClientsFromConfig(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfg, []byte(
+		"admin_clients:\n"+
+			"  - name: telegram\n    scopes: [queue:read, queue:decide, holds:read, holds:decide, reconcile:read]\n"+
+			"  - name: pre-screener\n    scopes: [queue:read, holds:read]\n"), 0o600))
+	// telegram's token is set; pre-screener's is intentionally unset → skipped + logged.
+	t.Setenv("DARBAAN_ADMIN_TOKEN_TELEGRAM", "tg-tok")
+
+	cli := parseCLI(t, []string{"--config", cfg, "version"})
+	clients, err := cli.resolveAdminClients()
+	require.NoError(t, err)
+	require.Len(t, clients, 1, "only the client whose token env is set is returned")
+	assert.Equal(t, "telegram", clients[0].Name)
+	assert.Equal(t, "tg-tok", clients[0].Token)
+	assert.Contains(t, clients[0].Scopes, admincfg.ScopeReconcileRead)
+}
+
+// No admin_clients: → nil, so the single DARBAAN_ADMIN_TOKEN root is the only
+// credential (back-compat).
+func TestResolveAdminClientsEmpty(t *testing.T) {
+	cli := parseCLI(t, []string{"version"})
+	clients, err := cli.resolveAdminClients()
+	require.NoError(t, err)
+	assert.Nil(t, clients)
+}
+
+// A malformed admin_clients: (unknown scope) fails at resolve, not at request
+// time.
+func TestResolveAdminClientsRejectsBadScope(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(cfg, []byte(
+		"admin_clients:\n  - name: x\n    scopes: [queue:write]\n"), 0o600))
+	cli := parseCLI(t, []string{"--config", cfg, "version"})
+	_, err := cli.resolveAdminClients()
+	assert.Error(t, err)
+}

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/alecthomas/kong"
 
 	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/admincfg"
 	"github.com/yaad-index/darbaan/internal/agentcfg"
 	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
@@ -298,6 +299,41 @@ func (c *CLI) resolvePrincipals(inboxes []inboxcfg.Inbox) (principalWiring, erro
 		mailOwner:  func(inbox string) string { return inbound.NormInbox(inbox) },
 		decoupled:  true,
 	}, nil
+}
+
+// resolveAdminClients resolves the configured admin_clients (ADR 0029): the
+// `admin_clients:` list, each a named admin-API credential whose token is read
+// from DARBAAN_ADMIN_TOKEN_<NAME> (never in config, ADR 0012). A client whose
+// token env is unset is logged and skipped — its scoped access stays disabled,
+// surfaced as a startup warning rather than a silent 401 at request time. With no
+// `admin_clients:` it returns nil, so the single DARBAAN_ADMIN_TOKEN root is the
+// only credential (back-compat).
+func (c *CLI) resolveAdminClients() ([]admin.ScopedClient, error) {
+	data, err := c.configBytes()
+	if err != nil {
+		return nil, err
+	}
+	clients, err := admincfg.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	if len(clients) == 0 {
+		return nil, nil
+	}
+	if err := admincfg.Validate(clients); err != nil {
+		return nil, err
+	}
+	out := make([]admin.ScopedClient, 0, len(clients))
+	for _, cl := range clients {
+		env := admincfg.TokenEnv(cl.Name)
+		token := os.Getenv(env)
+		if token == "" {
+			slog.Warn("admin client has no token; its scoped access is disabled", "client", cl.Name, "env", env)
+			continue
+		}
+		out = append(out, admin.ScopedClient{Name: cl.Name, Token: token, Scopes: cl.Scopes})
+	}
+	return out, nil
 }
 
 // openInbound opens the inbound (served mailbox) store per config.
@@ -824,6 +860,16 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
+
+	// Per-client scoped admin tokens (ADR 0029): register each configured
+	// admin_client's token + least-privilege scopes. DARBAAN_ADMIN_TOKEN stays the
+	// full-scope root (break-glass, and the credential the CLI uses by default);
+	// with no admin_clients: it is the only credential (back-compat).
+	adminClients, err := cli.resolveAdminClients()
+	if err != nil {
+		return err
+	}
+	adminSrv.SetScopedClients(adminClients)
 
 	// Resolve the configured inboxes (ADR 0023): a config with no inboxes: is one
 	// implicit "default" inbox built from the legacy top-level flags, so a

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -63,6 +63,31 @@ imap-addr: ":1143"
 # (required — serve fails closed without it), never inlined here.
 admin-addr: "127.0.0.1:1144"
 
+# --- Per-client scoped admin tokens (optional; ADR 0029) ---------------------
+# By default DARBAAN_ADMIN_TOKEN is a single full-capability token every admin
+# interface shares. To give each interface its own least-privilege, independently
+# revocable credential, list them under `admin_clients:`. Each client's token
+# comes from DARBAAN_ADMIN_TOKEN_<NAME> (name uppercased, non-alphanumerics ->
+# '_'), never inlined (ADR 0012). Scopes are per route, least-privilege:
+#   queue:read / queue:decide, holds:read / holds:decide,
+#   reconcile:read / reconcile:release, inboxes:read.
+# Revoke one client by unsetting its token env and restarting; the others are
+# unaffected. A client whose token env is unset is skipped with a startup warning.
+#
+# DARBAAN_ADMIN_TOKEN stays the full-scope ROOT (break-glass) — and it is the
+# credential the `darbaan queue|holds|reconcile` CLI uses by default, so no config
+# change is needed to keep the CLI working. Put the CLI on its own revocable
+# credential only if you want to: add a named client granted every scope and point
+# the CLI's DARBAAN_ADMIN_TOKEN at that token instead of the root.
+#
+# admin_clients:
+#   - name: telegram        # the approval bot: decide on mail + read the latch alert (#149)
+#     scopes: [queue:read, queue:decide, holds:read, holds:decide, reconcile:read]
+#     # token from DARBAAN_ADMIN_TOKEN_TELEGRAM
+#   - name: pre-screener    # read-only: inspects but never decides
+#     scopes: [queue:read, holds:read]
+#     # token from DARBAAN_ADMIN_TOKEN_PRE_SCREENER
+
 # The agent's Darbaan SMTP username. The password is NOT configured here: it is
 # supplied out-of-band via DARBAAN_AGENT_PASS, a reference to the encrypted
 # store (ADR 0012). Secrets are never inlined in config.


### PR DESCRIPTION
Final slice (3 of 3) for ADR 0029 (#59). Wiring + docs + ADR finalize. **Hard-gate** — touches `adr/0029` (finalize) + `README.md`, so it needs the maintainer's APPROVE on HEAD alongside 2-of-N.

## What

- **serve wiring** — `resolveAdminClients` parses `admin_clients:` from config, reads each token from `DARBAAN_ADMIN_TOKEN_<NAME>`, and calls `adminSrv.SetScopedClients`. **A client whose token env is unset is logged (`Warn`: client + env) and skipped** — a misconfigured least-privilege interface surfaces as a startup warning instead of a silent 401 at request time (per the slice-2 review note). No `admin_clients:` → nil → single-token root only (back-compat).
- **`config.example.yaml`** — commented `admin_clients:` example + scope vocabulary. **Spells out the CLI credential** (the other review note): `DARBAAN_ADMIN_TOKEN` stays the full-scope root the CLI uses by default (no config change needed to keep the CLI working), with a named full-scope client as the opt-in alternative to put the CLI on its own revocable token.
- **`README.md`** — brief pointer to per-client tokens.
- **ADR 0029 finalized** — status Proposed → **Accepted**; the Auth-resolution paragraph now states the **fixed-width-hash-before-`ConstantTimeCompare`** (it short-circuits on unequal length, so hashing removes the length leak).

## Testing

- `resolveAdminClients`: returns only clients whose token env is set (unset skipped + warned), nil on no `admin_clients:` (back-compat), rejects an unknown scope at resolve.
- Full `go build` / `go vet` / `gofmt -l` / `go test -race ./...` green.

## Wraps ADR 0029

Slice 1 `admincfg` (#185) + slice 2 enforcement (#187) + this. `closes #59`.