### PR TITLE
feat(sync): per-account sync-health observability + stall alert (#195)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           # Track the version pinned in go.mod (currently Go 1.26) so CI and the
           # module stay in lockstep — single source of truth.
@@ -37,7 +37,7 @@ jobs:
           fi
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
           # Pin the linter version so CI matches the local run (same reasoning as
           # go-version-file above); Dependabot bumps it deliberately.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Derive image tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/yaad-index/darbaan
           # On a tag push the version comes from the ref; on a manual run the
@@ -56,7 +56,7 @@ jobs:
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') && !contains(inputs.tag, '-') }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v5
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           # Use a PAT instead of the default GITHUB_TOKEN. Events made with
           # GITHUB_TOKEN do not trigger further workflows (GitHub's

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -228,6 +228,11 @@ approve/reject buttons.
   insecure-plaintext option noted in `docker-compose.yml`.
 - **Bounce won't verify** — confirm the DKIM `TXT` record matches the generated
   public key and the configured selector/domain.
+- **Is inbound sync healthy?** — `docker exec darbaan-darbaan-1 darbaan sync-status`
+  reports each fronted account's last successful sync, consecutive-error count, UID
+  watermark, and whether it is **stalled**. A stalled account also emits a loud
+  `account sync stalled` log event, so a persistent stall is visible without
+  reading the per-cycle log line by line.
 
 ## Configuration reference
 

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -85,6 +85,7 @@ type CLI struct {
 	InboundIMAPUsername     string        `name:"inbound-imap-username" help:"Upstream IMAP username for the sync."`
 	InboundIMAPMailbox      string        `name:"inbound-imap-mailbox" default:"INBOX" help:"Upstream mailbox to sync."`
 	InboundIMAPPollInterval time.Duration `name:"inbound-imap-poll-interval" default:"60s" help:"How often to poll the upstream mailbox for new mail."`
+	SyncStallThreshold      int           `name:"sync-stall-threshold" default:"3" help:"Consecutive failed sync cycles before an account is flagged stalled (loud ERROR + sync-status). Minimum 1."`
 	InboundSyncDB           string        `name:"inbound-sync-db" default:"darbaan-sync.db" help:"Path to the inbound sync-state (UIDVALIDITY + last UID) database." type:"path"`
 	InboundMaxAge           string        `name:"inbound-max-age" help:"Recency cutoff for the initial/full sync, e.g. 1y, 30d, 12h (ADR 0008). Empty = no cutoff (pull everything). Forward-only: widening it later needs a re-sync."`
 	InboundFilter           string        `name:"inbound-filter" help:"Path to the inbound filter rules (YAML, ADR 0021): serve-time allow/hide over synced mail. Empty = no filter (allow all)." type:"path"`
@@ -107,6 +108,7 @@ type CLI struct {
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
 	Holds      HoldsCmd      `cmd:"" help:"Inspect and decide inbound messages held for a human (ADR 0021)."`
 	Reconcile  ReconcileCmd  `cmd:"" help:"Inspect and release inboxes held by the reconcile safety cap (ADR 0026)."`
+	SyncStatus SyncStatusCmd `cmd:"" name:"sync-status" help:"Report each fronted account's inbound-sync health (via the running serve's admin API)."`
 	Filter     FilterCmd     `cmd:"" help:"Inspect the inbound filter without starting serve (ADR 0021/0022)."`
 	Telegram   TelegramCmd   `cmd:"" help:"Run the Telegram approval client (a separate admin-API client process)."`
 	DkimPubkey DkimPubkeyCmd `cmd:"" name:"dkim-pubkey" help:"Print the DKIM public-key record to pin to the agent."`
@@ -518,27 +520,48 @@ func imapKeywordWriter(syncers map[string]*imapsync.Syncer) listener.KeywordWrit
 // runSyncLoop polls one inbox's upstream on the configured interval until ctx is
 // cancelled. Sync errors are logged, never fatal — a flaky or unreachable
 // upstream must not take down serve.
-func (cli *CLI) runSyncLoop(ctx context.Context, inbox string, syncer *imapsync.Syncer) {
+func (cli *CLI) runSyncLoop(ctx context.Context, inbox string, syncer *imapsync.Syncer, health *syncHealth) {
 	slog.Info("inbound sync loop started", "inbox", inbox, "interval", cli.InboundIMAPPollInterval.String())
 	t := time.NewTicker(cli.InboundIMAPPollInterval)
 	defer t.Stop()
-	runSync(ctx, inbox, syncer) // initial pull at startup
+	runSync(ctx, inbox, syncer, health) // initial pull at startup
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			runSync(ctx, inbox, syncer)
+			runSync(ctx, inbox, syncer, health)
 		}
 	}
 }
 
-func runSync(ctx context.Context, inbox string, s *imapsync.Syncer) {
+// runSync runs one sync cycle and records its outcome in the health registry (#195).
+// On a persistent stall (consecutive errors crossing the threshold) it emits a
+// distinct high-severity event a downstream can alert on — the server-side
+// complement to the client-side fetch alert, catching a stall that never even
+// reaches a client.
+func runSync(ctx context.Context, inbox string, s *imapsync.Syncer, health *syncHealth) {
 	// Sync emits its own per-cycle summary (stored/watermark/uidvalidity, #190); the
-	// caller only needs to surface a hard failure.
+	// caller surfaces a hard failure and tracks per-account health.
 	if _, err := s.Sync(ctx); err != nil {
 		slog.Error("inbound sync failed", "inbox", inbox, "err", err)
+		if stalled, consec, since := health.recordFailure(inbox, err); stalled {
+			slog.Error("account sync stalled",
+				"inbox", inbox,
+				"consecutive_errors", consec,
+				"stalled_since", since.UTC().Format(time.RFC3339),
+				"last_error", err.Error())
+		}
+		return
 	}
+	// A successful cycle: record the fresh watermark (best-effort — a failed local
+	// read keeps the prior watermark rather than clobbering it).
+	uidValidity, watermark, werr := s.Watermark()
+	if werr != nil {
+		slog.Debug("could not read sync watermark for health", "inbox", inbox, "err", werr)
+		uidValidity = 0 // signals recordSuccess to keep the prior watermark
+	}
+	health.recordSuccess(inbox, uidValidity, watermark)
 }
 
 // DefaultSyncOnStatusInterval is the on-demand-sync debounce window for an inbox
@@ -692,6 +715,43 @@ func (*ReconcileStatusCmd) Run(cli *CLI) error {
 		fmt.Println("no inboxes are held by the reconcile safety cap")
 	}
 	return nil
+}
+
+// SyncStatusCmd reports each fronted account's inbound-sync health (#195): whether
+// it is syncing, since when, its error streak, and its UID watermark.
+type SyncStatusCmd struct{}
+
+func (*SyncStatusCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	st, err := client.SyncStatus(context.Background())
+	if err != nil {
+		return err
+	}
+	if len(st) == 0 {
+		fmt.Fprintln(os.Stderr, "no inbound-sync accounts (no inbox has an upstream configured)")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "INBOX\tSTATE\tLAST SUCCESS\tERRORS\tUIDVALIDITY\tWATERMARK\tLAST ERROR")
+	for _, s := range st {
+		state := "ok"
+		switch {
+		case s.Stalled:
+			state = "STALLED"
+		case s.ConsecutiveErrors > 0:
+			state = "erroring"
+		}
+		last := s.LastSuccess
+		if last == "" {
+			last = "never"
+		}
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%d\t%s\n",
+			s.Inbox, state, last, s.ConsecutiveErrors, s.UIDValidity, s.WatermarkUID, s.LastError)
+	}
+	return w.Flush()
 }
 
 // ReconcileReleaseCmd releases a held inbox: the operator confirms the large
@@ -1002,6 +1062,14 @@ func (*ServeCmd) Run(cli *CLI) error {
 			},
 		)
 	}
