### PR TITLE
feat(provenance): strip X-Darbaan-* at the content-write chokepoint (ADR 0030 slice 1)

### DIFF
--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -13,6 +13,7 @@ import (
 	"go.etcd.io/bbolt"
 
 	"github.com/yaad-index/darbaan/internal/blobstore"
+	"github.com/yaad-index/darbaan/internal/provenance"
 	"github.com/yaad-index/darbaan/internal/seqkey"
 )
 
@@ -191,19 +192,38 @@ func (s *bboltStore) SetContent(owner, inbox, id string, raw []byte) (Message, e
 			return ErrNotFound
 		}
 		// Content blob first, then the metadata flip (same ordering as Add).
-		if err := s.blobs.Put(id, raw); err != nil {
-			return fmt.Errorf("write content: %w", err)
+		clean, err := s.putBlob(id, raw)
+		if err != nil {
+			return err
 		}
 		rec.Pending = false
 		rec.Blobbed = true
 		msg = rec.Message
-		msg.Raw = raw
+		msg.Raw = clean
 		return putStored(tx, key, rec)
 	})
 	if err != nil {
 		return Message{}, fmt.Errorf("inbound: set content %s: %w", id, err)
 	}
 	return msg, nil
+}
+
+// putBlob is the single content-write chokepoint: it strips darbaan's reserved
+// X-Darbaan-* namespace (ADR 0030 Layer-1) before persisting the body, so no
+// caller — SetContent for lazily-fetched pending mail, or put for a present Add
+// — can store an un-stripped blob. It returns the sanitized bytes so the caller
+// mirrors them into the in-memory Message it hands back. A blob carrying a
+// namespace line it can't cleanly strip is rejected rather than stored; an inert
+// non-message blob (e.g. a locally-generated bounce) passes through untouched.
+func (s *bboltStore) putBlob(id string, raw []byte) ([]byte, error) {
+	clean, err := provenance.Strip(raw)
+	if err != nil {
+		return nil, fmt.Errorf("sanitize content: %w", err)
+	}
+	if err := s.blobs.Put(id, clean); err != nil {
+		return nil, fmt.Errorf("write content: %w", err)
+	}
+	return clean, nil
 }
 
 // put builds and persists a new message. For a present message it writes the
