### PR TITLE
docs(adr): ADR 0032 — incoming-message injection assessment

### DIFF
--- a/adr/0032-incoming-message-injection-assessment.md
+++ b/adr/0032-incoming-message-injection-assessment.md
@@ -56,6 +56,17 @@ secrets, or smuggle directives through quoted text or attachments raises the sco
 Coarse buckets are deliberate — they avoid false precision and can be refined as
 real traffic is seen (the ADR 0005 rationale).
 
+**Content in scope.** Because attachments are a named injection vector, the assessor
+is fed the message's **decoded text content — the body's text parts and text
+extracted from attachments** (e.g. the text of a PDF or an HTML part), not just the
+top-level `text/plain`; assessing only the outer body would blind it to a vector the
+threat model calls out. Extraction is **bounded** (per-part size and type limits, and
+no execution of active content — the assessor renders attachments to inert text, it
+never opens them as programs), so a hostile attachment cannot turn extraction itself
+into code execution. The exact decoders, media types, and limits are an
+implementation detail (follow-up); this ADR fixes only that decoded attachment
+content is *in* the assessment's scope and that extraction stays inert and bounded.
+
 ### 2. Isolation: the assessor is a zero-access component
 
 The assessment runs in a component with **no tools and no privileges** — no mail
@@ -95,10 +106,19 @@ rules, not re-derived from a spoofable `From` alone. ADR 0031's trust asymmetry
 carries over: only an authenticated or explicitly-vouched source earns the fast
 path, and an unknown/unauthenticated sender always gets full scrutiny — fail-safe.
 
-### 4. Disposition: low passes, high is held for the human
+### 4. Disposition: low passes, medium and high are held for the human
+
+All three score buckets map to a disposition; the fail-safe default groups the
+uncertain middle with the high end:
 
 - **Low risk → pass:** the summary + score travel with the message into the
   agent's view; normal flow.
+- **Medium risk → held / flagged for the human (v1 default):** medium is genuine
+  uncertainty, so it resolves toward *more* scrutiny, not less — it is held for a
+  person exactly like high. Splitting medium off to a lighter disposition (e.g.
+  pass-with-prominent-flag) is a policy call the operator can make later via the
+  tunable config (§5); v1 holds it. This keeps the coarse three-bucket score from
+  leaving any value undispositioned.
 - **High risk → held / flagged for the human:** the message is surfaced to the
   operator rather than flowing straight to the agent, so a person decides before
   the agent can act on it.

--- a/adr/0032-incoming-message-injection-assessment.md
+++ b/adr/0032-incoming-message-injection-assessment.md
@@ -1,6 +1,6 @@
 # ADR 0032: Incoming-message injection assessment
 
-**Status:** Proposed (2026-08-07)
+**Status:** Proposed (2026-08-08)
 
 Repoints the pre-screener concept from outbound to inbound.
 [ADR 0005](0005-agent-prescreener-plugin-risk-routing.md) introduced an automated
@@ -45,16 +45,26 @@ worth hijacking.
 ### 1. An incoming-assessment layer whose only job is injection defense
 
 Add an assessment layer that, for untrusted incoming mail, produces a **sanitized
-summary + a coarse risk score** (`low` | `medium` | `high`) describing how likely
-the content is an injection/hijack attempt. It **flags and scores; it never
-acts** — it cannot approve, send, mark-as-trusted, delete, label, or take any
-agent action. Its output is advisory signal, not a decision.
+summary + a numeric risk score in the range 0–100** describing how likely the
+content is an injection/hijack attempt, together with the **list of factors** that
+produced that score. It **flags and scores; it never acts** — it cannot approve,
+send, mark-as-trusted, delete, label, or take any agent action. Its output is
+advisory signal, not a decision.
 
-The score reflects *injection risk*, not importance or spam: content that tries to
-issue instructions to the reader, impersonate the operator, request credentials or
-secrets, or smuggle directives through quoted text or attachments raises the score.
-Coarse buckets are deliberate — they avoid false precision and can be refined as
-real traffic is seen (the ADR 0005 rationale).
+The score is a *risk score*, not an importance or spam score. It is presented
+against **labeled bands** so humans and routing rules can speak in words while the
+underlying number stays precise:
+
+- **0–33 → low**
+- **33–66 → medium**
+- **66–100 → high**
+
+The band cutoffs are **configuration**, tunable without re-plumbing anything: an
+operator can move the low/medium or medium/high boundary, and every downstream rule
+that keys on a band follows, because a band is only a labeled interval over the same
+0–100 number. This is the deliberate improvement over fixed coarse buckets — the
+score carries real resolution, and the labels are a presentation layer on top of it,
+not the primitive.
 
 **Content in scope.** Because attachments are a named injection vector, the assessor
 is fed the message's **decoded text content — the body's text parts and text