+
+	// Per-account sync-health registry (#195): the sync loop records each cycle's
+	// outcome, the admin API reads a snapshot (GET /sync-status). Created even with
+	// no syncers so the endpoint always answers (an empty set), and shared with the
+	// per-inbox sync loops spawned below.
+	health := newSyncHealth(cli.SyncStallThreshold)
+	svc.SetSyncStatusReader(health.snapshot)
+
 	// The inbound bounce-spoof guard (ADR 0024) runs ahead of the user filter on
 	// both faces, verifying with the bounce signer's own key. On by default; an
 	// explicit opt-out is logged. on_spoof=hold-for-human routes spoofs to the
@@ -1036,7 +1104,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		slog.Info("inbound sync disabled", "reason", "no inbox has an upstream configured")
 	}
 	for name, syn := range syncers {
-		go cli.runSyncLoop(ctx, name, syn)
+		go cli.runSyncLoop(ctx, name, syn, health)
 	}
 
 	// Per-inbox reconcile loops (ADR 0026): retract local copies of messages that

--- a/cmd/darbaan/synchealth.go
+++ b/cmd/darbaan/synchealth.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+// syncHealth is the per-account inbound-sync health registry (#195): the sync loop
+// records each cycle's outcome, and the admin API reads a snapshot. It is the
+// server-side complement to the client-side fetch alert (#191) — it catches a
+// stall that never even reaches a client. It is safe for concurrent use: one
+// writer goroutine per account (the sync loop) and the admin reader.
+type syncHealth struct {
+	mu        sync.RWMutex
+	rec       map[string]*syncHealthRecord
+	threshold int              // consecutive errors before an account is "stalled"
+	now       func() time.Time // injectable for tests
+}
+
+// syncHealthRecord is one account's tracked health.
+type syncHealthRecord struct {
+	lastSuccess  time.Time // last cycle that completed without error
+	firstFailure time.Time // start of the current error streak; zero when not failing
+	consecErrors int
+	lastError    string
+	watermarkUID uint32
+	uidValidity  uint32
+}
+
+// newSyncHealth builds the registry. A threshold below 1 is clamped to 1 so a
+// single failure can never be "not yet a stall".
+func newSyncHealth(threshold int) *syncHealth {
+	if threshold < 1 {
+		threshold = 1
+	}
+	return &syncHealth{rec: map[string]*syncHealthRecord{}, threshold: threshold, now: time.Now}
+}
+
+func (h *syncHealth) at(inbox string) *syncHealthRecord {
+	r := h.rec[inbox]
+	if r == nil {
+		r = &syncHealthRecord{}
+		h.rec[inbox] = r
+	}
+	return r
+}
+
+// recordSuccess clears the error streak and records the fresh watermark. A zero
+// uidValidity means the watermark could not be read this cycle; the prior one is
+// then kept rather than clobbered.
+func (h *syncHealth) recordSuccess(inbox string, uidValidity, watermarkUID uint32) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r := h.at(inbox)
+	r.lastSuccess = h.now()
+	r.consecErrors = 0
+	r.firstFailure = time.Time{}
+	r.lastError = ""
+	if uidValidity != 0 {
+		r.uidValidity = uidValidity
+		r.watermarkUID = watermarkUID
+	}
+}
+
+// recordFailure extends the error streak and reports whether the account has now
+// crossed the stall threshold, along with the streak length and when it began, so
+// the caller can emit a loud stall event.
+func (h *syncHealth) recordFailure(inbox string, err error) (stalled bool, consec int, since time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	r := h.at(inbox)
+	if r.consecErrors == 0 {
+		r.firstFailure = h.now()
+	}
+	r.consecErrors++
+	if err != nil {
+		r.lastError = err.Error()
+	}
+	return r.consecErrors >= h.threshold, r.consecErrors, r.firstFailure
+}
+
+// snapshot returns every account's health as admin.SyncStatus records, inbox-sorted
+// for stable output.
+func (h *syncHealth) snapshot() []admin.SyncStatus {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	out := make([]admin.SyncStatus, 0, len(h.rec))
+	for inbox, r := range h.rec {
+		st := admin.SyncStatus{
+			Inbox:             inbox,
+			ConsecutiveErrors: r.consecErrors,
+			LastError:         r.lastError,
+			WatermarkUID:      r.watermarkUID,
+			UIDValidity:       r.uidValidity,
+			Stalled:           r.consecErrors >= h.threshold,
+		}
+		if !r.lastSuccess.IsZero() {
+			st.LastSuccess = r.lastSuccess.UTC().Format(time.RFC3339)
+		}
+		out = append(out, st)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Inbox < out[j].Inbox })
+	return out
+}

