### PR TITLE
docs(readme): security-boundary callout — darbaan is not an authentication source

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ Two properties define it:
 - **Inbound is gated.** The client reads a synced, recency-bounded view of the
   real mailbox, never the live account directly.
 
+> [!CAUTION]
+> **Darbaan is not an authenticity / authentication source.**
+>
+> Darbaan is a proxy that reads from an upstream mail server; it does **not**
+> itself verify that a message genuinely came from its claimed sender. The
+> provenance it stamps (`X-Darbaan-Trust`, `X-Darbaan-Note`) is only as
+> trustworthy as the **upstream mail server's own sender authentication**
+> (SPF, DKIM, DMARC, spam filtering).
+>
+> When darbaan reads from a server that authenticates senders well — e.g. Gmail,
+> which enforces DMARC on its own domain and spam-filters spoofed mail before it
+> ever reaches the inbox — the signals darbaan re-exposes are meaningful. Point
+> darbaan at a mail server that does **not** authenticate senders and those
+> signals are **not** safe: a forged `From` would be served as if genuine. **The
+> security of the trust model rests entirely on the mail server on the other
+> side.**
+
 ## Outbound — nothing leaves without approval
 
 A client submits a message over SMTP, and:


### PR DESCRIPTION
Adds a prominent top-of-README `> [!CAUTION]` alert making the trust-model boundary explicit.

Substance: darbaan is a proxy that reads from an upstream mail server and does **not** itself verify a sender is genuine, so the provenance it stamps (`X-Darbaan-Trust` / `X-Darbaan-Note`, ADR 0030) is only as trustworthy as the upstream server's own SPF/DKIM/DMARC/spam filtering. Pointed at a server that authenticates senders well the signals are meaningful; pointed at one that does not, a forged `From` would be served as genuine.

Placed high — right after the intro, before the Outbound section — so it can't be missed. Docs-only; renders as a red boxed alert on GitHub.