@@ -72,84 +82,145 @@ content is *in* the assessment's scope and that extraction stays inert and bound
 The assessment runs in a component with **no tools and no privileges** — no mail
 credentials, no send path, no store writes, no admin authority. It is a runtime
 client (ADR 0017) that sits behind the credential-isolation boundary (ADR 0002)
-and holds no scoped power beyond returning a verdict. It is the deliberate inverse
+and holds no scoped power beyond returning its findings. It is the deliberate inverse
 of the privileged agent: the agent has access but should not read raw attacker
 bytes as trusted; the assessor reads the raw bytes but has nothing to hijack.
 
-Only the assessor's **sanitized summary + score** cross the boundary to the
-privileged agent — **never the raw payload as an instruction stream**. Even if the
-assessor is itself successfully injected, the blast radius is bounded to a wrong
-summary/score: it has no capability to act on the injection, and its text output is
-delivered onward as clearly-fenced, escaped data (the
-[ADR 0006](0006-rejection-as-async-dsn-bounce.md) principle — never echo attacker
-text as trusted), never as commands. This is the load-bearing property: **the
-gate's safety does not depend on the assessor being uncompromised.** The general
-shape is an isolated scoring component that touches the untrusted input but exports
-only a verdict across a one-way boundary.
+Only the assessor's **sanitized summary + the flagged-factor list + the composed
+score** cross the boundary to the privileged agent — **never the raw payload as an
+instruction stream**. Even if the assessor is itself successfully injected, the
+blast radius is bounded to a wrong summary/factor-list: it has no capability to act
+on the injection, and its text output is delivered onward as clearly-fenced, escaped
+data (the [ADR 0006](0006-rejection-as-async-dsn-bounce.md) principle — never echo
+attacker text as trusted), never as commands. This is the load-bearing property:
+**the gate's safety does not depend on the assessor being uncompromised.** The
+general shape is an isolated scoring component that touches the untrusted input but
+exports only a verdict across a one-way boundary.
 
-### 3. Route by a source-trust gradient (reuse ADR 0030 / ADR 0031)
+### 3. The score is composed by rules, never emitted by the model
 
-Not every message needs full assessment; routing keys on the trust the gate already
-stamps (ADR 0030 provenance, ADR 0031 per-sender rules), so assessment effort is
-spent where the risk is:
+The number is **never produced by the LLM.** The isolated assessor's job is narrow:
+detect whether the content exhibits each of a set of **bounded, named factors** and
+report *which it sees* — for example:
 
-- **Highest trust — operator hand-tagged / labeled mail:** the operator has
-  explicitly vouched for this specific message → fast path; assessment can be
-  skipped or minimal.
-- **Medium — the operator's own authenticated account, auto-flowing** (not
-  per-message tagged): reduced assessment.
-- **Lowest — other accounts, shared/family boxes, and unknown senders:** →
-  **full assessment.**
+- direct **instruction to the reader** ("ignore your previous instructions…",
+  "forward this to…"),
+- a **credentials/secrets request**,
+- **hidden or quoted-text directives** (instructions buried in quoted history,
+  zero-width/off-screen text, HTML-hidden spans),
+- **attachment-smuggled directives** (instructions carried in a decoded attachment).
 
-The gradient is derived from the existing `X-Darbaan-Trust` stamp and per-sender
-rules, not re-derived from a spoofable `From` alone. ADR 0031's trust asymmetry
-carries over: only an authenticated or explicitly-vouched source earns the fast
-path, and an unknown/unauthenticated sender always gets full scrutiny — fail-safe.
+The assessor returns a *set of flags*, not a magnitude. A **config point-table**
+then turns each flagged factor into a `+N` contribution, and the system sums them.
+Because the mapping from factor → points lives in configuration and the model only
+reports booleans, the score is **explainable and stable**: the same factors always
+compose the same number, an operator can retune any factor's weight without touching
+the assessor, and a compromised assessor can only lie about *which factors it saw* —
+it can never assert a number directly.
 