--- a/cmd/darbaan/synchealth_test.go
+++ b/cmd/darbaan/synchealth_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncHealthSuccessAndSnapshot(t *testing.T) {
+	h := newSyncHealth(3)
+	base := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return base }
+
+	h.recordSuccess("work", 42, 1000)
+
+	snap := h.snapshot()
+	require.Len(t, snap, 1)
+	s := snap[0]
+	assert.Equal(t, "work", s.Inbox)
+	assert.False(t, s.Stalled)
+	assert.Equal(t, 0, s.ConsecutiveErrors)
+	assert.Equal(t, uint32(42), s.UIDValidity)
+	assert.Equal(t, uint32(1000), s.WatermarkUID)
+	assert.Equal(t, base.Format(time.RFC3339), s.LastSuccess)
+}
+
+// The stall flag flips only when consecutive errors cross the threshold, and the
+// reported "since" is the first failure of the streak.
+func TestSyncHealthStallThreshold(t *testing.T) {
+	h := newSyncHealth(3)
+	t0 := time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC)
+	h.now = func() time.Time { return t0 }
+
+	stalled, n, _ := h.recordFailure("work", errors.New("boom"))
+	assert.False(t, stalled)
+	assert.Equal(t, 1, n)
+	stalled, n, _ = h.recordFailure("work", errors.New("boom"))
+	assert.False(t, stalled)
+	assert.Equal(t, 2, n)
+	stalled, n, since := h.recordFailure("work", errors.New("boom"))
+	assert.True(t, stalled, "crosses the threshold at 3")
+	assert.Equal(t, 3, n)
+	assert.Equal(t, t0, since, "stall-since is the first failure of the streak")
+
+	snap := h.snapshot()
+	require.Len(t, snap, 1)
+	assert.True(t, snap[0].Stalled)
+	assert.Equal(t, "boom", snap[0].LastError)
+	assert.Equal(t, 3, snap[0].ConsecutiveErrors)
+}
+
+// A successful cycle clears the error streak; a zero UIDVALIDITY (watermark
+// unreadable that cycle) keeps the prior watermark rather than clobbering it.
+func TestSyncHealthRecoveryKeepsWatermarkOnZero(t *testing.T) {
+	h := newSyncHealth(2)
+	h.recordSuccess("work", 42, 1000)
+	h.recordFailure("work", errors.New("e"))
+	h.recordFailure("work", errors.New("e"))
+	require.True(t, h.snapshot()[0].Stalled)
+
+	h.recordSuccess("work", 0, 0) // recovered, but watermark not read this cycle
+
+	s := h.snapshot()[0]
+	assert.False(t, s.Stalled)
+	assert.Equal(t, 0, s.ConsecutiveErrors)
+	assert.Empty(t, s.LastError)
+	assert.Equal(t, uint32(42), s.UIDValidity, "prior watermark kept when the read failed")
+	assert.Equal(t, uint32(1000), s.WatermarkUID)
+}
+
+// A threshold below 1 clamps to 1 (one failure stalls); the snapshot is inbox-sorted.
+func TestSyncHealthThresholdClampAndSort(t *testing.T) {
+	h := newSyncHealth(0)
+	stalled, _, _ := h.recordFailure("b", errors.New("e"))
+	assert.True(t, stalled, "threshold clamps to 1 so a single failure stalls")
+	h.recordSuccess("a", 1, 1)
+
+	snap := h.snapshot()
+	require.Len(t, snap, 2)
+	assert.Equal(t, "a", snap[0].Inbox, "snapshot is inbox-sorted")
+	assert.Equal(t, "b", snap[1].Inbox)
+}

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -195,6 +195,23 @@ func (c *Client) ReconcileStatus(ctx context.Context) ([]ReconcileStatus, error)
 	return st, nil
 }
 
