### PR TITLE
ci: SHA-pin all GitHub Actions (#73)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # Track the version pinned in go.mod (currently Go 1.26) so CI and the
           # module stay in lockstep — single source of truth.
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Pin the linter version so CI matches the local run (same reasoning as
           # go-version-file above); Dependabot bumps it deliberately.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Derive image tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/yaad-index/darbaan
           # On a tag push the version comes from the ref; on a manual run the
@@ -56,7 +56,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') && !contains(inputs.tag, '-') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           # Use a PAT instead of the default GITHUB_TOKEN. Events made with
           # GITHUB_TOKEN do not trigger further workflows (GitHub's


### PR DESCRIPTION
Fixes #73 (supply-chain hygiene, surfaced non-blocking in the #72 review).

Mutable major-version tags (`actions/checkout@v7`, …) can be repointed to different code. This pins **every** action to an immutable commit SHA with a trailing `# vX.Y.Z` comment for readability.

Applied **repo-wide** (the issue asked for consistency, not piecemeal) — ci.yml, release-please.yml, **and** docker-publish.yml:

| Action | SHA | Version |
|---|---|---|
| actions/checkout | 9c091bb | v7.0.0 |
| actions/setup-go | b7ad1da | v7.0.0 |
| golangci/golangci-lint-action | ba0d7d2 | v9.3.0 |
| googleapis/release-please-action | 45996ed | v5.0.0 |
| docker/setup-buildx-action | bb05f3f | v4.2.0 |
| docker/login-action | af1e73f | v4.4.0 |
| docker/metadata-action | dc80280 | v6.2.0 |
| docker/build-push-action | 53b7df9 | v7.3.0 |

Dependabot's `github-actions` ecosystem is already configured (#42) and bumps SHA-pinned actions (SHA + version comment), so the pins stay current + readable. Each SHA resolved from its major tag (annotated tags dereferenced to the commit); no version change, just tag→SHA. Ref #72, #42.