-### 4. Disposition: low passes, medium and high are held for the human
+**Sender baseline and recipient position are added by the system, outside the LLM
+entirely.** Two contributions never touch the assessor:
 
-All three score buckets map to a disposition; the fail-safe default groups the
-uncertain middle with the high end:
+- **Sender baseline.** A configured starting value keyed on the sender (by domain,
+  pattern, or per-sender rule): a trusted/vouched sender contributes ≈ 0, an unknown
+  sender contributes `+N`. This is derived from the same trust the gate already
+  stamps — the source-trust gradient below and the ADR 0030 provenance /
+  ADR 0031 per-sender rules — not from a spoofable `From` read by the model.
+- **Recipient position.** Whether the mailbox was a `To`, `CC`, or `BCC` recipient
+  is a separate system adjustment (bulk/BCC-shaped delivery is a mild risk signal).
+  It is fed into **both** the assessor's prompt (as context) *and* the routing
+  arithmetic (as a score term), so the same fact informs the read and the gate.
 
-- **Low risk → pass:** the summary + score travel with the message into the
-  agent's view; normal flow.
-- **Medium risk → held / flagged for the human (v1 default):** medium is genuine
-  uncertainty, so it resolves toward *more* scrutiny, not less — it is held for a
-  person exactly like high. Splitting medium off to a lighter disposition (e.g.
-  pass-with-prominent-flag) is a policy call the operator can make later via the
-  tunable config (§5); v1 holds it. This keeps the coarse three-bucket score from
-  leaving any value undispositioned.
-- **High risk → held / flagged for the human:** the message is surfaced to the
-  operator rather than flowing straight to the agent, so a person decides before
-  the agent can act on it.
+The final risk score is therefore `sender_baseline + recipient_adjustment +
+Σ(flagged content factors × point-table)`, with the content term contributed by the
+isolated assessor and the other two contributed by the trusted system.
 
-The human gate remains the backstop for any *consequential* action — defense in
-depth. Even a low-scored message that leads the agent toward a real-world action
-still meets the outbound sluice's human release (ADR 0003 / ADR 0004). The
-assessment lowers the odds an injection reaches the agent unflagged; it never
-replaces the human as the final authority.
+### 4. Short-circuit at the gate
 
-### 5. The assessment prompt / heuristics are tunable
+Scoring is **additive and short-circuiting**: contributions are applied in order and
+the running total is checked against the human-surface threshold (§6) as it grows.
+**Once the total crosses the threshold, tallying stops and the message is gated** —
+there is no need to enumerate every remaining factor to know it must be held. The
+result stays fully **explainable**: the disposition names *which factors carried the
+total across the line*, so a held message always comes with its reason.
 