+// SyncStatus reports each fronted account's inbound-sync health (#195).
+func (c *Client) SyncStatus(ctx context.Context) ([]SyncStatus, error) {
+	resp, err := c.request(ctx, http.MethodGet, "/sync-status", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, errorFrom(resp)
+	}
+	var st []SyncStatus
+	if err := json.NewDecoder(resp.Body).Decode(&st); err != nil {
+		return nil, err
+	}
+	return st, nil
+}
+
 // ReleaseReconcile releases a latched inbox — confirm the large retraction and
 // resume reconciliation (ADR 0026).
 func (c *Client) ReleaseReconcile(ctx context.Context, inbox string) (ReconcileReleaseResult, error) {

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -75,6 +75,9 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 	s.register(mux, "GET /reconcile", s.handleReconcileStatus)
 	s.register(mux, "POST /reconcile/{inbox}/release", s.handleReconcileRelease)
 
+	// Per-account inbound-sync health (#195): is every fronted account syncing?
+	s.register(mux, "GET /sync-status", s.handleSyncStatus)
+
 	s.http = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	return s, nil
 }
@@ -256,6 +259,16 @@ func (s *Server) handleReconcileStatus(w http.ResponseWriter, _ *http.Request) {
 	}
 	if st == nil {
 		st = []ReconcileStatus{}
+	}
+	writeJSON(w, http.StatusOK, st)
+}
+
+// handleSyncStatus reports the inbound-sync health of every fronted account (#195).
+// An empty list (no account syncs) is a normal 200, not an error.
+func (s *Server) handleSyncStatus(w http.ResponseWriter, _ *http.Request) {
+	st := s.svc.SyncStatusAll()
+	if st == nil {
+		st = []SyncStatus{}
 	}
 	writeJSON(w, http.StatusOK, st)
 }

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -48,6 +48,10 @@ type Service struct {
 	// nil when no inbox has an upstream (nothing to reconcile).
 	reconcileRelease func(ctx context.Context, inbox string) (int, error)
 	reconcileStatus  func() ([]ReconcileStatus, error)
+
+	// Sync-health reader (#195), wired by serve over its per-account health
+	// registry; nil when no inbox syncs (the endpoint then reports an empty set).
+	syncStatus func() []SyncStatus
 }
 
 // ReconcileStatus reports one inbox's reconciliation latch (ADR 0026): whether
