### PR TITLE
docs: note mounted key files must be readable by the nonroot uid (#48)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,6 +67,21 @@ Extract the public key with:
 openssl pkey -in secrets/dkim/dkim.pem -pubout -outform DER | tail -c 32 | base64
 ```
 
+### Key-file permissions (nonroot container)
+
+The container runs as a **nonroot** user (uid 65532), so every mounted key file —
+`secrets/tls/key.pem` and `secrets/dkim/dkim.pem` — must be **readable by that
+uid**. A key generated `0600` under your own host uid makes the container
+crash-loop on `permission denied` at startup. Make the keys readable by the
+container:
+
+```sh
+# keeps 0600, readable only by the container's uid (needs sudo to chown to a uid you don't own)
+sudo chown 65532 secrets/tls/key.pem secrets/dkim/dkim.pem
+# or, without sudo — readable by anyone on the host, which is fine inside ./secrets:
+chmod 644 secrets/tls/key.pem secrets/dkim/dkim.pem
+```
+
 ## 4. Configure `.env`
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The short version:
 ```sh
 cp .env.example .env        # fill DARBAAN_AGENT_PASS, DARBAAN_ADMIN_TOKEN
 # put a TLS cert+key in ./secrets/tls/ and an ed25519 DKIM key in ./secrets/dkim/
+# the container runs as nonroot (uid 65532) — make the mounted key files readable
+# by it (`chown 65532 <key>`, keeps 0600) or startup fails with "permission denied"
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,10 @@
 #
 #   1. cp .env.example .env   and fill DARBAAN_AGENT_PASS
 #   2. put TLS cert+key in ./secrets/tls/ and an ed25519 DKIM key in ./secrets/dkim/
+#      NOTE: the container runs as nonroot (uid 65532), so the mounted key files
+#      must be READABLE by that uid — a key created 0600 under your own host uid
+#      makes the container crash-loop on "permission denied". `chown 65532 <key>`
+#      (keeps 0600, readable only by the container) or `chmod 644 <key>` fixes it.
 #   3. docker compose up -d
 #
 # Safe by default: sender-type=stub, so the container sends NOTHING until you set
@@ -69,6 +73,8 @@ services:
       DARBAAN_INBOUND_IMAP_PASSWORD: "${DARBAAN_INBOUND_IMAP_PASSWORD:-}"
     volumes:
       - darbaan-data:/data # the three bbolt DBs (sluice / audit / inbound)
+      # The key files must be readable by the container's nonroot uid 65532 (see
+      # step 2 above) — otherwise startup crash-loops on "permission denied".
       - ./secrets/tls:/run/secrets/tls:ro # you provide cert.pem + key.pem
       - ./secrets/dkim:/run/secrets/dkim:ro # you provide dkim.pem (ed25519)
       # - ./config.yaml:/etc/darbaan/config.yaml:ro   # optional mounted config


### PR DESCRIPTION
Fixes #48 (docs-only, lean option a).

The distroless image runs as **nonroot (uid 65532)**, but operators naturally create their TLS key and DKIM key `0600` owned by their own uid. Bind-mounted read-only, the container then crash-loops on `permission denied` at startup (surfaced on the #47 live deploy).

Documents the requirement at every place an operator creates or mounts the keys:
- **docker-compose.yml** — a note at the secrets step (2) and on the `./secrets/tls` + `./secrets/dkim` volume mounts.
- **README.md** quick-start — a one-line note by the key step.
- **INSTALL.md** §3 — a dedicated *Key-file permissions (nonroot container)* subsection: `sudo chown 65532` (keeps 0600, container-only readable) or `chmod 644` (no sudo, host-readable within ./secrets).

Docs-only, no code. Ref #47, ADR 0012.