-What counts as "injection-shaped" evolves with attacker technique, so the
-assessor's prompt (or heuristic ruleset) is **configuration, tunable over time**
-without a core change — the same posture as ADR 0030's config-driven trust and
-ADR 0031's rules. The fixed contract is the *shape* — isolation, verdict-only
-output, fail-safe routing; the detector inside it is not fixed.
+### 5. Cheap-to-expensive evaluation order
+
+Because the sender baseline and recipient position are **instant, no-LLM lookups**,
+they are applied **first**, before the content assessor is ever invoked. The
+isolated content assessor — the expensive step — is only run **if the cheap terms
+have not already crossed the gate.** A known-bad sender (baseline alone over the
+threshold) is held **without the assessor ever running**; the model is spent only on
+messages where the content read can still change the outcome. This is the
+source-trust gradient (§6) expressed as an ordering: cheap trust signals gate the
+obvious cases, and the costly read is reserved for the genuinely uncertain ones.
+
+### 6. Route by a source-trust gradient; human-surface threshold is operator config
+
+Routing keys on the composed score against a **human-surface threshold** that is
+**operator configuration**, with the **default set to HIGH (≈ 70)**:
+
+- **Below the threshold (low and medium bands, by default) → the agent handles it:**
+  the sanitized summary, the score, and the flagged-factor list travel with the
+  message into the agent's view; normal flow.
+- **At or above the threshold (high band, by default) → held / flagged for the
+  human:** the message is surfaced to the operator rather than flowing straight to
+  the agent, so a person decides before the agent can act on it.
+
+This **replaces the earlier v1 rule that held the medium band by default.** With a
+composed, explainable score and the human send gate still standing behind every
+consequential action, medium-band mail flows to the agent by default and only
+high-band mail is held — while an operator who wants a more conservative posture
+simply lowers the threshold in config (down to the medium boundary, or lower), with
+no code change. The threshold is one number over the same 0–100 scale the bands
+label.
+
+The gradient this threshold sits on is derived from the existing `X-Darbaan-Trust`
+stamp and per-sender rules (ADR 0030 / ADR 0031), not re-derived from a spoofable
+`From` alone. ADR 0031's trust asymmetry carries over: only an authenticated or
+explicitly-vouched source earns a low baseline and the fast path, and an
+unknown/unauthenticated sender always starts with a raised baseline and gets full
+scrutiny — fail-safe.
+
+Safety is preserved regardless of where the threshold sits: the agent only ever sees
+the **sanitized summary + composed score + factor list, never the raw payload**, and
+any *consequential* action the agent is steered toward still meets the outbound
+sluice's human release (ADR 0003 / ADR 0004) — defense in depth. The assessment
+lowers the odds an injection reaches the agent unflagged; it never replaces the human
+as the final authority.
+
+### 7. Point-table, thresholds, and prompt are all tunable
+
+What counts as "injection-shaped" evolves with attacker technique, so everything
+that shapes the number is **configuration, tunable over time** without a core
+change — the same posture as ADR 0030's config-driven trust and ADR 0031's rules:
+
+- the **factor point-table** (how many points each flagged factor adds),
+- the **sender baselines** and the **recipient-position adjustment**,
+- the **band cutoffs** (low/medium/high boundaries),
+- the **human-surface threshold**,
+- the assessor's **prompt / detector ruleset** (which factors it looks for).
+
+The fixed contract is the *shape* — isolation, model-flags-not-numbers,
+system-composed score, verdict-only output across the boundary, fail-safe routing;
+the weights and the detector inside it are not fixed.
 
 ## Fail-safe
 
 Consistent with the inbound trust floor and the outbound sluice, every ambiguity
 resolves toward *more* human scrutiny, never less:
 
-- Assessor absent, unreachable, erroring, or timing out → the message is treated as
-  **not cleared** (routed as if lowest-trust / held for the human), never
-  auto-passed as `low`. A deployment that runs no assessor simply has every
-  untrusted message reach the human and agent under the existing trust stamp — the
-  assessor can only *add* a flag, never remove the human backstop.
-- The assessor can only **raise** scrutiny (flag / hold) or leave the existing
-  human gate in place; it has no path to *lower* the outbound human gate.
-- Its output is always rendered onward as fenced, escaped data, never executed.
+- Assessor absent, unreachable, erroring, or timing out → its content contribution
+  is treated as **not cleared**: the message is routed as if held (surfaced to the
+  human), never auto-passed as low. A deployment that runs no assessor simply falls
+  back to the system-composed terms (sender baseline + recipient position) under the
+  existing trust stamp — the assessor can only *add* risk points, never remove the
+  human backstop.
+- The composed score can only ever **raise** scrutiny (add points, hold) or leave
+  the existing human gate in place; nothing in the pipeline can *lower* the outbound
+  human gate.
+- The assessor's output is always rendered onward as fenced, escaped data, never
+  executed.
 
 ## Consequences
 
@@ -159,28 +230,35 @@ resolves toward *more* human scrutiny, never less:
 - This supersedes the prior send-side 0032 framing (the outbound risk-verdict
   contract), which never landed. ADR 0005's light/strict outbound *routing* is
   untouched but is no longer the target of automated pre-screening.
-- The isolation requirement — a zero-access assessor whose only export is a
-  verdict — is the security core: the component that reads attacker bytes must have
-  nothing to hijack, so a compromised assessor degrades to a wrong score, not an
-  action.
+- Splitting the number's *composition* (system, rule-driven, explainable) from the
+  content *read* (isolated model, flags only) is the security core alongside
+  isolation: the component that reads attacker bytes never gets to assert a
+  magnitude, so a compromised assessor degrades to a wrong flag-set fed through a
+  fixed table — still bounded, still explainable — not an arbitrary number and never
+  an action.
+- Cheap-first ordering keeps cost proportional to uncertainty: obvious cases (known
+  senders on either end of the trust gradient) gate on instant lookups, and the
+  model is spent only where the content read can still move the outcome.
 - Broader direction: this is one instance of a generic "assess untrusted input in