@@ -56,6 +60,18 @@ type ReconcileStatus struct {
 	Inbox     string `json:"inbox"`
 	Suspended bool   `json:"suspended"`
 	HeldCount int    `json:"held_count"`
+}
+
+// SyncStatus reports one fronted account's inbound-sync health (#195), so a health
+// check can answer "is every account syncing, and since when?" without log-scraping.
+type SyncStatus struct {
+	Inbox             string `json:"inbox"`
+	LastSuccess       string `json:"last_success,omitempty"` // RFC3339; empty until the first successful cycle
+	ConsecutiveErrors int    `json:"consecutive_errors"`
+	LastError         string `json:"last_error,omitempty"`
+	WatermarkUID      uint32 `json:"watermark_uid"`
+	UIDValidity       uint32 `json:"uidvalidity"`
+	Stalled           bool   `json:"stalled"` // consecutive errors have crossed the stall threshold
 }
 
 // ReconcileReleaseResult is the outcome of releasing a latched inbox (ADR 0026).
@@ -98,6 +114,22 @@ func (s *Service) ReconcileStatusAll() ([]ReconcileStatus, error) {
 		return nil, ErrReconcileUnavailable
 	}
 	return s.reconcileStatus()
+}
+
+// SetSyncStatusReader wires the per-account sync-health reader (#195). serve
+// supplies it over its health registry; without it (no inbox syncs) the endpoint
+// reports an empty set rather than an error.
+func (s *Service) SetSyncStatusReader(status func() []SyncStatus) {
+	s.syncStatus = status
+}
+
+// SyncStatusAll returns the inbound-sync health of every fronted account (#195).
+// An empty set (nil reader, i.e. no account syncs) is a valid answer, not an error.
+func (s *Service) SyncStatusAll() []SyncStatus {
+	if s.syncStatus == nil {
+		return nil
+	}
+	return s.syncStatus()
 }
 
 // NewService wires the approval service. inbox and signer may be nil only when

