### PR TITLE
feat(listener): serve-path sanitize-then-stamp backstop (ADR 0030 slice 5)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -342,8 +342,8 @@ func (c *CLI) resolveAdminClients() ([]admin.ScopedClient, error) {
 // openInbound opens the inbound (served mailbox) store per config, wiring the
 // per-inbox provenance resolver so the content-write chokepoint stamps
 // X-Darbaan-Trust (and X-Darbaan-Note) by authenticated inbox (ADR 0030).
-func (c *CLI) openInbound(inboxes []inboxcfg.Inbox) (inbound.InboundStore, error) {
-	return inbound.New(c.InboundType, c.InboundDB, inbound.WithProvenanceResolver(provenanceResolver(inboxes)))
+func (c *CLI) openInbound(resolver inbound.ProvenanceResolver) (inbound.InboundStore, error) {
+	return inbound.New(c.InboundType, c.InboundDB, inbound.WithProvenanceResolver(resolver))
 }
 
 // provenanceResolver maps an inbox name to the trust + note to stamp (ADR 0030),
@@ -926,8 +926,12 @@ func (*ServeCmd) Run(cli *CLI) error {
 	if err != nil {
 		return err
 	}
+	// One provenance resolver, shared by the write chokepoint (the store) and the
+	// serve-path backstop (the IMAP read face), so both stamp identically by
+	// authenticated inbox (ADR 0030).
+	provResolver := provenanceResolver(inboxes)
 
-	inbox, err := cli.openInbound(inboxes)
+	inbox, err := cli.openInbound(provResolver)
 	if err != nil {
 		return err
 	}
@@ -1113,6 +1117,9 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
+		ServeStamp: func(inbox string, raw []byte) ([]byte, error) {
+			return provenance.Sanitize(raw, provResolver(inbox))
+		},
 	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner, syncNow)
 	if err != nil {
 		return err

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -34,7 +34,18 @@ type IMAPServerConfig struct {
 	Addr          string
 	TLSConfig     *tls.Config // enables STARTTLS; required unless AllowInsecure
 	AllowInsecure bool        // permit AUTH over plaintext — local/testing only
+	// ServeStamp re-runs the provenance sanitize-then-stamp on a message's raw
+	// before serving it (ADR 0030 slice 5 backstop), keyed on the serving inbox.
+	// It closes the legacy gap — pre-ADR blobs serve with their real trust, and
+	// served trust stays fresh on a config change — and is idempotent, so it's a
+	// safe belt-and-suspenders on every fetch. nil disables it (serve as stored).
+	ServeStamp ServeStamp
 }
+
+// ServeStamp sanitizes+stamps a raw message for the given (serving) inbox,
+// returning the served bytes (ADR 0030). It reads only the inbox key it is
+// given, never the message.
+type ServeStamp func(inbox string, raw []byte) ([]byte, error)
 
 // ContentFetch resolves a message's full content (Raw) on demand: for a present
 // record from its blob, for a pending record by fetching the body from upstream
@@ -90,7 +101,7 @@ func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore,
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner, syncNow: syncNow}, nil, nil
+			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner, syncNow: syncNow, serveStamp: cfg.ServeStamp}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -123,6 +134,7 @@ type imapSession struct {
 	principal     *Principal                // the authenticated agent + its grants (ADR 0027)
 	mailOwner     func(inbox string) string // synced-mail owner key per inbox (ADR 0027); nil = key by the connecting agent
 	syncNow       SyncTrigger               // debounced on-demand pull on STATUS (ADR 0028); nil = disabled
+	serveStamp    ServeStamp                // serve-path provenance re-stamp (ADR 0030 slice 5); nil = serve as stored
 	owner         string
 	selectedInbox string // the inbox name of the SELECTed mailbox (ADR 0023)
 	authed        bool
@@ -466,6 +478,21 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 			switch full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); {
 			case err == nil:
 				raw = full.Raw
+				// Serve-path backstop (ADR 0030 slice 5): re-run the same sanitize +
+				// stamp as the write chokepoint, keyed strictly on the session's
+				// server-side selected inbox (never anything from the blob), so a
+				// pre-ADR/legacy blob serves with its real trust and the stamp stays
+				// fresh on a config change. Idempotent on an already-stamped blob. A
+				// blob that can't be safely re-stamped serves empty rather than
+				// un-sanitized — real stored blobs are sanitized at write, so this is
+				// a near-dead edge.
+				if s.serveStamp != nil {
+					if stamped, serr := s.serveStamp(s.selectedInbox, raw); serr == nil {
+						raw = stamped
+					} else {
+						raw = nil
+					}
+				}
 			case errors.Is(err, inbound.ErrContentUnavailable):
 				// The upstream content can't be resolved (a stale local→upstream UID
 				// mapping, #190). Serve an empty body rather than erroring: the FETCH

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
@@ -14,7 +15,20 @@ import (
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/listener"
+	"github.com/yaad-index/darbaan/internal/provenance"
 )
+
+func startIMAPServeStamp(t *testing.T, store inbound.InboundStore, ss listener.ServeStamp) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true, ServeStamp: ss},
+		listener.SingleAuth("agent", "pw"), store, nil, nil, map[string]*filter.Filter{inbound.DefaultInbox: nil}, nil, false, nil, nil)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
 
 func seedInbound(t *testing.T) inbound.InboundStore {
 	t.Helper()
@@ -745,4 +759,36 @@ func TestIMAPBouncePrivacyOnSharedInbox(t *testing.T) {
 		"agent-a sees shared synced mail + its own bounce, never agent-b's")
 	assert.Equal(t, map[string]bool{"synced-w": true, "bounce-b": true}, subjects("agent-b"),
 		"agent-b sees shared synced mail + its own bounce, never agent-a's")
+}
+
+// The serve-path backstop (ADR 0030 slice 5) re-runs the sanitize+stamp on the
+// raw before serving, keyed on the session's selected inbox — so a blob stored
+// with one trust value serves with the CURRENT config's value (freshness /
+// legacy gap), with exactly one trust header (idempotent, not stacked).
+func TestIMAPServeStampReStampsFresh(t *testing.T) {
+	store := seedInbound(t) // present bounce at seq 1, stored trust=unknown (default resolver)
+
+	// Serve-path resolves TRUSTED for the inbox: it must override the stored value.
+	ss := func(_ string, raw []byte) ([]byte, error) {
+		return provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustTrusted})
+	}
+
+	c, err := imapclient.DialInsecure(startIMAPServeStamp(t, store, ss), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	body := string(msgs[0].FindBodySection(&imap.FetchItemBodySection{}))
+	assert.Contains(t, body, "X-Darbaan-Trust: trusted", "serve-path stamps the current config value")
+	assert.NotContains(t, body, "X-Darbaan-Trust: unknown", "stored value overridden on serve")
+	assert.Equal(t, 1, strings.Count(body, "X-Darbaan-Trust:"), "exactly one trust header, not stacked")
+	assert.Contains(t, body, "refused-marker", "body preserved")
 }


