### PR TITLE
feat(inboxcfg): per-inbox per-sender trust rules + resolution (ADR 0031 slice 1)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -351,13 +351,13 @@ func (c *CLI) openInbound(resolver inbound.ProvenanceResolver) (inbound.InboundS
 // defaulting to unknown trust (no note) for an unconfigured inbox. It reads only
 // config — never message content.
 func provenanceResolver(inboxes []inboxcfg.Inbox) inbound.ProvenanceResolver {
-	m := make(map[string]provenance.Stamp, len(inboxes))
+	byName := make(map[string]inboxcfg.Inbox, len(inboxes))
 	for _, in := range inboxes {
-		m[inbound.NormInbox(in.Name)] = provenance.Stamp{Trust: in.TrustHeaderValue(), Note: in.Trust.Note, Banner: in.Trust.BodyBanner}
+		byName[inbound.NormInbox(in.Name)] = in
 	}
-	return func(inbox string) provenance.Stamp {
-		if s, ok := m[inbound.NormInbox(inbox)]; ok {
-			return s
+	return func(inbox, from string) provenance.Stamp {
+		if in, ok := byName[inbound.NormInbox(inbox)]; ok {
+			return in.SenderStamp(from) // per-sender rule → inbox default → unknown (ADR 0031)
 		}
 		return provenance.Stamp{Trust: provenance.TrustUnknown}
 	}
@@ -1118,7 +1118,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
 		ServeStamp: func(inbox string, raw []byte) ([]byte, error) {
-			return provenance.Sanitize(raw, provResolver(inbox))
+			return provenance.Sanitize(raw, provResolver(inbox, provenance.From(raw)))
 		},
 	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner, syncNow)
 	if err != nil {

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -61,7 +61,7 @@ func newBbolt(path string, resolve ProvenanceResolver) (InboundStore, error) {
 	if resolve == nil {
 		// No resolver wired → stamp the fail-safe unknown trust (no note), so the
 		// content-write chokepoint always stamps a valid value (ADR 0030).
-		resolve = func(string) provenance.Stamp { return provenance.Stamp{Trust: provenance.TrustUnknown} }
+		resolve = func(string, string) provenance.Stamp { return provenance.Stamp{Trust: provenance.TrustUnknown} }
 	}
 	db, err := bbolt.Open(path, 0o600, &bbolt.Options{Timeout: time.Second})
 	if err != nil {
@@ -227,7 +227,10 @@ func (s *bboltStore) SetContent(owner, inbox, id string, raw []byte) (Message, e
 // locally-generated bounce) passes through untouched (unstamped → read as
 // unknown).
 func (s *bboltStore) putBlob(inbox, id string, raw []byte) ([]byte, error) {
-	clean, err := provenance.Sanitize(raw, s.resolve(inbox))
+	// Trust is resolved from the authenticated inbox and the message's From
+	// (per-sender rules, ADR 0031). The From is read from the raw here; the trust
+	// asymmetry keeps that safe (only `trusted` is gated on the upstream, slice 2).
+	clean, err := provenance.Sanitize(raw, s.resolve(inbox, provenance.From(raw)))
 	if err != nil {
 		return nil, fmt.Errorf("sanitize content: %w", err)
 	}

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -199,12 +199,14 @@ type InboundStore interface {
 	Close() error
 }
 
-// ProvenanceResolver maps an inbox name to the provenance the store's
-// content-write chokepoint stamps for that inbox (ADR 0030): its trust verdict
-// and optional note. It reads only the authenticated inbox, never message
-// content, so a message can't influence its own provenance. A nil resolver
+// ProvenanceResolver maps a message's (authenticated inbox, sender address) to
+// the provenance the store's content-write chokepoint stamps (ADR 0030 + 0031):
+// its trust verdict and optional note. It reads only config — the inbox's trust
+// default and its per-sender rules, matched against `from`. The sender From is
+// message-derived, but the trust asymmetry keeps it safe: a From only ever raises
+// trust to `trusted` under the upstream-authentication boundary. A nil resolver
 // selects the unknown-trust / no-note fail-safe default.
-type ProvenanceResolver func(inbox string) provenance.Stamp
+type ProvenanceResolver func(inbox, from string) provenance.Stamp
 
 // Factory constructs an InboundStore of a given type from a path and provenance
 // resolver (nil → stamp unknown trust, no note).

--- a/internal/inbound/inbound_test.go
+++ b/internal/inbound/inbound_test.go
@@ -212,7 +212,7 @@ func TestAdd_StripsForgedTrustAndStamps(t *testing.T) {
 // from the namespace strip).
 func TestSetContent_StampsConfiguredProvenance(t *testing.T) {
 	s, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"),
-		inbound.WithProvenanceResolver(func(inbox string) provenance.Stamp {
+		inbound.WithProvenanceResolver(func(inbox, _ string) provenance.Stamp {
 			if inbox == inbound.DefaultInbox {
 				return provenance.Stamp{Trust: provenance.TrustTrusted, Note: "operator forwarded"}
 			}
@@ -238,7 +238,7 @@ func TestSetContent_StampsConfiguredProvenance(t *testing.T) {
 // a fenced top-of-body banner on a text/plain message (ADR 0030 slice 4).
 func TestSetContent_BannersWhenConfigured(t *testing.T) {
 	s, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"),
-		inbound.WithProvenanceResolver(func(string) provenance.Stamp {
+		inbound.WithProvenanceResolver(func(string, string) provenance.Stamp {
 			return provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true}
 		}))
 	require.NoError(t, err)
@@ -250,6 +250,29 @@ func TestSetContent_BannersWhenConfigured(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(filled.Raw), "BEGIN DARBAAN TRUST BANNER", "banner stamped into the stored body")
 	assert.Contains(t, string(filled.Raw), "X-Darbaan-Trust: untrusted", "header still authoritative")
+}
+
+// The content-write chokepoint extracts the message From and passes it to the
+// resolver (ADR 0031): a sender-keyed resolver stamps by the actual From, so
+// per-sender rules take effect at write time.
+func TestSetContent_ResolvesTrustBySender(t *testing.T) {
+	s, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"),
+		inbound.WithProvenanceResolver(func(_ string, from string) provenance.Stamp {
+			if from == "ops@example.com" {
+				return provenance.Stamp{Trust: provenance.TrustTrusted}
+			}
+			return provenance.Stamp{Trust: provenance.TrustUnknown}
+		}))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Close() })
+
+	trusted, err := s.Add(inbound.Delivery{Owner: "agent", Raw: []byte("From: Ops <ops@example.com>\r\nSubject: hi\r\n\r\nbody")})
+	require.NoError(t, err)
+	assert.Contains(t, string(trusted.Raw), "X-Darbaan-Trust: trusted", "stamped from the From-matched rule")
+
+	other, err := s.Add(inbound.Delivery{Owner: "agent", Raw: []byte("From: someone@else.test\r\nSubject: hi\r\n\r\nbody")})
+	require.NoError(t, err)
+	assert.Contains(t, string(other.Raw), "X-Darbaan-Trust: unknown", "a non-matching sender takes the default")
 }
 
 // An inbox with no note configured stamps trust but no X-Darbaan-Note — and a

--- a/internal/inboxcfg/inboxcfg.go
+++ b/internal/inboxcfg/inboxcfg.go
@@ -94,6 +94,22 @@ type Trust struct {
 	// BodyBanner is a reserved (ADR 0030 slice 4) toggle for a fenced top-of-body
 	// trust banner. Parsed now; not yet acted on.
 	BodyBanner bool `yaml:"body_banner"`
+	// Rules are per-sender overrides (ADR 0031): the most-specific rule whose
+	// matcher matches a message's From supplies the trust level + note, overriding
+	// the inbox Level default. Matched on From only (v1); a `trusted` rule is sound
+	// only under the upstream-authentication boundary (the README caution).
+	Rules []TrustRule `yaml:"rules"`
+}
+
+// TrustRule maps a sender to a trust level + optional note (ADR 0031). Exactly
+// one matcher is set: From (an exact address, most specific) or FromDomain (the
+// From's domain). Level is trusted or untrusted — unknown is the absence of a
+// rule, not a rule outcome.
+type TrustRule struct {
+	From       string `yaml:"from"`
+	FromDomain string `yaml:"from_domain"`
+	Level      string `yaml:"level"`
+	Note       string `yaml:"note"`
 }
 
 // Trust levels an operator may set. Anything else is a config error; an omitted
@@ -229,17 +245,115 @@ func (in Inbox) validateTrust() error {
 		return fmt.Errorf("trust.level %q is invalid (want %q or %q, or omit for unknown)",
 			in.Trust.Level, TrustLevelTrusted, TrustLevelUntrusted)
 	}
-	if n := in.Trust.Note; n != "" {
-		if len(n) > maxNoteLen {
-			return fmt.Errorf("trust.note is too long (%d > %d bytes)", len(n), maxNoteLen)
+	if err := validateNote(in.Trust.Note); err != nil {
+		return fmt.Errorf("trust.note: %w", err)
+	}
+	return validateRules(in.Trust.Rules)
+}
+
+// validateNote rejects a note that isn't a single sane header value (ADR 0030).
+func validateNote(note string) error {
+	if note == "" {
+		return nil
+	}
+	if len(note) > maxNoteLen {
+		return fmt.Errorf("too long (%d > %d bytes)", len(note), maxNoteLen)
+	}
+	for _, r := range note {
+		if r < 0x20 || r == 0x7f {
+			return fmt.Errorf("contains a control character")
 		}
-		for _, r := range n {
-			if r < 0x20 || r == 0x7f {
-				return fmt.Errorf("trust.note contains a control character")
+	}
+	return nil
+}
+
+// validateRules checks each per-sender rule (ADR 0031): exactly one matcher, a
+// trusted/untrusted level, a sane note, and no duplicate matcher (which would be
+// an ambiguous double-classification of the same sender).
+func validateRules(rules []TrustRule) error {
+	seenFrom := make(map[string]bool, len(rules))
+	seenDomain := make(map[string]bool, len(rules))
+	for i, r := range rules {
+		hasFrom := strings.TrimSpace(r.From) != ""
+		hasDomain := strings.TrimSpace(r.FromDomain) != ""
+		if hasFrom == hasDomain {
+			return fmt.Errorf("trust.rules[%d]: exactly one of `from` or `from_domain` is required", i)
+		}
+		if r.Level != TrustLevelTrusted && r.Level != TrustLevelUntrusted {
+			return fmt.Errorf("trust.rules[%d]: level %q must be %q or %q", i, r.Level, TrustLevelTrusted, TrustLevelUntrusted)
+		}
+		if err := validateNote(r.Note); err != nil {
+			return fmt.Errorf("trust.rules[%d].note: %w", i, err)
+		}
+		if hasFrom {
+			if k := normAddr(r.From); seenFrom[k] {
+				return fmt.Errorf("trust.rules: duplicate from %q", r.From)
+			} else {
+				seenFrom[k] = true
+			}
+		} else {
+			if k := normDomain(r.FromDomain); seenDomain[k] {
+				return fmt.Errorf("trust.rules: duplicate from_domain %q", r.FromDomain)
+			} else {
+				seenDomain[k] = true
 			}
 		}
 	}
 	return nil
+}
+
+// SenderStamp resolves the provenance to stamp for a message whose (normalized,
+// lower-cased) sender address is `from`, in this inbox (ADR 0031): the
+// most-specific matching rule — an exact-address rule beats a domain rule —
+// supplies the trust level + note, else the inbox's own default level + note. The
+// banner toggle is always the inbox's. `from` == "" (no parseable From) matches
+// no rule and takes the inbox default.
+func (in Inbox) SenderStamp(from string) provenance.Stamp {
+	trust := in.TrustHeaderValue()
+	note := in.Trust.Note
+	if from != "" {
+		if r, ok := in.matchRule(from); ok {
+			if r.Level == TrustLevelUntrusted {
+				trust = provenance.TrustUntrusted
+			} else {
+				trust = provenance.TrustTrusted
+			}
+			note = r.Note
+		}
+	}
+	return provenance.Stamp{Trust: trust, Note: note, Banner: in.Trust.BodyBanner}
+}
+
+// matchRule returns the most-specific rule matching from: an exact-address rule
+// wins over a domain rule (rules are deduped at load, so at most one per tier).
+func (in Inbox) matchRule(from string) (TrustRule, bool) {
+	dom := domainOf(from)
+	var domainMatch *TrustRule
+	for i := range in.Trust.Rules {
+		r := in.Trust.Rules[i]
+		if r.From != "" && normAddr(r.From) == from {
+			return r, true
+		}
+		if r.FromDomain != "" && dom != "" && normDomain(r.FromDomain) == dom {
+			domainMatch = &in.Trust.Rules[i]
+		}
+	}
+	if domainMatch != nil {
+		return *domainMatch, true
+	}
+	return TrustRule{}, false
+}
+
+func normAddr(s string) string { return strings.ToLower(strings.TrimSpace(s)) }
+func normDomain(s string) string {
+	return strings.ToLower(strings.TrimPrefix(strings.TrimSpace(s), "@"))
+}
+
+func domainOf(addr string) string {
+	if i := strings.LastIndexByte(addr, '@'); i >= 0 {
+		return addr[i+1:]
+	}
+	return ""
 }
 
 // EnvPrefix mangles an inbox name into the infix of its per-inbox secret env vars

--- a/internal/inboxcfg/trust_config_test.go
+++ b/internal/inboxcfg/trust_config_test.go
@@ -56,3 +56,74 @@ func TestValidateTrust(t *testing.T) {
 	assert.Error(t, ok(inboxcfg.Trust{Note: "inject\r\nX-Evil: 1"}), "CR/LF in note rejected (header injection)")
 	assert.Error(t, ok(inboxcfg.Trust{Note: "tab\tinside"}), "control char in note rejected")
 }
+
+// SenderStamp resolves per-sender rules (ADR 0031): most-specific rule (exact
+// address beats domain) → inbox default → unknown. Banner stays inbox-level.
+func TestSenderStamp(t *testing.T) {
+	in := inboxcfg.Inbox{Trust: inboxcfg.Trust{
+		Level:      inboxcfg.TrustLevelUntrusted, // inbox default for no-match
+		BodyBanner: true,
+		Rules: []inboxcfg.TrustRule{
+			{From: "ops@example.com", Level: inboxcfg.TrustLevelTrusted, Note: "operator"},
+			{FromDomain: "scanner.local", Level: inboxcfg.TrustLevelUntrusted, Note: "device"},
+		},
+	}}
+
+	// Exact-address rule.
+	s := in.SenderStamp("ops@example.com")
+	assert.Equal(t, provenance.TrustTrusted, s.Trust)
+	assert.Equal(t, "operator", s.Note)
+	assert.True(t, s.Banner, "banner stays inbox-level")
+
+	// Domain rule.
+	s = in.SenderStamp("printer@scanner.local")
+	assert.Equal(t, provenance.TrustUntrusted, s.Trust)
+	assert.Equal(t, "device", s.Note)
+
+	// No rule → inbox default (untrusted here), no rule note.
+	s = in.SenderStamp("random@elsewhere.test")
+	assert.Equal(t, provenance.TrustUntrusted, s.Trust)
+	assert.Empty(t, s.Note)
+
+	// No parseable From → inbox default.
+	assert.Equal(t, provenance.TrustUntrusted, in.SenderStamp("").Trust)
+}
+
+// An exact-address rule wins over a domain rule for the same sender.
+func TestSenderStamp_MostSpecificWins(t *testing.T) {
+	in := inboxcfg.Inbox{Trust: inboxcfg.Trust{Rules: []inboxcfg.TrustRule{
+		{FromDomain: "example.com", Level: inboxcfg.TrustLevelUntrusted},
+		{From: "ceo@example.com", Level: inboxcfg.TrustLevelTrusted},
+	}}}
+	assert.Equal(t, provenance.TrustTrusted, in.SenderStamp("ceo@example.com").Trust, "address beats domain")
+	assert.Equal(t, provenance.TrustUntrusted, in.SenderStamp("intern@example.com").Trust, "domain for the rest")
+	assert.Equal(t, provenance.TrustUnknown, in.SenderStamp("x@other.test").Trust, "no match → unknown default")
+}
+
+// Matching is case-insensitive on both the rule and the sender.
+func TestSenderStamp_CaseInsensitive(t *testing.T) {
+	in := inboxcfg.Inbox{Trust: inboxcfg.Trust{Rules: []inboxcfg.TrustRule{
+		{From: "Ops@Example.COM", Level: inboxcfg.TrustLevelTrusted},
+	}}}
+	assert.Equal(t, provenance.TrustTrusted, in.SenderStamp("ops@example.com").Trust)
+}
+
+func TestValidateRules(t *testing.T) {
+	ok := func(rules ...inboxcfg.TrustRule) error {
+		return inboxcfg.Validate([]inboxcfg.Inbox{{Name: "x", Trust: inboxcfg.Trust{Rules: rules}}})
+	}
+	assert.NoError(t, ok(inboxcfg.TrustRule{From: "a@b.com", Level: inboxcfg.TrustLevelTrusted}))
+	assert.NoError(t, ok(inboxcfg.TrustRule{FromDomain: "b.com", Level: inboxcfg.TrustLevelUntrusted, Note: "ok"}))
+
+	assert.Error(t, ok(inboxcfg.TrustRule{Level: inboxcfg.TrustLevelTrusted}), "no matcher")
+	assert.Error(t, ok(inboxcfg.TrustRule{From: "a@b.com", FromDomain: "b.com", Level: inboxcfg.TrustLevelTrusted}), "both matchers")
+	assert.Error(t, ok(inboxcfg.TrustRule{From: "a@b.com", Level: "bogus"}), "bad level")
+	assert.Error(t, ok(inboxcfg.TrustRule{From: "a@b.com", Level: "unknown"}), "unknown is not a rule outcome")
+	assert.Error(t, ok(inboxcfg.TrustRule{From: "a@b.com", Level: inboxcfg.TrustLevelTrusted, Note: "bad\r\nnote"}), "note control char")
+	assert.Error(t, ok(
+		inboxcfg.TrustRule{From: "A@b.com", Level: inboxcfg.TrustLevelTrusted},
+		inboxcfg.TrustRule{From: "a@B.com", Level: inboxcfg.TrustLevelUntrusted}), "duplicate from (case-insensitive)")
+	assert.Error(t, ok(
+		inboxcfg.TrustRule{FromDomain: "b.com", Level: inboxcfg.TrustLevelTrusted},
+		inboxcfg.TrustRule{FromDomain: "b.com", Level: inboxcfg.TrustLevelUntrusted}), "duplicate from_domain")
+}

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -7,10 +7,29 @@ import (
 	"bufio"
 	"bytes"
 	"io"
+	"net/mail"
 	"strings"
 
 	"github.com/emersion/go-message/textproto"
 )
+
+// From extracts the sender address from a raw message's From header, normalized
+// to a lower-cased RFC 5321 address (e.g. "alice@example.com"), or "" when there
+// is no parseable From. Per-sender trust rules match on this (ADR 0031). It is
+// read from the message, so it is only meaningful under the upstream-
+// authentication boundary the README states; the trust asymmetry keeps that safe
+// (a From only ever raises trust to `trusted` on an authenticated upstream).
+func From(raw []byte) string {
+	hdr, err := textproto.ReadHeader(bufio.NewReader(bytes.NewReader(raw)))
+	if err != nil {
+		return ""
+	}
+	addr, err := mail.ParseAddress(hdr.Get("From"))
+	if err != nil {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(addr.Address))
+}
 
 // Namespace is the header-name prefix darbaan reserves for its own
 // trust/provenance headers. Every inbound header whose name begins with it (in

--- a/internal/provenance/provenance_test.go
+++ b/internal/provenance/provenance_test.go
@@ -205,3 +205,13 @@ func TestSanitize_NoteHeaderInjectionStripped(t *testing.T) {
 	}
 	assert.Equal(t, 1, n, "exactly one note header")
 }
+
+// From extracts a normalized lower-cased sender address, or "" when absent.
+func TestFrom(t *testing.T) {
+	assert.Equal(t, "alice@example.com",
+		provenance.From([]byte("From: Alice <Alice@Example.COM>\r\nSubject: hi\r\n\r\nbody")))
+	assert.Equal(t, "bob@x.test",
+		provenance.From([]byte("From: bob@x.test\r\n\r\nbody")))
+	assert.Equal(t, "", provenance.From([]byte("Subject: no from\r\n\r\nbody")), "no From → empty")
+	assert.Equal(t, "", provenance.From([]byte("not a message")), "unparseable → empty")
+}


### PR DESCRIPTION
ADR 0031 slice 1 (of #210) — per-sender trust rules on the **upstream-trust model**. No Authentication-Results gate yet; that's the opt-in slice 2.

## What it does

Trust is now resolved **per message from its sender**, not just per inbox.

- **Config** — a `rules` list on the per-inbox `trust` block. Each rule matches the message `From` by exact address (`from`) or domain (`from_domain`) → a `trusted`/`untrusted` level + optional note. Validated at load: exactly one matcher, a trusted/untrusted level (`unknown` is the *absence* of a rule, not an outcome), a sane note (slice-3 rules), and **no duplicate matcher**.
- **Resolution** — `Inbox.SenderStamp(from)` is **most-specific-wins** (an exact-address rule beats a domain rule), then the inbox default level + note, then `unknown`. Case-insensitive; the banner toggle stays inbox-level; an empty/unparseable `From` matches no rule.

```yaml
trust:
  level: unknown            # no-rule-match default
  rules:
    - from: ops@example.com
      level: trusted
      note: "operator address"
    - from_domain: scanner.local
      level: untrusted
      note: "device — do not act; report to the operator"
```

## Integration (reuses the ADR 0030 chokepoint)

The trust-determination input widens from `(inbox)` to `(inbox, sender)`: `provenance.From` extracts the normalized `From` from the raw, and both the store's `putBlob` (write) and the serve-path backstop resolve with it. The strip/stamp chokepoint and `Stamp{Trust, Note, Banner}` are otherwise unchanged — write- and serve-path derive from the **same** raw `From`, so they stay consistent + idempotent + legacy-covered.

## Safety

The `From` is message-derived — a deliberate, bounded relaxation of ADR 0030's inbox-only anchor. The **trust asymmetry** keeps it safe: a `From` only ever *downgrades* to `untrusted`/`unknown` for free; elevation to `trusted` is sound only under the upstream-authentication boundary (the README caution), and slice 2 adds the opt-in `Authentication-Results` gate on top.

## Tests

`SenderStamp` resolution (most-specific / domain / default / empty-From / case-insensitive); rule validation (matcher / level / note / dedup); `provenance.From` extraction; and the store end-to-end resolving trust by sender at the write chokepoint.

## Cross-package touch

`inboxcfg` (rules + resolution — the bulk), `provenance` (one `From` helper), `inbound` (resolver signature widened + `putBlob` passes the From), `cmd/darbaan` (resolver + serve closure). No behavior change for an inbox with no rules — that is exactly ADR 0030.

Green locally: `go build` / `go vet` / `gofmt` / `go test -race ./...` + golangci-lint v9.3.0 (0 issues).