--- a/internal/admin/syncstatus_test.go
+++ b/internal/admin/syncstatus_test.go
@@ -1,0 +1,46 @@
+package admin_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+)
+
+// GET /sync-status returns each account's health when a reader is wired (#195).
+func TestSyncStatusRoundtrip(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	svc.SetSyncStatusReader(func() []admin.SyncStatus {
+		return []admin.SyncStatus{
+			{Inbox: "work", LastSuccess: "2026-07-17T12:00:00Z", WatermarkUID: 1000, UIDValidity: 42},
+			{Inbox: "stuck", ConsecutiveErrors: 5, LastError: "boom", Stalled: true},
+		}
+	})
+	addr := startServer(t, svc, "secret-token")
+	c := admin.NewClient(addr, "secret-token")
+
+	st, err := c.SyncStatus(context.Background())
+	require.NoError(t, err)
+	require.Len(t, st, 2)
+	assert.Equal(t, "work", st[0].Inbox)
+	assert.False(t, st[0].Stalled)
+	assert.Equal(t, uint32(1000), st[0].WatermarkUID)
+	assert.True(t, st[1].Stalled)
+	assert.Equal(t, "boom", st[1].LastError)
+	assert.Equal(t, 5, st[1].ConsecutiveErrors)
+}
+
+// With no reader wired (no inbox syncs), the endpoint answers an empty set — a
+// valid answer, not an error.
+func TestSyncStatusEmptyWhenNoReader(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	addr := startServer(t, svc, "tok")
+	c := admin.NewClient(addr, "tok")
+
+	st, err := c.SyncStatus(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, st, "no reader → empty set, not an error")
+}

--- a/internal/admincfg/admincfg.go
+++ b/internal/admincfg/admincfg.go
@@ -37,6 +37,7 @@ const (
 	ScopeReconcileRead    = "reconcile:read"
 	ScopeReconcileRelease = "reconcile:release"
 	ScopeInboxesRead      = "inboxes:read"
+	ScopeSyncRead         = "sync:read"
 )
 
 // RouteScopes is the authoritative route→required-scope map (ADR 0029): every
@@ -58,6 +59,7 @@ var RouteScopes = map[string]string{
 	"GET /reconcile":                      ScopeReconcileRead,
 	"POST /reconcile/{inbox}/release":     ScopeReconcileRelease,
 	"GET /inboxes":                        ScopeInboxesRead,
+	"GET /sync-status":                    ScopeSyncRead,
 }
 
 // allScopes is the set of valid scopes, derived from the RouteScopes values so it