-  isolation, let a human gate any consequential action" pattern; the same shape
-  could later gate other agent-actionable inputs. v1 scopes it to inbound mail.
+  isolation, compose an explainable score by rule, let a human gate any consequential
+  action" pattern; the same shape could later gate other agent-actionable inputs.
+  v1 scopes it to inbound mail.
 - Scope here is the decision only (Proposed). Implementation — the assessor process
-  and its zero-access seam, the trust-gradient routing hook on the ingest/serve
-  path, the held/flagged disposition surface, and the tunable prompt config — is
-  deferred to follow-up PRs after sign-off.
+  and its zero-access seam, the factor detectors, the point-table / baseline / band /
+  threshold config, the trust-gradient routing hook on the ingest/serve path, and the
+  held/flagged disposition surface — is deferred to follow-up PRs after sign-off.
 
 ## Boundaries
 
 - **v1 is read/flag only.** The assessor never mutates the message beyond attaching
-  its sanitized summary/score, and never acts. Auto-quarantine or auto-delete of
-  high-risk mail is deliberately out of scope — a human decides on a hold.
-- **Not an authentication source.** The trust gradient inherits ADR 0031's
-  boundary: keying the fast path on sender identity is only as strong as the
-  upstream's sender authentication; unknown/unauthenticated senders always get full
-  assessment, so a spoofed `From` reaches the fast path only under the same
-  conditions ADR 0031 already bounds.
+  its sanitized summary, factor list, and composed score, and never acts.
+  Auto-quarantine or auto-delete of high-scoring mail is deliberately out of scope —
+  a human decides on a hold.
+- **Not an authentication source.** The sender baseline inherits ADR 0031's
+  boundary: keying a low baseline on sender identity is only as strong as the
+  upstream's sender authentication; unknown/unauthenticated senders always start with
+  a raised baseline and get full assessment, so a spoofed `From` earns the low
+  baseline only under the same conditions ADR 0031 already bounds.
 - **The assessor is not the gate.** It reduces how much untrusted content reaches
   the agent unflagged; the human release on the outbound sluice remains the
   authority for any consequential action.