@@ -234,10 +254,11 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byt
 	key := seqkey.Encode(seq)
 	blobbed := false
 	if !pending {
-		msg.Raw = d.Raw // present (return carries it; storedRec drops it for storage)
-		if err := s.blobs.Put(msg.ID, d.Raw); err != nil {
-			return Message{}, nil, fmt.Errorf("write content: %w", err)
+		clean, err := s.putBlob(msg.ID, d.Raw)
+		if err != nil {
+			return Message{}, nil, err
 		}
+		msg.Raw = clean // present (return carries it; storedRec drops it for storage)
 		blobbed = true
 	}
 	if err := putStored(tx, key, storedRec(msg, blobbed)); err != nil {

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -158,6 +158,44 @@ func TestPendingThenSetContent(t *testing.T) {
 	assert.Equal(t, raw, got.Raw)
 }
 
+// A forged X-Darbaan-* header on upstream mail is stripped at the content-write
+// chokepoint (ADR 0030 slice 1), so it never reaches a served blob — not the
+// SetContent return, nor a later Get. FetchContent for pending mail also routes
+// through SetContent, so this is the served-path guarantee.
+func TestSetContent_StripsProvenanceNamespace(t *testing.T) {
+	s := newStore(t)
+	_, m, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "hi", UpstreamUID: 7, UIDValidity: 1})
+	require.NoError(t, err)
+
+	forged := []byte("Subject: hi\r\nX-Darbaan-Trust: trusted\r\n\r\nbody")
+	filled, err := s.SetContent("agent", inbound.DefaultInbox, m.ID, forged)
+	require.NoError(t, err)
+	assert.NotContains(t, string(filled.Raw), "X-Darbaan-", "forged header stripped before persist")
+
+	got, err := s.Get("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got.Raw), "X-Darbaan-", "served blob carries no X-Darbaan-* header")
+	assert.Contains(t, string(got.Raw), "Subject: hi", "unrelated header preserved")
+	assert.Contains(t, string(got.Raw), "body", "body preserved")
+}
+
+// The present/Add path (a message stored with content up front, not via the
+// pending→SetContent fill) is the second blob-write site and must strip too —
+// the invariant is that NO write path persists an un-stripped X-Darbaan-*. Both
+// SetContent and Add route through the shared putBlob chokepoint.
+func TestAdd_StripsProvenanceNamespace(t *testing.T) {
+	s := newStore(t)
+	forged := []byte("Subject: hi\r\nX-Darbaan-Trust: trusted\r\n\r\nbody")
+	m, err := s.Add(inbound.Delivery{Owner: "agent", Subject: "hi", Raw: forged})
+	require.NoError(t, err)
+	assert.NotContains(t, string(m.Raw), "X-Darbaan-", "Add strips before persist")
+
+	got, err := s.Get("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got.Raw), "X-Darbaan-", "present blob carries no X-Darbaan-* header")
+	assert.Contains(t, string(got.Raw), "body", "body preserved")
+}
+
 func TestAddListGet(t *testing.T) {
 	s := newStore(t)
 	m, err := s.Add(inbound.Delivery{

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -1,0 +1,86 @@
+// Package provenance sanitizes darbaan's reserved X-Darbaan-* trust/provenance
+// header namespace on inbound mail. This slice implements the ADR 0030 Layer-1
+// floor (the unconditional strip); later slices add trust stamping on top.
+package provenance
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+
+	"github.com/emersion/go-message/textproto"
+)
+
+// Namespace is the header-name prefix darbaan reserves for its own
+// trust/provenance headers. Every inbound header whose name begins with it (in
+// any case) is under darbaan's exclusive control and is stripped before darbaan
+// stamps its own, so a sender can never pre-forge one (ADR 0030).
+const Namespace = "X-Darbaan-"
+
+var namespaceLower = strings.ToLower(Namespace)
+
+// Strip removes every X-Darbaan-* header from a raw RFC 822 message —
+// regardless of value, count, or position — and returns the message with its
+// body preserved byte-for-byte (only the header block is re-serialized, the
+// same mechanism as the send-path From rewrite). This is the ADR 0030 Layer-1
+// anti-spoof floor: because the whole namespace is deleted unconditionally, a
+// sender cannot smuggle in e.g. `X-Darbaan-Trust: trusted`.
+//
+// The content-write chokepoint feeds Strip both untrusted upstream mail (always
+// well-formed RFC 822) and darbaan's own locally-generated blobs (bounces, etc.),
+// some of which are not full messages. So a blob whose header block does not
+// parse is passed through unchanged — it has no RFC 822 header block a compliant
+// consumer would read a trust header from — UNLESS its header region actually
+// contains a namespace line, in which case Strip errors and (by the caller's
+// contract) the blob is not persisted, rather than risk a lenient consumer
+// reading a smuggled look-alike.
+func Strip(raw []byte) ([]byte, error) {
+	br := bufio.NewReader(bytes.NewReader(raw))
+	hdr, err := textproto.ReadHeader(br)
+	if err != nil {
+		if hasNamespaceHeaderLine(raw) {
+			return nil, err
+		}
+		return raw, nil
+	}
+	for fields := hdr.Fields(); fields.Next(); {
+		if strings.HasPrefix(strings.ToLower(fields.Key()), namespaceLower) {
+			fields.Del()
+		}
+	}
+	var buf bytes.Buffer
+	if err := textproto.WriteHeader(&buf, hdr); err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(&buf, br); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// hasNamespaceHeaderLine reports whether raw's header region (up to the first
+// blank line) begins any X-Darbaan-* field. It is a byte-level scan used only on
+// the parse-failure path, to tell an inert non-message blob (pass through) from
+// one smuggling a namespace look-alike (refuse). Folded continuation lines are
+// skipped; a blank line ends the header region.
+func hasNamespaceHeaderLine(raw []byte) bool {
+	for len(raw) > 0 {
+		var line []byte
+		if nl := bytes.IndexByte(raw, '\n'); nl < 0 {
+			line, raw = raw, nil
+		} else {
+			line, raw = raw[:nl], raw[nl+1:]
+		}
+		line = bytes.TrimRight(line, "\r")
+		switch {
+		case len(line) == 0:
+			return false // header/body boundary
+		case line[0] == ' ' || line[0] == '\t':
+			continue // folded continuation
+		case len(line) >= len(Namespace) && strings.EqualFold(string(line[:len(Namespace)]), Namespace):
+			return true
+		}
+	}
+	return false
+}

--- a/internal/provenance/provenance_test.go
+++ b/internal/provenance/provenance_test.go
@@ -1,0 +1,123 @@
+package provenance_test
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-message/textproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/provenance"
+)
+
+// headerKeys re-parses raw and returns its header field keys, so tests can
+// assert on the header block specifically (not a substring match that a body
+// could satisfy).
+func headerKeys(t *testing.T, raw []byte) []string {
+	t.Helper()
+	hdr, err := textproto.ReadHeader(bufio.NewReader(bytes.NewReader(raw)))
+	require.NoError(t, err)
+	var keys []string
+	for f := hdr.Fields(); f.Next(); {
+		keys = append(keys, f.Key())
+	}
+	return keys
+}
+
+func bodyOf(t *testing.T, raw []byte) []byte {
+	t.Helper()
+	i := bytes.Index(raw, []byte("\r\n\r\n"))
+	require.GreaterOrEqual(t, i, 0, "message has a header/body separator")
+	return raw[i+4:]
+}
+
+func assertNoNamespace(t *testing.T, raw []byte) {
+	t.Helper()
+	for _, k := range headerKeys(t, raw) {
+		assert.False(t, strings.HasPrefix(strings.ToLower(k), strings.ToLower(provenance.Namespace)),
+			"no %s* header survives, found %q", provenance.Namespace, k)
+	}
+}
+
+// The whole namespace is removed regardless of case, count, or position, while
+// unrelated headers and the body survive.
+func TestStrip_RemovesWholeNamespace(t *testing.T) {
+	raw := []byte("From: a@b\r\n" +
+		"X-Darbaan-Trust: trusted\r\n" +
+		"Subject: hi\r\n" +
+		"x-darbaan-note: injected directive\r\n" +
+		"X-DARBAAN-Source: forged\r\n" +
+		"\r\n" +
+		"hello body\r\n")
+
+	out, err := provenance.Strip(raw)
+	require.NoError(t, err)
+
+	assertNoNamespace(t, out)
+	keys := headerKeys(t, out)
+	assert.Contains(t, keys, "From", "unrelated headers preserved")
+	assert.Contains(t, keys, "Subject")
+	assert.Equal(t, []byte("hello body\r\n"), bodyOf(t, out), "body preserved byte-for-byte")
+}
+
+// A sender forging multiple trust headers has every one removed — no "keep the
+// last" ambiguity, the whole namespace goes.
+func TestStrip_RemovesForgedDuplicates(t *testing.T) {
+	raw := []byte("X-Darbaan-Trust: trusted\r\n" +
+		"X-Darbaan-Trust: also-trusted\r\n" +
+		"Subject: hi\r\n\r\nbody")
+	out, err := provenance.Strip(raw)
+	require.NoError(t, err)
+	assertNoNamespace(t, out)
+	assert.Contains(t, headerKeys(t, out), "Subject")
+}
+
+// A message that never carried a namespace header is unchanged in substance:
+// its headers and body both survive.
+func TestStrip_Passthrough(t *testing.T) {
+	raw := []byte("From: a@b\r\nSubject: normal\r\n\r\njust a body")
+	out, err := provenance.Strip(raw)
+	require.NoError(t, err)
+	keys := headerKeys(t, out)
+	assert.Contains(t, keys, "From")
+	assert.Contains(t, keys, "Subject")
+	assert.Equal(t, []byte("just a body"), bodyOf(t, out))
+}
+
+// Security-critical: the strip touches only the header block. An attacker who
+// writes a fake `X-Darbaan-Trust:` line into the message BODY must not have it
+// removed (removing body content would be a different bug) — and, more to the
+// point, that body line is not a header and never had any trust meaning.
+func TestStrip_LeavesBodyContentAlone(t *testing.T) {
+	body := "X-Darbaan-Trust: trusted\r\nthis line is body text, not a header\r\n"
+	raw := []byte("Subject: hi\r\nX-Darbaan-Trust: trusted\r\n\r\n" + body)
+
+	out, err := provenance.Strip(raw)
+	require.NoError(t, err)
+
+	assertNoNamespace(t, out) // the real header is gone
+	assert.Equal(t, []byte(body), bodyOf(t, out), "body left untouched, including a look-alike line")
+}
+
+// A blob that isn't a well-formed message (a locally-generated non-message, e.g.
+// a toy bounce) has no RFC 822 header block to strip, so it passes through
+// unchanged rather than being rejected — the content-write chokepoint feeds this
+// path darbaan's own blobs, not just upstream mail.
+func TestStrip_NonMessagePassesThrough(t *testing.T) {
+	raw := []byte("bounce")
+	out, err := provenance.Strip(raw)
+	require.NoError(t, err)
+	assert.Equal(t, raw, out)
+}
+
+// A malformed blob that nonetheless carries a namespace line in its header
+// region is refused (error), not passed through — so a smuggled look-alike a
+// lenient consumer might read can't slip past on the parse-failure path.
+func TestStrip_MalformedWithNamespaceRefused(t *testing.T) {
+	raw := []byte("X-Darbaan-Trust: trusted\r\nthis-line-has-no-colon\r\n\r\nbody")
+	_, err := provenance.Strip(raw)
+	require.Error(t, err, "a namespace line on an unparseable message is refused, not passed through")
+}


### PR DESCRIPTION
ADR 0030 slice 1 (of #200) — the Layer-1 anti-spoof floor, shippable on its own. No config, no trust logic yet.

## What it does

Unconditionally strips the entire `X-Darbaan-*` header namespace from inbound mail **before the body blob is persisted**, so no upstream (or attacker-forged) provenance header can reach a served message. A sender cannot pre-forge `X-Darbaan-Trust: trusted` — the whole namespace is deleted regardless of value, case, count, or position, ahead of any trust logic a later slice adds.

## Where the guarantee lives

- **`internal/provenance.Strip`** — re-serializes only the header block and preserves the body byte-for-byte (the same `textproto` read/rewrite the send-path From rewrite already uses). Deletes every field whose name begins with `X-Darbaan-` (case-insensitive).
- Enforced at a single store chokepoint, **`inbound.bboltStore.putBlob`**, that **both** blob-write sites call — `SetContent` (lazily-fetched pending mail) **and** `put` (a present `Add`). The invariant can't live in one caller when there are two, so the strip is structural: no write path can persist an un-stripped blob.

> **Review fix (thanks to the CHANGES_REQUESTED catch):** the first push stripped only in `SetContent`, leaving the present/`Add` path (`put` → `blobs.Put`) as a bypass. Both sites now route through `putBlob`; added a test for the `Add` path.

## Parse-failure handling

The chokepoint feeds `Strip` both untrusted upstream mail (always well-formed RFC 822) and darbaan's own locally-generated blobs (bounces), some of which aren't full messages. A blob whose header block won't parse has no RFC 822 header block a compliant consumer reads a trust header from, so it **passes through unchanged** — **unless** its header region carries a namespace line, in which case it is **refused** (not persisted) rather than risk a lenient consumer reading a smuggled look-alike.

## Scope

Layer-1 only. Config-driven trust **stamping** (`X-Darbaan-Trust` value from the authenticated source), the note, the body banner, and the serve-path backstop are the later slices, one PR each, per the ADR.

## Cross-package touch

Two packages: new `internal/provenance` (the strip helper + its tests), and `internal/inbound` (one call added at the `SetContent` chokepoint + an end-to-end test). The inbound change is exactly the one call site plus its import.

## Tests

- `provenance`: strip across case/count/position; a body line that *looks* like an `X-Darbaan-` header is left untouched (only the header block is edited); clean passthrough when no namespace header is present.
- `inbound`: end-to-end — a forged `X-Darbaan-Trust: trusted` on upstream mail never reaches the served blob (`SetContent` return nor a later `Get`), with the unrelated header + body preserved.

Green locally: `go build` / `go vet` / `gofmt` / `go test ./...` + golangci-lint v9.3.0 (0 issues).