--- a/internal/admincfg/admincfg_test.go
+++ b/internal/admincfg/admincfg_test.go
@@ -70,7 +70,7 @@ func TestValidate(t *testing.T) {
 
 func TestAllScopesAndValidScope(t *testing.T) {
 	all := admincfg.AllScopes()
-	assert.Len(t, all, 7)
+	assert.Len(t, all, 8)
 	for _, s := range all {
 		assert.True(t, admincfg.ValidScope(s))
 	}
@@ -94,6 +94,7 @@ func TestRouteScopesComplete(t *testing.T) {
 		"GET /reconcile",
 		"POST /reconcile/{inbox}/release",
 		"GET /inboxes",
+		"GET /sync-status",
 	}
 	assert.Len(t, admincfg.RouteScopes, len(wantRoutes), "no extra/missing routes")
 	for _, r := range wantRoutes {

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -74,6 +74,18 @@ func (s *Syncer) stateKey() string {
 	return s.inbox + "\x00" + s.mailbox
 }
 
+// Watermark returns this account's persisted sync cursor — the mailbox UIDVALIDITY
+// and the highest synced UID — for health reporting (#195). It reads the local
+// state store only (no upstream contact), so it is cheap to call after each sync
+// cycle. Before the first successful sync both are zero.
+func (s *Syncer) Watermark() (uidValidity, lastUID uint32, err error) {
+	st, err := s.state.Load(s.stateKey())
+	if err != nil {
+		return 0, 0, err
+	}
+	return st.UIDValidity, st.LastUID, nil
+}
+
 // Dialer is the production DialFunc: TLS-connect to addr and log in with the
 // Darbaan-held upstream credentials. The engine is tested with an injected
 // DialFunc against an in-process server.

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -141,6 +141,30 @@ func TestSyncPullsIncrementally(t *testing.T) {
 	assert.Len(t, msgs, 3)
 }
 
+// Watermark reports the persisted sync cursor (UIDVALIDITY + highest synced UID)
+// for health reporting (#195): zero before the first sync, advanced afterward.
+func TestSyncerWatermark(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: a\r\n\r\nx")
+	appendMsg(t, user, "Subject: b\r\n\r\ny")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+
+	uidv, last, err := syncer.Watermark()
+	require.NoError(t, err)
+	assert.Zero(t, uidv)
+	assert.Zero(t, last)
+
+	_, err = syncer.Sync(context.Background())
+	require.NoError(t, err)
+
+	uidv, last, err = syncer.Watermark()
+	require.NoError(t, err)
+	assert.NotZero(t, uidv, "UIDVALIDITY is set after the first sync")
+	assert.Equal(t, uint32(2), last, "watermark advanced to the highest synced UID")
+}
+
 func TestSyncTagsInbox(t *testing.T) {
 	addr, user := startUpstream(t)
 	appendMsg(t, user, "From: a@x.test\r\nSubject: w\r\n\r\nbody")


### PR DESCRIPTION
Fixes #195. Builds on #191's per-cycle summary log — makes inbound-sync health **queryable** and makes a persistent stall **loud**, so a silently-degrading account surfaces without someone tailing the log (the failure mode behind the ~20h #190 outage).

## What
1. **Per-account health registry** (`cmd/darbaan/synchealth.go`) — the sync loop records each cycle's outcome per fronted account: last-successful-sync timestamp, consecutive-error count, last error, and the UID watermark + UIDVALIDITY. Concurrency-safe (one writer goroutine per account + the admin reader).
2. **Queryable via the admin API** — `GET /sync-status` (new `sync:read` scope; localhost/trusted posture per ADR 0016) + a `darbaan sync-status` CLI command (tabwriter output: state / last-success / errors / uidvalidity / watermark / last-error). Answers "is every account syncing, and since when?" without log-scraping. Empty set (no account syncs) is a valid 200.
3. **Loud repeated-failure signal** — when an account's consecutive sync errors cross `--sync-stall-threshold` (default 3), a distinct high-severity `account sync stalled` structured event is emitted (inbox, consecutive_errors, stalled_since, last_error) — the server-side complement to the client-side fetch alert (#191), catching a stall that never even reaches a client.

## Notes
- Watermark is read from the local sync state store (no upstream contact), so it's cheap to call each cycle; a failed read keeps the prior watermark rather than clobbering it.
- Mirrors the existing `reconcile-status` plumbing exactly (service reader-injection, route→scope map, client method, CLI subcommand). The RouteScopes completeness test is updated for the new route.

## Tests / gate
`synchealth_test.go` (threshold crossing, recovery, watermark-keep-on-zero, sort/clamp), admin `syncstatus_test.go` (roundtrip + empty-when-no-reader), imapsync `TestSyncerWatermark`, admincfg route/scope pins updated. Local gate: build/vet/gofmt/`-race`/golangci-lint 0 (no CI on this repo). Non-goal: not a metrics/Prometheus stack — just "which account is stalled and since when" + a loud stall. Ref #190/#191, ADR 0016/0019.