--- a/adr/0032-incoming-message-injection-assessment.md
+++ b/adr/0032-incoming-message-injection-assessment.md
@@ -1,0 +1,166 @@
+# ADR 0032: Incoming-message injection assessment
+
+**Status:** Proposed (2026-08-07)
+
+Repoints the pre-screener concept from outbound to inbound.
+[ADR 0005](0005-agent-prescreener-plugin-risk-routing.md) introduced an automated
+risk verdict for *queued outbound* mail; that framing is set aside here (see
+Context). Outbound stays the simple default-block-to-human sluice
+([ADR 0003](0003-outbound-sluice-trap-default-deny.md)) with no automated verdict.
+This ADR builds directly on the inbound trust work — the provenance stamp
+([ADR 0030](0030-gate-stamp-trust-provenance-headers-on-inbound-mail.md)) and
+per-sender trust rules ([ADR 0031](0031-per-sender-trust-rules.md)) — and on the
+credential-isolation ([ADR 0002](0002-policy-in-a-separate-box-credential-isolation.md))
+and runtime-client ([ADR 0017](0017-interfaces-as-clients-over-local-api.md))
+boundaries.
+
+## Context
+
+The real risk an autonomous mail agent carries is not spam or misjudged
+importance — it is **prompt injection**. Untrusted incoming content is
+attacker-controlled, and anything the model treats as instruction inside it can
+hijack the agent (a confused-deputy attack): steer it, with its own access, into a
+rash or exfiltrating action. This is the standing surface ADR 0030 already named
+when it stamped inbound trust — but a trust stamp only *labels* the risk; it does
+not read the content and assess whether this particular message is trying to hijack
+the reader.
+
+The *outbound* side is already handled. The sluice is default-deny and every send
+is gated by a human (ADR 0003 / [ADR 0004](0004-pluggable-approval-pipeline.md)):
+a message never leaves without a person releasing it, so no automated "is this send
+risky" verdict is load-bearing there — the human is the gate. The prior (unmerged)
+elaboration of ADR 0005 built a risk-verdict contract for that outbound path; with
+the human send gate as the backstop, it was adding an automated risk signal to a
+step the sluice already fully guards. That effort is better spent where the
+untrusted content actually *enters*: the inbound path.
+
+What is missing is a defense that reads incoming content *before* the privileged
+agent treats it as instruction, and tells the human (and the agent) how risky it
+looks — **without itself becoming a new injection foothold**. That is the hard
+constraint: the component that reads attacker-controlled bytes must have nothing
+worth hijacking.
+
+## Decision
+
+### 1. An incoming-assessment layer whose only job is injection defense
+
+Add an assessment layer that, for untrusted incoming mail, produces a **sanitized
+summary + a coarse risk score** (`low` | `medium` | `high`) describing how likely
+the content is an injection/hijack attempt. It **flags and scores; it never
+acts** — it cannot approve, send, mark-as-trusted, delete, label, or take any
+agent action. Its output is advisory signal, not a decision.
+
+The score reflects *injection risk*, not importance or spam: content that tries to
+issue instructions to the reader, impersonate the operator, request credentials or
+secrets, or smuggle directives through quoted text or attachments raises the score.
+Coarse buckets are deliberate — they avoid false precision and can be refined as
+real traffic is seen (the ADR 0005 rationale).
+
+### 2. Isolation: the assessor is a zero-access component
+
+The assessment runs in a component with **no tools and no privileges** — no mail
+credentials, no send path, no store writes, no admin authority. It is a runtime
+client (ADR 0017) that sits behind the credential-isolation boundary (ADR 0002)
+and holds no scoped power beyond returning a verdict. It is the deliberate inverse
+of the privileged agent: the agent has access but should not read raw attacker
+bytes as trusted; the assessor reads the raw bytes but has nothing to hijack.
+
+Only the assessor's **sanitized summary + score** cross the boundary to the
+privileged agent — **never the raw payload as an instruction stream**. Even if the
+assessor is itself successfully injected, the blast radius is bounded to a wrong
+summary/score: it has no capability to act on the injection, and its text output is
+delivered onward as clearly-fenced, escaped data (the
+[ADR 0006](0006-rejection-as-async-dsn-bounce.md) principle — never echo attacker
+text as trusted), never as commands. This is the load-bearing property: **the
+gate's safety does not depend on the assessor being uncompromised.** The general
+shape is an isolated scoring component that touches the untrusted input but exports
+only a verdict across a one-way boundary.
+
+### 3. Route by a source-trust gradient (reuse ADR 0030 / ADR 0031)
+
+Not every message needs full assessment; routing keys on the trust the gate already
+stamps (ADR 0030 provenance, ADR 0031 per-sender rules), so assessment effort is
+spent where the risk is:
+
+- **Highest trust — operator hand-tagged / labeled mail:** the operator has
+  explicitly vouched for this specific message → fast path; assessment can be
+  skipped or minimal.
+- **Medium — the operator's own authenticated account, auto-flowing** (not
+  per-message tagged): reduced assessment.
+- **Lowest — other accounts, shared/family boxes, and unknown senders:** →
+  **full assessment.**
+
+The gradient is derived from the existing `X-Darbaan-Trust` stamp and per-sender
+rules, not re-derived from a spoofable `From` alone. ADR 0031's trust asymmetry
+carries over: only an authenticated or explicitly-vouched source earns the fast
+path, and an unknown/unauthenticated sender always gets full scrutiny — fail-safe.
+
+### 4. Disposition: low passes, high is held for the human
+
+- **Low risk → pass:** the summary + score travel with the message into the
+  agent's view; normal flow.
+- **High risk → held / flagged for the human:** the message is surfaced to the
+  operator rather than flowing straight to the agent, so a person decides before
+  the agent can act on it.
+
+The human gate remains the backstop for any *consequential* action — defense in
+depth. Even a low-scored message that leads the agent toward a real-world action
+still meets the outbound sluice's human release (ADR 0003 / ADR 0004). The
+assessment lowers the odds an injection reaches the agent unflagged; it never
+replaces the human as the final authority.
+
+### 5. The assessment prompt / heuristics are tunable
+
+What counts as "injection-shaped" evolves with attacker technique, so the
+assessor's prompt (or heuristic ruleset) is **configuration, tunable over time**
+without a core change — the same posture as ADR 0030's config-driven trust and
+ADR 0031's rules. The fixed contract is the *shape* — isolation, verdict-only
+output, fail-safe routing; the detector inside it is not fixed.
+
+## Fail-safe
+
+Consistent with the inbound trust floor and the outbound sluice, every ambiguity
+resolves toward *more* human scrutiny, never less:
+
+- Assessor absent, unreachable, erroring, or timing out → the message is treated as
+  **not cleared** (routed as if lowest-trust / held for the human), never
+  auto-passed as `low`. A deployment that runs no assessor simply has every
+  untrusted message reach the human and agent under the existing trust stamp — the
+  assessor can only *add* a flag, never remove the human backstop.
+- The assessor can only **raise** scrutiny (flag / hold) or leave the existing
+  human gate in place; it has no path to *lower* the outbound human gate.
+- Its output is always rendered onward as fenced, escaped data, never executed.
+
+## Consequences
+
+- The automated-risk effort moves to where untrusted content enters (inbound
+  injection) and off the outbound path, which stays the simple
+  default-block-to-human sluice (ADR 0003) — no outbound risk verdict is built.
+- This supersedes the prior send-side 0032 framing (the outbound risk-verdict
+  contract), which never landed. ADR 0005's light/strict outbound *routing* is
+  untouched but is no longer the target of automated pre-screening.
+- The isolation requirement — a zero-access assessor whose only export is a
+  verdict — is the security core: the component that reads attacker bytes must have
+  nothing to hijack, so a compromised assessor degrades to a wrong score, not an
+  action.
+- Broader direction: this is one instance of a generic "assess untrusted input in
+  isolation, let a human gate any consequential action" pattern; the same shape
+  could later gate other agent-actionable inputs. v1 scopes it to inbound mail.
+- Scope here is the decision only (Proposed). Implementation — the assessor process
+  and its zero-access seam, the trust-gradient routing hook on the ingest/serve
+  path, the held/flagged disposition surface, and the tunable prompt config — is
+  deferred to follow-up PRs after sign-off.
+
+## Boundaries
+
+- **v1 is read/flag only.** The assessor never mutates the message beyond attaching
+  its sanitized summary/score, and never acts. Auto-quarantine or auto-delete of
+  high-risk mail is deliberately out of scope — a human decides on a hold.
+- **Not an authentication source.** The trust gradient inherits ADR 0031's
+  boundary: keying the fast path on sender identity is only as strong as the
+  upstream's sender authentication; unknown/unauthenticated senders always get full
+  assessment, so a spoofed `From` reaches the fast path only under the same
+  conditions ADR 0031 already bounds.
+- **The assessor is not the gate.** It reduces how much untrusted content reaches
+  the agent unflagged; the human release on the outbound sluice remains the
+  authority for any consequential action.

