### PR TITLE
ci: adopt golangci-lint (house linter)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,13 @@ jobs:
             exit 1
           fi
 
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          # Pin the linter version so CI matches the local run (same reasoning as
+          # go-version-file above); Dependabot bumps it deliberately.
+          version: v2.11.4
+
       - name: Test
         # -race: the listener + bbolt code is concurrent, so the gate runs the
         # race detector.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+# House linter config (golangci-lint v2). The linter version is pinned in
+# .github/workflows/ci.yml so CI and local runs match; Dependabot bumps it.
+version: "2"
+linters:
+  # standard = errcheck, govet, ineffassign, staticcheck, unused.
+  default: standard
+  enable:
+    - misspell
+  settings:
+    misspell:
+      ignore-rules:
+        # "teh" is the Unicode letter name "teh marbuta" (ة, U+0629), not a typo of "the".
+        - teh


### PR DESCRIPTION
Adopt golangci-lint as the house linter (standardizing across the Go repos; aligned with the yaad-grove companion PR — identical `.golangci.yml`).

## Changes
- **`.golangci.yml`** (golangci-lint v2): `default: standard` (errcheck, govet, ineffassign, staticcheck, unused) + `misspell`, with one `misspell` ignore-rule for `teh` (the Unicode letter name "teh marbuta", ة/U+0629 — not a typo of "the"; kept for cross-repo config parity).
- **CI `Lint` step** via `golangci/golangci-lint-action@v9` (pinned major), after the gofmt check and before the race test; `go-version-file: go.mod` unchanged. Linter pinned to `v2.11.4` so CI matches local runs.

## Fix surface
**Zero code changes** — the standard set is already clean on this repo. Verified `golangci-lint run ./...` → 0 issues with the committed config.

2-of-N gate; creator-merge on CI green.