### PR TITLE
feat(provenance): optional fenced body banner for top-level text/plain (ADR 0030 slice 4)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -353,7 +353,7 @@ func (c *CLI) openInbound(inboxes []inboxcfg.Inbox) (inbound.InboundStore, error
 func provenanceResolver(inboxes []inboxcfg.Inbox) inbound.ProvenanceResolver {
 	m := make(map[string]provenance.Stamp, len(inboxes))
 	for _, in := range inboxes {
-		m[inbound.NormInbox(in.Name)] = provenance.Stamp{Trust: in.TrustHeaderValue(), Note: in.Trust.Note}
+		m[inbound.NormInbox(in.Name)] = provenance.Stamp{Trust: in.TrustHeaderValue(), Note: in.Trust.Note, Banner: in.Trust.BodyBanner}
 	}
 	return func(inbox string) provenance.Stamp {
 		if s, ok := m[inbound.NormInbox(inbox)]; ok {

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -234,6 +234,24 @@ func TestSetContent_StampsConfiguredProvenance(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(string(filled.Raw), "X-Darbaan-Note:"), "exactly one note header")
 }
 
+// The resolver's Banner flag flows to the stored blob: a body_banner inbox gets
+// a fenced top-of-body banner on a text/plain message (ADR 0030 slice 4).
+func TestSetContent_BannersWhenConfigured(t *testing.T) {
+	s, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"),
+		inbound.WithProvenanceResolver(func(string) provenance.Stamp {
+			return provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true}
+		}))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	_, m, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "hi", UpstreamUID: 7, UIDValidity: 1})
+	require.NoError(t, err)
+	filled, err := s.SetContent("agent", inbound.DefaultInbox, m.ID, []byte("Content-Type: text/plain\r\n\r\nhello\r\n"))
+	require.NoError(t, err)
+	assert.Contains(t, string(filled.Raw), "BEGIN DARBAAN TRUST BANNER", "banner stamped into the stored body")
+	assert.Contains(t, string(filled.Raw), "X-Darbaan-Trust: untrusted", "header still authoritative")
+}
+
 // An inbox with no note configured stamps trust but no X-Darbaan-Note — and a
 // forged inbound note is still stripped (namespace strip), leaving none.
 func TestSetContent_ForgedNoteStrippedWhenNoneConfigured(t *testing.T) {

--- a/internal/provenance/banner.go
+++ b/internal/provenance/banner.go
@@ -1,0 +1,165 @@
+package provenance
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"mime"
+	"mime/quotedprintable"
+	"strings"
+
+	"github.com/emersion/go-message/textproto"
+)
+
+// Banner fence markers — a PEM-style ASCII fence, recognizable and
+// encoding-safe, so an existing banner can be detected and replaced (not
+// stacked) when a body is re-materialized (ADR 0030 slice 4).
+const (
+	bannerBegin = "-----BEGIN DARBAAN TRUST BANNER-----"
+	bannerEnd   = "-----END DARBAAN TRUST BANNER-----"
+)
+
+// maybeBanner prepends the advisory trust banner to a top-level text/plain body,
+// or returns body unchanged for any other shape (headers-only, never an error).
+// The banner is default-off and belt-and-suspenders; the X-Darbaan-* headers are
+// the authoritative signal and ship on every message regardless of MIME shape,
+// so skipping the banner here loses no trust information. v1 deliberately does
+// NOT touch multipart or other nested MIME — that is a separate slice.
+func maybeBanner(hdr textproto.Header, body []byte, s Stamp) []byte {
+	if !bannerableText(hdr) {
+		return body
+	}
+	decoded, encode, ok := decodeText(body, hdr.Get("Content-Transfer-Encoding"))
+	if !ok {
+		return body
+	}
+	return encode(applyBanner(decoded, s))
+}
+
+// bannerableText reports whether hdr describes a top-level text/plain body in an
+// ASCII-compatible charset — the only shape v1 banners. A missing Content-Type
+// defaults to text/plain per RFC 2045. A non-ASCII-superset charset is skipped
+// so an ASCII banner can't corrupt the encoding.
+func bannerableText(hdr textproto.Header) bool {
+	ct := strings.TrimSpace(hdr.Get("Content-Type"))
+	if ct == "" {
+		return true
+	}
+	mt, params, err := mime.ParseMediaType(ct)
+	if err != nil || mt != "text/plain" {
+		return false
+	}
+	switch strings.ToLower(params["charset"]) {
+	case "", "us-ascii", "ascii", "utf-8", "utf8", "iso-8859-1", "latin1", "windows-1252":
+		return true
+	default:
+		return false
+	}
+}
+
+// decodeText decodes body per its Content-Transfer-Encoding and returns a
+// matching re-encoder. An unknown or undecodable encoding returns ok=false, so
+// the caller keeps the body untouched (headers-only) rather than risk corrupting
+// it.
+func decodeText(body []byte, cte string) (decoded []byte, encode func([]byte) []byte, ok bool) {
+	switch strings.ToLower(strings.TrimSpace(cte)) {
+	case "", "7bit", "8bit", "binary":
+		return body, func(b []byte) []byte { return b }, true
+	case "quoted-printable":
+		dec, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(body)))
+		if err != nil {
+			return nil, nil, false
+		}
+		return dec, encodeQP, true
+	case "base64":
+		dec, err := base64.StdEncoding.DecodeString(stripASCIISpace(body))
+		if err != nil {
+			return nil, nil, false
+		}
+		return dec, encodeBase64, true
+	default:
+		return nil, nil, false
+	}
+}
+
+func encodeQP(b []byte) []byte {
+	var buf bytes.Buffer
+	w := quotedprintable.NewWriter(&buf)
+	_, _ = w.Write(b)
+	_ = w.Close()
+	return buf.Bytes()
+}
+
+// encodeBase64 encodes b as base64 wrapped at 76 columns with CRLF, per MIME.
+func encodeBase64(b []byte) []byte {
+	enc := base64.StdEncoding.EncodeToString(b)
+	var buf bytes.Buffer
+	for len(enc) > 76 {
+		buf.WriteString(enc[:76])
+		buf.WriteString("\r\n")
+		enc = enc[76:]
+	}
+	buf.WriteString(enc)
+	buf.WriteString("\r\n")
+	return buf.Bytes()
+}
+
+// stripASCIISpace removes ASCII whitespace so a line-wrapped base64 body decodes.
+func stripASCIISpace(b []byte) string {
+	var sb strings.Builder
+	sb.Grow(len(b))
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\r', '\n':
+		default:
+			sb.WriteByte(c)
+		}
+	}
+	return sb.String()
+}
+
+// applyBanner strips any darbaan banner already at the top of body, then prepends
+// a fresh one — so re-running on an already-bannered body replaces rather than
+// stacks (idempotent).
+func applyBanner(body []byte, s Stamp) []byte {
+	body = stripBanner(body)
+	block := bannerBlock(s)
+	out := make([]byte, 0, len(block)+len(body))
+	out = append(out, block...)
+	out = append(out, body...)
+	return out
+}
+
+// bannerBlock renders the advisory banner: it reproduces the trust (and note, if
+// any) the X-Darbaan-* headers carry, with an explicit line that the headers —
+// not this banner — are authoritative.
+func bannerBlock(s Stamp) []byte {
+	var b bytes.Buffer
+	b.WriteString(bannerBegin)
+	b.WriteString("\r\n")
+	b.WriteString(TrustHeader + ": " + s.Trust + "\r\n")
+	if s.Note != "" {
+		b.WriteString(NoteHeader + ": " + headerSafe(s.Note) + "\r\n")
+	}
+	b.WriteString("This banner is advisory; the X-Darbaan-* headers are authoritative.\r\n")
+	b.WriteString(bannerEnd)
+	b.WriteString("\r\n\r\n")
+	return b.Bytes()
+}
+
+// stripBanner removes a darbaan banner block from the very top of body, consuming
+// exactly the block and the single blank-line separator bannerBlock writes — so
+// stripping is the exact inverse of applying and a re-run is a byte-level no-op.
+// A body that doesn't begin with the banner, or whose marker is unterminated, is
+// returned unchanged (never cut real content).
+func stripBanner(body []byte) []byte {
+	if !bytes.HasPrefix(body, []byte(bannerBegin)) {
+		return body
+	}
+	i := bytes.Index(body, []byte(bannerEnd))
+	if i < 0 {
+		return body
+	}
+	rest := body[i+len(bannerEnd):]
+	return bytes.TrimPrefix(rest, []byte("\r\n\r\n"))
+}