--- a/adr/README.md
+++ b/adr/README.md
@@ -5,9 +5,10 @@ its context, the decision, and the consequences. ADRs are immutable once
 Accepted — to change one, add a new ADR that supersedes it.
 
 These records (0001–0016) capture the v1 design, locked 2026-06-25 and amended
-through 2026-06-26 (maintainer review). Later records (0017–0029) extend it —
+through 2026-06-26 (maintainer review). Later records (0017–0032) extend it —
 labeling, the inbound filter, multi-inbox, reconciliation, multi-agent tenancy,
-on-demand sync, and per-client admin scopes.
+on-demand sync, per-client admin scopes, inbound trust stamping, and
+incoming-message injection assessment.
 
 | ADR | Title |
 |---|---|
@@ -41,3 +42,6 @@ on-demand sync, and per-client admin scopes.
 | [0027](0027-multi-agent-tenancy.md) | Multi-agent tenancy: per-agent logins, grants, and per-principal mailbox naming |
 | [0028](0028-on-demand-inbound-sync-on-status.md) | On-demand inbound sync: STATUS triggers a debounced upstream pull of the queried inbox |
 | [0029](0029-admin-per-client-scoped-tokens.md) | Admin API: per-client scoped, independently-revocable tokens |
+| [0030](0030-gate-stamp-trust-provenance-headers-on-inbound-mail.md) | Gate-stamp trust/provenance headers on inbound mail |
+| [0031](0031-per-sender-trust-rules.md) | Per-sender trust rules |
+| [0032](0032-incoming-message-injection-assessment.md) | Incoming-message injection assessment |


