### PR TITLE
fix(imapsync): don't hang the client on an unresolvable upstream UID (#190)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -415,7 +415,7 @@ func (cli *CLI) newSenders(inboxes []inboxcfg.Inbox) (map[string]backend.Sender,
 // backend host are skipped (no sync). The syncers share one sync-state store
 // (keyed per inbox internally); the returned stop func closes it. An empty map
 // means no inbox syncs (gated off, like the stub sender).
-func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore, mailOwner func(inbox string) string) (map[string]*imapsync.Syncer, func(), error) {
+func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore, mailOwner func(inbox string) string, al audit.AuditLog) (map[string]*imapsync.Syncer, func(), error) {
 	syncers := map[string]*imapsync.Syncer{}
 	var state imapsync.StateStore
 	stop := func() {
@@ -449,6 +449,10 @@ func (cli *CLI) newSyncers(inboxes []inboxcfg.Inbox, store inbound.InboundStore,
 		// Per-inbox structured logger (#151): every sync/reconcile record this
 		// syncer emits is tagged with its inbox.
 		syn.SetLogger(slog.Default().With("inbox", in.Name))
+		// On-demand retraction audit (#190): a content fetch that finds the upstream
+		// UID gone drops the stale mapping and records a "retract", same sink as the
+		// reconcile loop.
+		syn.SetAudit(al)
 		// Gmail label write-through (ADR 0020 20c): capability-gated, harmless on a
 		// non-Gmail backend (reports not-supported → WriteKeywords uses plain keywords).
 		syn.SetLabelStore(imapsync.RawGmailLabelStore(in.Backend.IMAPHost, in.Backend.IMAPUsername, pass, mailbox))
@@ -530,13 +534,10 @@ func (cli *CLI) runSyncLoop(ctx context.Context, inbox string, syncer *imapsync.
 }
 
 func runSync(ctx context.Context, inbox string, s *imapsync.Syncer) {
-	n, err := s.Sync(ctx)
-	if err != nil {
+	// Sync emits its own per-cycle summary (stored/watermark/uidvalidity, #190); the
+	// caller only needs to surface a hard failure.
+	if _, err := s.Sync(ctx); err != nil {
 		slog.Error("inbound sync failed", "inbox", inbox, "err", err)
-		return
-	}
-	if n > 0 {
-		slog.Info("inbound sync pulled messages", "inbox", inbox, "count", n)
 	}
 }
 
@@ -954,7 +955,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// One inbound syncer per inbox with an upstream (ADR 0019/0023), built before
 	// the read face so per-inbox FetchContent serves pending bodies on demand. An
 	// empty map = no inbox syncs.
-	syncers, stopSync, err := cli.newSyncers(inboxes, inbox, pw.mailOwner)
+	syncers, stopSync, err := cli.newSyncers(inboxes, inbox, pw.mailOwner, al)
 	if err != nil {
 		return err
 	}

--- a/cmd/darbaan/sync_test.go
+++ b/cmd/darbaan/sync_test.go
@@ -18,7 +18,7 @@ func TestNewSyncersPerInbox(t *testing.T) {
 		{Name: "personal", Backend: inboxcfg.Backend{IMAPHost: "imap.b.example:993"}},
 		{Name: "local-only"}, // no upstream host → skipped (no syncer)
 	}
-	syncers, stop, err := cli.newSyncers(inboxes, nil, func(inbox string) string { return inbox })
+	syncers, stop, err := cli.newSyncers(inboxes, nil, func(inbox string) string { return inbox }, nil)
 	require.NoError(t, err)
 	defer stop()
 	require.Len(t, syncers, 2)
@@ -65,7 +65,7 @@ func TestNewSendersPerInbox(t *testing.T) {
 func TestInboundSyncDisabledByDefault(t *testing.T) {
 	cli := &CLI{}
 	inboxes := []inboxcfg.Inbox{{Name: inbound.DefaultInbox}} // no backend host → no syncer
-	syncers, stop, err := cli.newSyncers(inboxes, nil, func(inbox string) string { return inbox })
+	syncers, stop, err := cli.newSyncers(inboxes, nil, func(inbox string) string { return inbox }, nil)
 	require.NoError(t, err)
 	require.Empty(t, syncers)
 	require.NotNil(t, stop)

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -12,6 +12,7 @@ import (
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapclient"
 
+	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/inbound"
 )
 
@@ -31,7 +32,14 @@ type Syncer struct {
 	maxAge     time.Duration  // recency cutoff; 0 = no cutoff (ADR 0008)
 	labelStore LabelStoreFunc // Gmail X-GM-LABELS writer; nil = plain keywords only (ADR 0020)
 	logger     *slog.Logger   // structured logger; defaults to slog.Default(), injectable via SetLogger
+	audit      audit.AuditLog // retract audit sink for on-demand stale-mapping drops (#190); nil = no audit
 }
+
+// SetAudit installs the audit sink for on-demand retractions — when a content
+// fetch finds the upstream UID gone, the stale mapping is dropped and a "retract"
+// record is appended, matching the reconcile loop's audit trail (#190 ask 2). nil
+// leaves the drop un-audited (still logged).
+func (s *Syncer) SetAudit(a audit.AuditLog) { s.audit = a }
 
 // SetLabelStore installs the Gmail X-GM-LABELS label writer (ADR 0020 20c). When
 // set, WriteKeywords replicates label changes via X-GM-LABELS on a Gmail backend
@@ -125,6 +133,12 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 	// Retry any label writes that failed their immediate upstream replicate
 	// (ADR 0020 best-effort write-through). Best-effort; never fails the sync.
 	s.reconcileKeywords()
+
+	// Per-cycle visibility (#190 ask 3): one summary line per account per sync, so a
+	// stalled or desynced inbox is obvious from the log without reading fetches
+	// line-by-line — how many new messages this cycle stored, the local UID
+	// watermark (the cursor), and the current UIDVALIDITY.
+	s.logger.Info("inbound sync cycle", "stored", stored, "watermark_uid", highest, "uidvalidity", sel.UIDValidity)
 	return stored, nil
 }
 
@@ -295,7 +309,13 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 		return inbound.Message{}, fmt.Errorf("imapsync: select %q: %w", s.mailbox, err)
 	}
 	if sel.UIDValidity != m.UIDValidity {
-		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: mailbox reset (uidvalidity %d != %d)", id, sel.UIDValidity, m.UIDValidity)
+		// The mailbox was reset upstream: the whole UID space changed, so this
+		// mapping is stale. Don't drop a single record here — a UIDVALIDITY change is
+		// the reconcile loop's re-seed concern, not a per-message expunge. Surface it
+		// and let the read face serve empty rather than hang (#190).
+		s.logger.Warn("content unavailable: mailbox reset",
+			"id", id, "have_uidvalidity", m.UIDValidity, "upstream_uidvalidity", sel.UIDValidity)
+		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: mailbox reset (uidvalidity %d != %d): %w", id, sel.UIDValidity, m.UIDValidity, inbound.ErrContentUnavailable)
 	}
 
 	var set imap.UIDSet
@@ -323,7 +343,28 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 		return inbound.Message{}, fmt.Errorf("imapsync: fetch content %s: %w", id, err)
 	}
 	if raw == nil {
-		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found", id, m.UpstreamUID)
+		// The upstream UID is gone (expunged) while its local mapping survives — the
+		// exact stale mapping that hangs a client's fetch (#190). Drop it now so it
+		// can't poison future fetches, instead of waiting for the hourly reconcile
+		// pass; this mirrors the reconcile retraction (ADR 0026) at the moment of
+		// detection. Best-effort: even if the drop fails, return the sentinel so the
+		// read face serves empty and the client proceeds.
+		s.logger.Warn("content unavailable: upstream uid gone, dropping stale mapping",
+			"id", id, "upstream_uid", m.UpstreamUID)
+		if derr := s.store.RemoveSynced(owner, inbox, id); derr != nil {
+			s.logger.Error("could not drop stale mapping", "id", id, "upstream_uid", m.UpstreamUID, "err", derr)
+		} else if s.audit != nil {
+			// Best-effort audit, consistent with the reconcile retraction record; a
+			// failed append must not fail the already-committed drop (ADR 0011).
+			_ = s.audit.Append(audit.Record{
+				Event:     "retract",
+				Agent:     owner,
+				Inbox:     inbound.NormInbox(inbox),
+				MessageID: id,
+				Detail:    fmt.Sprintf("inbox=%s upstream_uid=%d content fetch found upstream uid gone", inbound.NormInbox(inbox), m.UpstreamUID),
+			})
+		}
+		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found: %w", id, m.UpstreamUID, inbound.ErrContentUnavailable)
 	}
 	return s.store.SetContent(owner, inbox, id, raw)
 }

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -231,6 +231,50 @@ func TestFetchContentStaleUIDValidity(t *testing.T) {
 
 	_, err = syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
 	require.Error(t, err)
+	// A mailbox reset is unresolvable-content, the clean-skip sentinel (#190) — the
+	// read face serves empty rather than hanging. It is NOT dropped here (a
+	// UIDVALIDITY change is reconcile's re-seed concern, not a per-message expunge).
+	assert.ErrorIs(t, err, inbound.ErrContentUnavailable)
+	_, gerr := store.Get("agent", inbound.DefaultInbox, m.ID)
+	assert.NoError(t, gerr, "a mailbox-reset record is not dropped on a single fetch")
+}
+
+// #190: FetchContent on a message whose upstream UID has vanished (expunged
+// upstream, local mapping stale) returns the ErrContentUnavailable sentinel AND
+// drops the dangling record + audits the retraction — the on-demand mirror of the
+// reconcile pass, so one poisoned UID can't stall an account's poll indefinitely.
+func TestFetchContentDropsVanishedMapping(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: real\r\n\r\nbody")
+
+	store := newInbound(t)
+	aud := &captureAudit{}
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	syncer.SetAudit(aud)
+
+	n, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	id, upUID := msgs[0].ID, msgs[0].UpstreamUID
+
+	// The upstream message is expunged: its UID vanishes, the local mapping stays.
+	expungeUID(t, addr, upUID)
+
+	_, ferr := syncer.FetchContent("agent", inbound.DefaultInbox, id)
+	require.Error(t, ferr)
+	assert.ErrorIs(t, ferr, inbound.ErrContentUnavailable, "unresolvable content is the clean-skip sentinel")
+
+	// The dangling record is dropped on detection, not left to poison future fetches.
+	_, gerr := store.Get("agent", inbound.DefaultInbox, id)
+	assert.ErrorIs(t, gerr, inbound.ErrNotFound, "the stale mapping is retracted")
+
+	// The retraction is audited, matching the reconcile trail.
+	require.Len(t, aud.recs, 1)
+	assert.Equal(t, "retract", aud.recs[0].Event)
+	assert.Equal(t, id, aud.recs[0].MessageID)
 }
 
 // A lost/reset sync cursor re-fetches everything, but the upstream-UID dedup

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -16,6 +16,14 @@ import (
 // ErrNotFound is returned by Get when no message matches.
 var ErrNotFound = errors.New("inbound: message not found")
 
+// ErrContentUnavailable marks a message whose upstream content can't be resolved:
+// the local→upstream UID mapping is stale — the upstream message was expunged, or
+// the mailbox's UIDVALIDITY changed. It is a terminal "skip this cleanly" signal,
+// distinct from a transient/connection error. The IMAP read face serves an empty
+// body and completes the FETCH rather than hanging the client, so one unresolvable
+// UID can't stall a whole account's poll (#190).
+var ErrContentUnavailable = errors.New("inbound: message content unavailable")
+
 // Address is one parsed envelope address. It mirrors the IMAP envelope address
 // (name + mailbox@host) without importing the IMAP library, keeping the store
 // IMAP-type-free (ADR 0016).

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -463,8 +463,17 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 		if !done {
 			done = true
 			var full inbound.Message
-			if full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); err == nil {
+			switch full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); {
+			case err == nil:
 				raw = full.Raw
+			case errors.Is(err, inbound.ErrContentUnavailable):
+				// The upstream content can't be resolved (a stale local→upstream UID
+				// mapping, #190). Serve an empty body rather than erroring: the FETCH
+				// response stays well-formed and the command completes, so one
+				// unresolvable UID can't stall the client's whole poll. The event is
+				// surfaced by the syncer at WARN and the stale mapping is dropped there;
+				// the message's stored ENVELOPE / SIZE / FLAGS still serve normally.
+				raw, err = nil, nil
 			}
 		}
 		return raw, err

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -214,6 +214,52 @@ func TestIMAPFetchResolvesPendingOnDemand(t *testing.T) {
 	assert.False(t, got.Pending) // cached present after the on-demand fetch
 }
 
+// #190: a BODY[] fetch whose content is unresolvable (a stale upstream mapping)
+// must NOT hang or error — it serves an empty body and completes, so the client
+// proceeds. Critically, one poisoned UID must not stall the rest of the range.
+func TestIMAPFetchContentUnavailableServesEmpty(t *testing.T) {
+	store := seedInbound(t) // present bounce at seq 1
+	_, m, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "gone", UpstreamUID: 7239, UIDValidity: 1,
+	})
+	require.NoError(t, err) // pending record at seq 2
+
+	fetch := func(owner, inbox, id string) (inbound.Message, error) {
+		if id == m.ID {
+			return inbound.Message{}, inbound.ErrContentUnavailable // stale mapping
+		}
+		return store.Get(owner, inbound.DefaultInbox, id)
+	}
+
+	c, err := imapclient.DialInsecure(startIMAPWithFetch(t, store, fetch), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	// BODY[] of the poisoned record completes cleanly with an empty body — the
+	// command returns, it does not hang or error.
+	msgs, err := c.Fetch(imap.SeqSetNum(2), &imap.FetchOptions{
+		UID:         true,
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err, "an unresolvable body completes, it does not error/hang")
+	require.Len(t, msgs, 1)
+	// A degenerate empty body (at most the section terminator), never the missing
+	// content or a hang.
+	assert.LessOrEqual(t, len(msgs[0].FindBodySection(&imap.FetchItemBodySection{})), 2, "an empty body is served")
+
+	// The whole range still returns both messages: one poisoned UID at the head
+	// does not stall the fetch of everything after it (the outage this fixes).
+	all, err := c.Fetch(imap.SeqSetNum(1, 2), &imap.FetchOptions{
+		UID:         true,
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	assert.Len(t, all, 2, "one unresolvable UID does not stall the whole fetch")
+}
+
 func TestIMAPFetchMarksSeenAndPersists(t *testing.T) {
 	store := seedInbound(t)
 	c, err := imapclient.DialInsecure(startIMAP(t, store), nil)


### PR DESCRIPTION
Fixes #190 — a downstream IMAP client's `UID FETCH … BODY[]` against one fronted account hung indefinitely (~20h silent outage) when a message's local→upstream UID mapping was stale (upstream message expunged).

## Root cause
`FetchContent` returned an error for the unresolvable UID, but the read face (`fetchMessage`) had already written a partial FETCH response (UID/FLAGS) and returned **without completing it** — no tagged result reached the client, so it hung on the read. Clients fetch oldest-first, so one poisoned UID at the head stalled the whole poll; logged only at INFO, nothing surfaced.

## Fix (the three asks)
1. **Don't hang.** Classify unresolvable content with a sentinel `inbound.ErrContentUnavailable` (wrapping both the vanished-UID and mailbox-reset cases). The read face serves an **empty body** for that message and completes the FETCH, so one unresolvable UID can't stall the rest. The stored ENVELOPE / SIZE / FLAGS still serve — only the body is empty.
2. **Repair the stale mapping.** A content fetch that finds the upstream UID **gone** drops the dangling local mapping and audits the retraction (same sink as reconcile) — at the moment of detection, not waiting for the hourly pass. A mailbox reset (UIDVALIDITY change) is deliberately **not** dropped per-message — that stays reconcile's re-seed concern.
3. **Sync visibility.** Unresolved content now logs at **WARN** (was effectively invisible), and each sync cycle emits a **per-account summary** (stored count, local UID watermark, UIDVALIDITY) so a stalled or desynced inbox is obvious from the log.

## Tests
- `listener.TestIMAPFetchContentUnavailableServesEmpty` — a BODY[] on a poisoned UID completes with an empty body, and a fetch of the whole range still returns every message (the outage scenario: head-of-queue poison no longer stalls the rest).
- `imapsync.TestFetchContentDropsVanishedMapping` — expunge upstream, then FetchContent returns the sentinel, drops the record, and audits a `retract`.
- `imapsync.TestFetchContentStaleUIDValidity` extended — the mailbox-reset case is the sentinel and is **not** dropped on a single fetch.

Gate (no CI on this repo → verified locally): build, vet, gofmt, full test suite, `-race` on the touched packages, golangci-lint 0.