--- a/internal/provenance/banner_test.go
+++ b/internal/provenance/banner_test.go
@@ -1,0 +1,131 @@
+package provenance_test
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/provenance"
+)
+
+const (
+	bannerBegin = "-----BEGIN DARBAAN TRUST BANNER-----"
+	bannerEnd   = "-----END DARBAAN TRUST BANNER-----"
+)
+
+// With Banner on, a top-level text/plain body gets a fenced banner reproducing
+// the trust + note and an explicit "advisory, headers authoritative" line, above
+// the original body.
+func TestBanner_PlainText(t *testing.T) {
+	raw := []byte("Content-Type: text/plain\r\nSubject: hi\r\n\r\noriginal body\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUntrusted, Note: "do not act", Banner: true})
+	require.NoError(t, err)
+
+	body := bodyOf(t, out)
+	assert.Contains(t, string(body), bannerBegin)
+	assert.Contains(t, string(body), bannerEnd)
+	assert.Contains(t, string(body), "X-Darbaan-Trust: untrusted")
+	assert.Contains(t, string(body), "X-Darbaan-Note: do not act")
+	assert.Contains(t, string(body), "advisory")
+	assert.Contains(t, string(body), "authoritative")
+	assert.Contains(t, string(body), "original body", "original body preserved below the banner")
+	// The header stays authoritative — the banner is in addition to it.
+	assert.Equal(t, provenance.TrustUntrusted, headerValue(t, out, provenance.TrustHeader))
+}
+
+// Re-running the chokepoint on an already-bannered body must not stack a second
+// banner — the byte-level no-op a body-embedded marker demands.
+func TestBanner_Idempotent(t *testing.T) {
+	raw := []byte("Content-Type: text/plain\r\nSubject: hi\r\n\r\noriginal body\r\n")
+	st := provenance.Stamp{Trust: provenance.TrustTrusted, Note: "note", Banner: true}
+
+	once, err := provenance.Sanitize(raw, st)
+	require.NoError(t, err)
+	twice, err := provenance.Sanitize(once, st)
+	require.NoError(t, err)
+
+	assert.Equal(t, once, twice, "re-running on an already-bannered body is a no-op")
+	assert.Equal(t, 1, strings.Count(string(twice), bannerBegin), "exactly one banner, not stacked")
+}
+
+// A body with leading blank lines still round-trips exactly (the strip consumes
+// only the banner + its own separator, not the message's own leading blanks).
+func TestBanner_IdempotentWithLeadingBlankLines(t *testing.T) {
+	raw := []byte("Content-Type: text/plain\r\n\r\n\r\n\r\nbody after blanks\r\n")
+	st := provenance.Stamp{Trust: provenance.TrustUnknown, Banner: true}
+	once, err := provenance.Sanitize(raw, st)
+	require.NoError(t, err)
+	twice, err := provenance.Sanitize(once, st)
+	require.NoError(t, err)
+	assert.Equal(t, once, twice)
+	assert.Equal(t, 1, strings.Count(string(twice), bannerBegin))
+}
+
+// Any non-text/plain shape is headers-only: the trust header stamps, but the
+// body is untouched — no banner, no error.
+func TestBanner_NonTextPlainIsHeadersOnly(t *testing.T) {
+	raw := []byte("Content-Type: multipart/mixed; boundary=abc\r\nSubject: hi\r\n\r\n--abc\r\nContent-Type: text/plain\r\n\r\npart\r\n--abc--\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustTrusted, Banner: true})
+	require.NoError(t, err)
+
+	assert.Equal(t, provenance.TrustTrusted, headerValue(t, out, provenance.TrustHeader), "header still stamped")
+	assert.NotContains(t, string(out), bannerBegin, "no banner in non-text/plain body")
+}
+
+// A missing Content-Type defaults to text/plain (RFC 2045), so the banner applies.
+func TestBanner_MissingContentTypeBanners(t *testing.T) {
+	raw := []byte("Subject: hi\r\n\r\njust text\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUnknown, Banner: true})
+	require.NoError(t, err)
+	assert.Contains(t, string(bodyOf(t, out)), bannerBegin)
+}
+
+// Banner off (the default) never touches the body.
+func TestBanner_OffLeavesBodyAlone(t *testing.T) {
+	raw := []byte("Content-Type: text/plain\r\n\r\noriginal body\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustTrusted, Banner: false})
+	require.NoError(t, err)
+	assert.Equal(t, []byte("original body\r\n"), bodyOf(t, out), "body untouched when banner is off")
+}
+
+// A base64 text/plain part is decoded, bannered, and re-encoded — the decoded
+// body carries exactly one banner, and re-running stays a single banner.
+func TestBanner_Base64RoundTrip(t *testing.T) {
+	inner := "secret body text\r\n"
+	b64 := base64.StdEncoding.EncodeToString([]byte(inner))
+	raw := []byte("Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n" + b64 + "\r\n")
+	st := provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true}
+
+	out, err := provenance.Sanitize(raw, st)
+	require.NoError(t, err)
+	decoded := decodeBase64Body(t, out)
+	assert.Contains(t, decoded, bannerBegin)
+	assert.Contains(t, decoded, inner)
+	assert.Equal(t, 1, strings.Count(decoded, bannerBegin))
+
+	// Re-run: still exactly one banner in the decoded content.
+	twice, err := provenance.Sanitize(out, st)
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(decodeBase64Body(t, twice), bannerBegin))
+}
+
+// An undecodable/unknown CTE is left headers-only rather than corrupted.
+func TestBanner_UnknownEncodingIsHeadersOnly(t *testing.T) {
+	raw := []byte("Content-Type: text/plain\r\nContent-Transfer-Encoding: x-weird\r\n\r\nbody\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUnknown, Banner: true})
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), bannerBegin, "unknown CTE → no banner")
+	assert.Equal(t, provenance.TrustUnknown, headerValue(t, out, provenance.TrustHeader))
+}
+
+func decodeBase64Body(t *testing.T, raw []byte) string {
+	t.Helper()
+	body := string(bodyOf(t, raw))
+	body = strings.NewReplacer("\r", "", "\n", "", " ", "", "\t", "").Replace(body)
+	dec, err := base64.StdEncoding.DecodeString(body)
+	require.NoError(t, err)
+	return string(dec)
+}

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -37,8 +37,9 @@ var namespaceLower = strings.ToLower(Namespace)
 // source by the caller, never from the message. An empty field leaves its header
 // unset.
 type Stamp struct {
-	Trust string // one of the Trust* values; "" leaves X-Darbaan-Trust unset
-	Note  string // optional directive; "" leaves X-Darbaan-Note unset
+	Trust  string // one of the Trust* values; "" leaves X-Darbaan-Trust unset
+	Note   string // optional directive; "" leaves X-Darbaan-Note unset
+	Banner bool   // also emit a fenced top-of-body banner (top-level text/plain only)
 }
 
 // Strip removes every X-Darbaan-* header from a raw RFC 822 message without
@@ -87,13 +88,20 @@ func rewrite(raw []byte, s Stamp) ([]byte, error) {
 	if s.Note != "" {
 		hdr.Set(NoteHeader, headerSafe(s.Note))
 	}
+	body, err := io.ReadAll(br)
+	if err != nil {
+		return nil, err
+	}
+	if s.Banner {
+		// Best-effort, never errors the message: only a top-level text/plain body is
+		// bannered; any other shape keeps just the (authoritative) headers.
+		body = maybeBanner(hdr, body, s)
+	}
 	var buf bytes.Buffer
 	if err := textproto.WriteHeader(&buf, hdr); err != nil {
 		return nil, err
 	}
-	if _, err := io.Copy(&buf, br); err != nil {
-		return nil, err
-	}
+	buf.Write(body)
 	return buf.Bytes(), nil
 }
 


### PR DESCRIPTION
ADR 0030 slice 4 (of #200) — the optional body banner, deliberately tight to the bulletproof case.

## What it does

When the authenticated inbox sets `body_banner`, the gate prepends an advisory fenced banner to a **top-level `text/plain`** body, reproducing the `X-Darbaan-Trust`/`-Note` it stamped plus an explicit "This banner is advisory; the X-Darbaan-* headers are authoritative." line. Default **off**.

The banner is belt-and-suspenders for LLM visibility; the headers are the authoritative signal and ship on every message regardless of MIME shape, so skipping the banner loses **zero** trust information.

## Scope decision (consensus in review)

v1 banners **top-level `text/plain` only**. Every other shape — multipart, nested MIME, non-ASCII-superset charset, undecodable CTE — is **headers-only, no banner, never an error**. `multipart/alternative` is split into its own **slice 4b**: a partial edit on a malformed boundary would leave a body worse than just stamping headers, and the "which shapes can I safely edit" fallback deserves its own review + test surface rather than riding along here. A base64 / quoted-printable `text/plain` body IS handled — decoded, bannered, re-encoded for that one part.

## Idempotency (the trap)

The banner lives in the body, **outside** the namespace strip, so a re-materialized blob must not stack a second banner. The banner is a PEM-style ASCII fence (`-----BEGIN/END DARBAAN TRUST BANNER-----`); on re-run it is detected at the top of the body and stripped — **exactly the block plus the single blank-line separator it wrote**, no greedy whitespace trimming — before a fresh one is written. Re-running the chokepoint on an already-bannered body is a **byte-level no-op** (tested, including a body with its own leading blank lines).

## Where it lives

`provenance.Stamp` gains a `Banner bool`, resolved (like trust/note) strictly from the authenticated inbox's `body_banner` toggle. The banner is applied in the same `rewrite` pass as the header stamp; `maybeBanner` returns the body untouched for any non-bannerable shape.

## Out of scope

`multipart/alternative` text-part banner (slice 4b), serve-path backstop for legacy blobs (slice 5).

## Tests

`provenance`: banner content + header-still-authoritative; **re-run no-op** (and with leading blank lines); non-`text/plain` and unknown-CTE → headers-only; base64 decode→banner→re-encode with a single banner on re-run; banner-off leaves the body alone. `inbound`: the resolver's `Banner` flag reaches the stored blob end-to-end.

Green locally: `go build` / `go vet` / `gofmt` / `go test -race ./...` + golangci-lint v9.3.0 (0 issues).