### PR DESCRIPTION
ADR 0030 slice 5 (of #200) — the serve-path backstop. Last core slice; closes the legacy gap.

## What it does

The read face now re-runs the **full `provenance.Sanitize`** (the same strip + stamp as the write chokepoint) on a message's raw before serving it, in `rawResolver` — the single memoized point every body FETCH resolves through.

- **Keyed strictly on the session's server-side selected inbox** (`s.selectedInbox`, the authenticated SELECT state), never anything read from the blob — so the serve-path trust anchor is as unspoofable as the write-path one. SELECT serves one authenticated mailbox and FETCH serves from it, so serving-inbox == the blob's stored inbox → each blob gets its true trust.
- Gives **pre-ADR / legacy blobs** their real trust on serve (rather than a stale `unknown`), and keeps served trust **fresh** if an inbox's trust config later changes.
- **Idempotent by construction**: strip removes any write-time stamp and the re-stamp re-adds the same value; the banner strip-then-rewrite already no-ops. So it's a safe belt-and-suspenders on *every* fetch.
- A blob that can't be safely re-stamped serves **empty** rather than un-sanitized (real stored blobs are sanitized at write → near-dead edge). Per-fetch cost is one header-block rewrite (+ banner if toggled) — acceptable per the ADR; **no caching** in v1.

## Wiring

A `ServeStamp` hook on `IMAPServerConfig`, built in `main` from the **same** provenance resolver the store uses (`provResolver`), so write-path and serve-path stamp identically. `nil` disables it (tests serve as stored, and stored blobs are already write-stamped).

## Test

A blob stored with `trust=unknown` (default resolver) serves as the current config's `trusted` via a `ServeStamp` resolver — exactly one trust header (freshness + idempotence), body preserved. End-to-end over the real IMAP FETCH path.

## #200 status after this

ADR ✅ · slice 1 (strip) ✅ · 2 (trust) ✅ · 3 (note) ✅ · 4 (banner) ✅ · **5 (serve-path backstop)** here. That's all core slices — the one remaining optional follow-on is **slice 4b** (multipart/alternative banner). This PR does **not** close #200 (4b pending).

Green locally: `go build` / `go vet` / `gofmt` / `go test -race ./...` + golangci-lint v9.3.0 (0 issues).