### PR DESCRIPTION
## ADR 0032 — Incoming-message injection assessment

**Proposed. ADR only, no implementation. Hard sign-off gate — no code lands until this is approved.**

This replaces the earlier (never-merged) send-side pre-screener framing on this branch. The automated risk effort is **repointed from outbound to inbound**, where untrusted content actually enters — outbound stays the default-deny human sluice (ADR 0003 / 0004), so no automated send-verdict is load-bearing there. The real risk an autonomous mail agent carries is **prompt injection** on the incoming path: attacker-controlled content that hijacks the agent (confused-deputy) into a rash action with its own access.

### What it decides

1. **An incoming-assessment layer** that produces, for untrusted incoming mail, a **sanitized summary + a 0–100 numeric risk score + the list of factors** behind that score. It flags and scores; it never acts. The score is shown against **labeled bands** (0–33 low, 33–66 medium, 66–100 high) whose cutoffs are config — the number carries the resolution, the labels are a presentation layer.
2. **The score is composed by rules, never emitted by the model.** The isolated assessor detects **bounded content factors** (instruction-to-the-reader, secrets request, hidden/quoted-text directives, attachment-smuggled directives) and reports *which* it sees; a config **point-table** turns each flag into `+N`. A compromised assessor can lie about which factors it saw, but can never assert a number or take an action.
3. **Sender baseline + recipient position are added by the system, outside the model.** A configured sender baseline (trusted ≈ 0, unknown = `+N`, keyed on the ADR 0030/0031 trust the gate already stamps) and a recipient-position adjustment (To/CC/BCC) fold into the same total — fed into both the assessor prompt and the routing arithmetic.
4. **Short-circuit at the gate.** Contributions are additive; once the running total crosses the human-surface threshold, tallying stops and the message is held — still explainable by which factors carried it across.
5. **Cheap-to-expensive order.** The no-LLM sender + recipient terms are applied first; the expensive content assessor runs only if those have not already crossed the gate. A known-bad sender is held **without the assessor ever running**.
6. **Isolation** — the assessor is a zero-access component (no tools, no credentials, no send/store/admin power; a runtime client per ADR 0017 behind the ADR 0002 boundary). Only the sanitized summary + factor list + composed score cross to the privileged agent — never the raw payload as an instruction stream. The gate's safety does not depend on the assessor being uncompromised.
7. **Disposition — human-surface threshold is operator config, default HIGH (≈70).** Low + medium bands flow to the agent (with summary + score + factors); high is held for the human. This **replaces the earlier medium-held-by-default**; an operator wanting a stricter posture just lowers the threshold. The agent only ever sees the sanitized verdict, and any consequential action still meets the outbound human send gate — defense in depth.

**Source-trust gradient + tunability:** routing keys on the existing `X-Darbaan-Trust` stamp and per-sender rules (ADR 0030 / 0031), not a spoofable `From`; the point-table, sender baselines, recipient adjustment, band cutoffs, human-surface threshold, and assessor prompt are all config. The fixed contract is the *shape* — isolation, model-flags-not-numbers, system-composed score, verdict-only output, fail-safe routing.

**Fail-safe throughout:** assessor absent/unreachable/errored/timed-out → its content contribution is treated as not-cleared and the message is held, never auto-passed as low; the assessor can only *raise* scrutiny, never lower the human gate. Attachment text is in scope (a named injection vector) via inert, bounded extraction (size/type limits, no active-content execution).

### Content scope

Decoded text from body parts **and** attachments (e.g. PDF/HTML text), not just top-level `text/plain`. Extraction is inert and bounded; exact decoders/limits are an implementation detail.

### Files

- `adr/0032-incoming-message-injection-assessment.md`
- `adr/README.md` — index row for 0032 (also backfills the 0030/0031 rows)

### Gate

Architecture-decision PR — hard sign-off gate. Status stays **Proposed**; implementation (the assessor process + its zero-access seam, the factor detectors, the point-table / baseline / band / threshold config, the trust-gradient routing hook, the held/flagged disposition surface) is deferred to follow-up PRs after approval.
