### PR TITLE
feat(riskscore): ADR 0032 slice 1 — deterministic scoring + config core

### DIFF
--- a/internal/riskscore/config.go
+++ b/internal/riskscore/config.go
@@ -1,0 +1,158 @@
+package riskscore
+
+import (
+	"fmt"
+
+	"github.com/yaad-index/darbaan/internal/provenance"
+
+	"gopkg.in/yaml.v3"
+)
+
+// unknownTrust is the trust level used as the sender-baseline fail-safe floor:
+// an unrecognized or empty trust maps here (ADR 0030's fail-safe default).
+const unknownTrust = provenance.TrustUnknown
+
+// Config is the tunable schema for the deterministic scorer (ADR 0032 §7). Every
+// weight is operator configuration; only the composition shape is fixed.
+type Config struct {
+	// SenderBaselines maps a stamped trust level (provenance.Trust*: "trusted",
+	// "untrusted", "unknown") to the baseline points a message from such a source
+	// starts with. Keyed on the trust the gate already stamped (ADR 0030/0031),
+	// never on a re-read of From. Must define the "unknown" floor.
+	SenderBaselines map[string]int `yaml:"sender_baselines"`
+	// RecipientAdjust maps a recipient position (to/cc/bcc) to its point
+	// adjustment; an unlisted position adds nothing.
+	RecipientAdjust map[Recipient]int `yaml:"recipient_adjust"`
+	// FactorPoints is the point-table: each flagged content factor's contribution.
+	// The table is authoritative — a flagged factor with no entry adds nothing.
+	FactorPoints map[Factor]int `yaml:"factor_points"`
+	// Bands are the labeled-interval cutoffs over the 0-100 score.
+	Bands Bands `yaml:"bands"`
+	// Threshold is the human-surface cutoff: a composed score at or above it is
+	// held for a human. Default is HIGH (see DefaultConfig); lower it for a more
+	// conservative posture.
+	Threshold int `yaml:"threshold"`
+}
+
+// Bands holds the band cutoffs. A score below LowMax is low; below MediumMax is
+// medium; at or above MediumMax is high.
+type Bands struct {
+	LowMax    int `yaml:"low_max"`
+	MediumMax int `yaml:"medium_max"`
+}
+
+// DefaultConfig returns the v1 default weights: a source-trust gradient on the
+// sender baseline, a mild bulk/BCC-shaped adjustment, the four v1 factors, bands
+// at 33/66, and a HIGH human-surface threshold (70) — low and medium bands flow
+// to the agent, only high is held.
+func DefaultConfig() Config {
+	return Config{
+		SenderBaselines: map[string]int{
+			provenance.TrustTrusted:   0,
+			provenance.TrustUntrusted: 40,
+			provenance.TrustUnknown:   30,
+		},
+		RecipientAdjust: map[Recipient]int{
+			RecipientTo:  0,
+			RecipientCc:  5,
+			RecipientBcc: 10,
+		},
+		FactorPoints: map[Factor]int{
+			FactorInstruction:          40,
+			FactorSecretsRequest:       40,
+			FactorHiddenDirectives:     30,
+			FactorAttachmentDirectives: 30,
+		},
+		Bands:     Bands{LowMax: 33, MediumMax: 66},
+		Threshold: 70,
+	}
+}
+
+// yamlConfig is the on-disk shape. Scalars are pointers so an omitted key is
+// distinguishable from an explicit zero (a zero threshold is a valid, very
+// strict setting); maps are overlaid per key onto the defaults.
+type yamlConfig struct {
+	SenderBaselines map[string]int    `yaml:"sender_baselines"`
+	RecipientAdjust map[Recipient]int `yaml:"recipient_adjust"`
+	FactorPoints    map[Factor]int    `yaml:"factor_points"`
+	Bands           *struct {
+		LowMax    *int `yaml:"low_max"`
+		MediumMax *int `yaml:"medium_max"`
+	} `yaml:"bands"`
+	Threshold *int `yaml:"threshold"`
+}
+
+// Parse unmarshals the injection-assessment config from YAML, overlaying any
+// provided values onto DefaultConfig (maps merge per key, so a partial config is
+// valid), then validates. A nil/empty input yields the validated defaults.
+func Parse(data []byte) (Config, error) {
+	var yc yamlConfig
+	if err := yaml.Unmarshal(data, &yc); err != nil {
+		return Config{}, fmt.Errorf("riskscore: parse config: %w", err)
+	}
+	cfg := DefaultConfig()
+	for k, v := range yc.SenderBaselines {
+		cfg.SenderBaselines[k] = v
+	}
+	for k, v := range yc.RecipientAdjust {
+		cfg.RecipientAdjust[k] = v
+	}
+	for k, v := range yc.FactorPoints {
+		cfg.FactorPoints[k] = v
+	}
+	if yc.Bands != nil {
+		if yc.Bands.LowMax != nil {
+			cfg.Bands.LowMax = *yc.Bands.LowMax
+		}
+		if yc.Bands.MediumMax != nil {
+			cfg.Bands.MediumMax = *yc.Bands.MediumMax
+		}
+	}
+	if yc.Threshold != nil {
+		cfg.Threshold = *yc.Threshold
+	}
+	if err := cfg.validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+// validate enforces the invariants the scorer relies on.
+func (c Config) validate() error {
+	if c.Bands.LowMax < 0 || c.Bands.MediumMax < 0 {
+		return fmt.Errorf("riskscore: band cutoffs must be non-negative (low_max=%d medium_max=%d)", c.Bands.LowMax, c.Bands.MediumMax)
+	}
+	if c.Bands.LowMax >= c.Bands.MediumMax {
+		return fmt.Errorf("riskscore: low_max (%d) must be less than medium_max (%d)", c.Bands.LowMax, c.Bands.MediumMax)
+	}
+	if c.Bands.MediumMax > MaxScore {
+		return fmt.Errorf("riskscore: medium_max (%d) must not exceed %d", c.Bands.MediumMax, MaxScore)
+	}
+	if c.Threshold < 0 || c.Threshold > MaxScore {
+		return fmt.Errorf("riskscore: threshold (%d) must be within [0, %d]", c.Threshold, MaxScore)
+	}
+	if _, ok := c.SenderBaselines[unknownTrust]; !ok {
+		return fmt.Errorf("riskscore: sender_baselines must define %q (the fail-safe floor)", unknownTrust)
+	}
+	for k, v := range c.SenderBaselines {
+		if v < 0 {
+			return fmt.Errorf("riskscore: sender_baseline %q must be non-negative (got %d)", k, v)
+		}
+	}
+	for k, v := range c.RecipientAdjust {
+		switch k {
+		case RecipientTo, RecipientCc, RecipientBcc:
+		default:
+			return fmt.Errorf("riskscore: unknown recipient position %q (want to/cc/bcc)", k)
+		}
+		if v < 0 {
+			return fmt.Errorf("riskscore: recipient_adjust %q must be non-negative (got %d)", k, v)
+		}
+	}
+	for k, v := range c.FactorPoints {
+		if v < 0 {
+			return fmt.Errorf("riskscore: factor_points %q must be non-negative (got %d)", k, v)
+		}
+	}
+	return nil
+}

--- a/internal/riskscore/config_test.go
+++ b/internal/riskscore/config_test.go
@@ -1,0 +1,99 @@
+package riskscore
+
+import (
+	"testing"
+
+	"github.com/yaad-index/darbaan/internal/provenance"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultConfigValid(t *testing.T) {
+	_, err := New(DefaultConfig())
+	assert.NoError(t, err)
+}
+
+func TestParseEmptyYieldsDefaults(t *testing.T) {
+	cfg, err := Parse(nil)
+	require.NoError(t, err)
+	assert.Equal(t, DefaultConfig(), cfg)
+}
+
+func TestParsePartialMerge(t *testing.T) {
+	cfg, err := Parse([]byte("threshold: 50\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 50, cfg.Threshold)
+	// Untouched fields keep their defaults.
+	assert.Equal(t, 33, cfg.Bands.LowMax)
+	assert.Equal(t, 0, cfg.SenderBaselines[provenance.TrustTrusted])
+	assert.Equal(t, 30, cfg.SenderBaselines[provenance.TrustUnknown])
+}
+
+func TestParseMapsMergePerKey(t *testing.T) {
+	in := `
+sender_baselines:
+  untrusted: 80
+recipient_adjust:
+  cc: 12
+factor_points:
+  instruction_to_reader: 55
+  custom_factor: 15
+`
+	cfg, err := Parse([]byte(in))
+	require.NoError(t, err)
+
+	// Overridden keys take the new value...
+	assert.Equal(t, 80, cfg.SenderBaselines[provenance.TrustUntrusted])
+	assert.Equal(t, 12, cfg.RecipientAdjust[RecipientCc])
+	assert.Equal(t, 55, cfg.FactorPoints[FactorInstruction])
+	assert.Equal(t, 15, cfg.FactorPoints[Factor("custom_factor")])
+	// ...while sibling keys stay at their defaults (per-key merge, not replace).
+	assert.Equal(t, 0, cfg.SenderBaselines[provenance.TrustTrusted])
+	assert.Equal(t, 30, cfg.SenderBaselines[provenance.TrustUnknown])
+	assert.Equal(t, 0, cfg.RecipientAdjust[RecipientTo])
+	assert.Equal(t, 40, cfg.FactorPoints[FactorSecretsRequest])
+}
+
+func TestParseBandsMerge(t *testing.T) {
+	cfg, err := Parse([]byte("bands:\n  low_max: 20\n"))
+	require.NoError(t, err)
+	assert.Equal(t, 20, cfg.Bands.LowMax)
+	assert.Equal(t, 66, cfg.Bands.MediumMax, "unset medium_max keeps the default")
+}
+
+func TestParseInvalidYAML(t *testing.T) {
+	_, err := Parse([]byte("threshold: [not-an-int]\n"))
+	assert.Error(t, err)
+}
+
+func TestParseValidationErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{"low>=medium", "bands:\n  low_max: 66\n  medium_max: 66\n"},
+		{"medium>100", "bands:\n  medium_max: 120\n"},
+		{"threshold>100", "threshold: 101\n"},
+		{"threshold<0", "threshold: -1\n"},
+		{"negative factor", "factor_points:\n  instruction_to_reader: -5\n"},
+		{"negative baseline", "sender_baselines:\n  untrusted: -1\n"},
+		{"unknown recipient", "recipient_adjust:\n  everyone: 5\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := Parse([]byte(c.yaml))
+			assert.Error(t, err)
+		})
+	}
+}
+
+// TestMissingUnknownBaseline: the fail-safe floor is required. Parse always
+// merges onto defaults (which include it), so this is exercised via New directly.
+func TestMissingUnknownBaseline(t *testing.T) {
+	cfg := DefaultConfig()
+	delete(cfg.SenderBaselines, provenance.TrustUnknown)
+	_, err := New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown")
+}

--- a/internal/riskscore/score.go
+++ b/internal/riskscore/score.go
@@ -1,0 +1,238 @@
+// Package riskscore composes the deterministic injection-risk score for an
+// incoming message (ADR 0032). It is the no-model core of the assessment: given
+// the trust the gate already stamped (ADR 0030/0031), the recipient position,
+// and the set of content factors an isolated assessor flags, it composes a
+// 0-100 score by a fixed rule, assigns a labeled band, and decides the
+// disposition.
+//
+// The model never produces the number. An isolated assessor (a later slice)
+// only reports which bounded factors it sees; this package turns those flags
+// into points via a configured point-table and sums them with the two
+// system-supplied terms — the sender baseline and the recipient-position
+// adjustment — neither of which touches the model. A compromised assessor can
+// therefore lie about which factors it saw, but can never assert a magnitude.
+package riskscore
+
+import "fmt"
+
+// MaxScore is the top of the score range. Composed totals are additive and can
+// exceed it, so they are clamped into [0, MaxScore] before banding — the score
+// stays a real 0-100 number and the bands stay bounded intervals.
+const MaxScore = 100
+
+// Factor is a named, bounded content signal an isolated assessor may flag
+// (ADR 0032 §3). The assessor reports which factors it sees; the point-table
+// (config) turns each into points. Factors below are the v1 vocabulary; the
+// table is authoritative, so an operator may add or reweight factors in config.
+type Factor string
+
+const (
+	// FactorInstruction: the content issues instructions to the reader
+	// ("ignore your previous instructions…", "forward this to…").
+	FactorInstruction Factor = "instruction_to_reader"
+	// FactorSecretsRequest: the content asks for credentials or secrets.
+	FactorSecretsRequest Factor = "secrets_request"
+	// FactorHiddenDirectives: directives buried in quoted history, zero-width or
+	// off-screen text, or HTML-hidden spans.
+	FactorHiddenDirectives Factor = "hidden_directives"
+	// FactorAttachmentDirectives: directives carried in a decoded attachment.
+	FactorAttachmentDirectives Factor = "attachment_directives"
+)
+
+// Recipient is the position the assessed mailbox held on the message. Bulk /
+// BCC-shaped delivery is a mild risk signal (ADR 0032 §3).
+type Recipient string
+
+const (
+	RecipientTo  Recipient = "to"
+	RecipientCc  Recipient = "cc"
+	RecipientBcc Recipient = "bcc"
+)
+
+// Band is the labeled interval a score falls in (ADR 0032 §1). Bands are a
+// presentation layer over the number; their cutoffs are config.
+type Band string
+
+const (
+	BandLow    Band = "low"
+	BandMedium Band = "medium"
+	BandHigh   Band = "high"
+)
+
+// Disposition is what the gate does with the message given its score.
+type Disposition string
+
+const (
+	// DispositionAgentHandled: the sanitized summary + score + factor list travel
+	// with the message into the agent's view (below the human-surface threshold).
+	DispositionAgentHandled Disposition = "agent_handled"
+	// DispositionHeld: the message is surfaced to a human before the agent sees
+	// it (at or above the threshold, or fail-safe).
+	DispositionHeld Disposition = "held"
+)
+
+// CheapResult is the no-model prefix of the composition: the sender baseline
+// plus the recipient-position adjustment (ADR 0032 §5). Both are instant config
+// lookups, applied before the expensive content assessor runs.
+type CheapResult struct {
+	Baseline  int    // sender-baseline component (from the stamped trust level)
+	Recipient int    // recipient-position component
+	Score     int    // Baseline + Recipient, clamped into [0, MaxScore]
+	Trust     string // the trust level used for the baseline (for explainability)
+	// Gated is true when the cheap score alone already reaches the human-surface
+	// threshold: the caller may skip the content assessor entirely — a known-bad
+	// sender is held without the assessor ever running (ADR 0032 §5).
+	Gated bool
+}
+
+// Result is the composed outcome for one message.
+type Result struct {
+	Score       int
+	Band        Band
+	Disposition Disposition
+	Baseline    int      // sender-baseline component
+	Recipient   int      // recipient-position component
+	Factors     []Factor // flagged factors that contributed (nil if short-circuited or none)
+	// ShortCircuited is true when the cheap terms reached the threshold and factor
+	// tallying was stopped (ADR 0032 §4) — the content assessor was not consulted.
+	ShortCircuited bool
+	// NotCleared is true for the fail-safe hold: an absent or errored assessment
+	// is held regardless of score (ADR 0032 fail-safe).
+	NotCleared bool
+	Reason     string // human-readable explanation of the disposition
+}
+
+// Scorer composes scores against a validated configuration.
+type Scorer struct{ cfg Config }
+
+// New returns a Scorer for cfg, or an error if cfg is invalid.
+func New(cfg Config) (*Scorer, error) {
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+	return &Scorer{cfg: cfg}, nil
+}
+
+// Config returns the scorer's configuration.
+func (s *Scorer) Config() Config { return s.cfg }
+
+// baselineFor returns the configured sender baseline for a stamped trust level,
+// falling back to the unknown baseline for any unrecognized or empty level
+// (fail-safe: an unrecognized trust is treated as unknown, the higher baseline).
+func (s *Scorer) baselineFor(trust string) int {
+	if v, ok := s.cfg.SenderBaselines[trust]; ok {
+		return v
+	}
+	return s.cfg.SenderBaselines[unknownTrust]
+}
+
+// CheapScore returns the no-model prefix — the sender baseline (from the stamped
+// trust level) plus the recipient-position adjustment — and whether it already
+// reaches the human-surface threshold. It performs no content assessment, so the
+// caller can consult it first and skip the expensive assessor when Gated is true
+// (cheap-first ordering, ADR 0032 §5).
+func (s *Scorer) CheapScore(trust string, r Recipient) CheapResult {
+	base := s.baselineFor(trust)
+	radj := s.cfg.RecipientAdjust[r] // an unlisted position adds nothing
+	score := clamp(base + radj)
+	return CheapResult{
+		Baseline:  base,
+		Recipient: radj,
+		Score:     score,
+		Trust:     trust,
+		Gated:     score >= s.cfg.Threshold,
+	}
+}
+
+// Compose adds the flagged content factors to a cheap prefix and returns the
+// full result. If the cheap prefix already reached the threshold, tallying is
+// short-circuited (ADR 0032 §4): the factors are not summed and the message is
+// held on the cheap terms alone, still explainable by those terms.
+//
+// A flagged factor with no point-table entry contributes zero — the table is
+// authoritative, and keeping the detector's factor set aligned with the table is
+// a configuration concern (the assessor slice validates that alignment).
+func (s *Scorer) Compose(cheap CheapResult, factors []Factor) Result {
+	if cheap.Gated {
+		return Result{
+			Score:          cheap.Score,
+			Band:           s.band(cheap.Score),
+			Disposition:    DispositionHeld,
+			Baseline:       cheap.Baseline,
+			Recipient:      cheap.Recipient,
+			ShortCircuited: true,
+			Reason:         "held: sender baseline and recipient position reached the human-surface threshold before content assessment",
+		}
+	}
+	total := cheap.Score
+	for _, f := range factors {
+		total += s.cfg.FactorPoints[f]
+	}
+	total = clamp(total)
+	disp, reason := s.disposition(total)
+	return Result{
+		Score:       total,
+		Band:        s.band(total),
+		Disposition: disp,
+		Baseline:    cheap.Baseline,
+		Recipient:   cheap.Recipient,
+		Factors:     factors,
+		Reason:      reason,
+	}
+}
+
+// Assess is the convenience full path: the cheap prefix followed by the factor
+// composition in one call. It is equivalent to Compose(CheapScore(trust, r),
+// factors) and is used when the factors are already known (e.g. in tests, or
+// once the assessor has run).
+func (s *Scorer) Assess(trust string, r Recipient, factors []Factor) Result {
+	return s.Compose(s.CheapScore(trust, r), factors)
+}
+
+// NotCleared is the fail-safe result for an ambiguous or errored assessment: the
+// message is held regardless of any score (ADR 0032 fail-safe). An assessor that
+// is absent, unreachable, erroring, or timed out routes here — never
+// auto-passed. A reason of "" gets a default explanation.
+func NotCleared(reason string) Result {
+	if reason == "" {
+		reason = "held: assessment not cleared (assessor absent, unreachable, or errored)"
+	}
+	return Result{
+		Disposition: DispositionHeld,
+		NotCleared:  true,
+		Reason:      reason,
+	}
+}
+
+// band maps a (clamped) score to its labeled interval.
+func (s *Scorer) band(score int) Band {
+	switch {
+	case score < s.cfg.Bands.LowMax:
+		return BandLow
+	case score < s.cfg.Bands.MediumMax:
+		return BandMedium
+	default:
+		return BandHigh
+	}
+}
+
+// disposition maps a (clamped) score to its disposition against the
+// human-surface threshold.
+func (s *Scorer) disposition(score int) (Disposition, string) {
+	if score >= s.cfg.Threshold {
+		return DispositionHeld, fmt.Sprintf("held: composed score %d reached the human-surface threshold %d", score, s.cfg.Threshold)
+	}
+	return DispositionAgentHandled, fmt.Sprintf("agent-handled: composed score %d is below the human-surface threshold %d", score, s.cfg.Threshold)
+}
+
+// clamp bounds a raw additive total into [0, MaxScore].
+func clamp(n int) int {
+	switch {
+	case n < 0:
+		return 0
+	case n > MaxScore:
+		return MaxScore
+	default:
+		return n
+	}
+}

--- a/internal/riskscore/score_test.go
+++ b/internal/riskscore/score_test.go
@@ -1,0 +1,166 @@
+package riskscore
+
+import (
+	"testing"
+
+	"github.com/yaad-index/darbaan/internal/provenance"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scorerWith returns a scorer built from the defaults with an override applied.
+func scorerWith(t *testing.T, mutate func(*Config)) *Scorer {
+	t.Helper()
+	cfg := DefaultConfig()
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	s, err := New(cfg)
+	require.NoError(t, err)
+	return s
+}
+
+func TestBandBoundaries(t *testing.T) {
+	// A trusted baseline set to the target, recipient "to" (0), no factors, yields
+	// a composed score equal to the target — so we can probe band edges directly.
+	cases := []struct {
+		score int
+		want  Band
+	}{
+		{0, BandLow}, {1, BandLow}, {32, BandLow},
+		{33, BandMedium}, {50, BandMedium}, {65, BandMedium},
+		{66, BandHigh}, {99, BandHigh}, {100, BandHigh},
+	}
+	for _, c := range cases {
+		s := scorerWith(t, func(cfg *Config) { cfg.SenderBaselines[provenance.TrustTrusted] = c.score })
+		got := s.Assess(provenance.TrustTrusted, RecipientTo, nil)
+		assert.Equalf(t, c.want, got.Band, "score %d", c.score)
+		assert.Equalf(t, c.score, got.Score, "score %d", c.score)
+	}
+}
+
+// TestClampExceeds100 covers the review clamp note: the additive formula can
+// exceed 100, and the composed score is clamped into the range before banding.
+func TestClampExceeds100(t *testing.T) {
+	s := scorerWith(t, nil) // defaults: untrusted 40, bcc 10, instruction 40, secrets 40 = 130
+	got := s.Assess(provenance.TrustUntrusted, RecipientBcc,
+		[]Factor{FactorInstruction, FactorSecretsRequest})
+	assert.Equal(t, MaxScore, got.Score, "over-100 total clamps to MaxScore")
+	assert.Equal(t, BandHigh, got.Band)
+	assert.Equal(t, DispositionHeld, got.Disposition)
+	assert.False(t, got.ShortCircuited, "untrusted(40)+bcc(10)=50 is below the 70 threshold, so factors are tallied")
+}
+
+func TestDispositionAgainstThreshold(t *testing.T) {
+	s := scorerWith(t, nil) // threshold 70
+
+	// trusted(0) + to(0) + instruction(40) = 40 → below threshold → agent-handled.
+	below := s.Assess(provenance.TrustTrusted, RecipientTo, []Factor{FactorInstruction})
+	assert.Equal(t, 40, below.Score)
+	assert.Equal(t, BandMedium, below.Band)
+	assert.Equal(t, DispositionAgentHandled, below.Disposition)
+
+	// unknown(30) + to(0) + instruction(40) = 70 → reaches threshold → held.
+	at := s.Assess(provenance.TrustUnknown, RecipientTo, []Factor{FactorInstruction})
+	assert.Equal(t, 70, at.Score)
+	assert.Equal(t, BandHigh, at.Band)
+	assert.Equal(t, DispositionHeld, at.Disposition)
+}
+
+// TestShortCircuitStopsTally proves the cheap terms gate the summation: once the
+// baseline+recipient reach the threshold, the factors are NOT added (the score
+// stays at the cheap total) and the assessor's factor set is not recorded.
+func TestShortCircuitStopsTally(t *testing.T) {
+	s := scorerWith(t, func(cfg *Config) { cfg.SenderBaselines[provenance.TrustUntrusted] = 70 })
+
+	cheap := s.CheapScore(provenance.TrustUntrusted, RecipientTo)
+	require.True(t, cheap.Gated, "untrusted baseline 70 alone reaches the threshold")
+
+	got := s.Compose(cheap, []Factor{FactorInstruction, FactorSecretsRequest})
+	assert.True(t, got.ShortCircuited)
+	assert.Equal(t, 70, got.Score, "tally stops at the cheap total; factor points are not added")
+	assert.Equal(t, DispositionHeld, got.Disposition)
+	assert.Empty(t, got.Factors, "factors are not recorded on a short-circuit")
+}
+
+func TestCheapScoreGating(t *testing.T) {
+	// Default: unknown baseline 30 + to 0 = 30 < 70 → not gated.
+	s := scorerWith(t, nil)
+	c := s.CheapScore(provenance.TrustUnknown, RecipientTo)
+	assert.Equal(t, 30, c.Score)
+	assert.Equal(t, 30, c.Baseline)
+	assert.Equal(t, 0, c.Recipient)
+	assert.False(t, c.Gated)
+
+	// Raise the untrusted baseline to the threshold → gated on the cheap terms.
+	s2 := scorerWith(t, func(cfg *Config) { cfg.SenderBaselines[provenance.TrustUntrusted] = 75 })
+	c2 := s2.CheapScore(provenance.TrustUntrusted, RecipientTo)
+	assert.True(t, c2.Gated)
+}
+
+// TestUnknownTrustFallback: an unrecognized trust level uses the unknown floor.
+func TestUnknownTrustFallback(t *testing.T) {
+	s := scorerWith(t, nil)
+	c := s.CheapScore("some-unrecognized-level", RecipientTo)
+	assert.Equal(t, s.Config().SenderBaselines[provenance.TrustUnknown], c.Baseline)
+	assert.Equal(t, "some-unrecognized-level", c.Trust)
+}
+
+// TestUnknownFactorContributesZero: the point-table is authoritative.
+func TestUnknownFactorContributesZero(t *testing.T) {
+	s := scorerWith(t, nil)
+	only := s.Assess(provenance.TrustTrusted, RecipientTo, []Factor{Factor("not_in_table")})
+	assert.Equal(t, 0, only.Score)
+
+	mixed := s.Assess(provenance.TrustTrusted, RecipientTo, []Factor{FactorInstruction, Factor("not_in_table")})
+	assert.Equal(t, 40, mixed.Score, "only the known factor contributes")
+}
+
+func TestRecipientAdjust(t *testing.T) {
+	s := scorerWith(t, nil)
+	assert.Equal(t, 0, s.Assess(provenance.TrustTrusted, RecipientTo, nil).Score)
+	assert.Equal(t, 5, s.Assess(provenance.TrustTrusted, RecipientCc, nil).Score)
+	assert.Equal(t, 10, s.Assess(provenance.TrustTrusted, RecipientBcc, nil).Score)
+	assert.Equal(t, 0, s.Assess(provenance.TrustTrusted, Recipient("unlisted"), nil).Score,
+		"an unlisted recipient position adds nothing")
+}
+
+func TestNotCleared(t *testing.T) {
+	def := NotCleared("")
+	assert.Equal(t, DispositionHeld, def.Disposition)
+	assert.True(t, def.NotCleared)
+	assert.NotEmpty(t, def.Reason)
+
+	custom := NotCleared("held: assessor RPC timed out")
+	assert.Equal(t, "held: assessor RPC timed out", custom.Reason)
+	assert.True(t, custom.NotCleared)
+	assert.Equal(t, DispositionHeld, custom.Disposition)
+}
+
+func TestAssessEqualsStagedCompose(t *testing.T) {
+	s := scorerWith(t, nil)
+	factors := []Factor{FactorHiddenDirectives}
+	staged := s.Compose(s.CheapScore(provenance.TrustUnknown, RecipientCc), factors)
+	oneShot := s.Assess(provenance.TrustUnknown, RecipientCc, factors)
+	assert.Equal(t, staged, oneShot)
+}
+
+// TestResultExplainability: a non-gated result carries its components + factors.
+func TestResultExplainability(t *testing.T) {
+	s := scorerWith(t, nil)
+	factors := []Factor{FactorInstruction, FactorHiddenDirectives}
+	got := s.Assess(provenance.TrustUnknown, RecipientCc, factors)
+	assert.Equal(t, 30, got.Baseline)
+	assert.Equal(t, 5, got.Recipient)
+	assert.Equal(t, factors, got.Factors)
+	assert.False(t, got.ShortCircuited)
+	assert.NotEmpty(t, got.Reason)
+}
+
+func TestClampNegativeFloor(t *testing.T) {
+	assert.Equal(t, 0, clamp(-5))
+	assert.Equal(t, 0, clamp(0))
+	assert.Equal(t, 42, clamp(42))
+	assert.Equal(t, MaxScore, clamp(MaxScore+1))
+}


### PR DESCRIPTION
## ADR 0032 implementation — slice 1: deterministic scoring + config core

First implementation slice of ADR 0032 (incoming-message injection assessment). Pure, unit-tested, **no model and no ingest wiring** — those are later slices. New package `internal/riskscore`.

Follows the agreed slice decomposition. The staged-API shape below (rather than a lazy callback) keeps the pure scoring engine free of the assessor's error domain.

### What it does

Composes the injection-risk score by a fixed rule and decides disposition. **The model never produces the number** — an isolated assessor (a later slice) only reports which bounded factors it sees; this package turns those flags into points.

```
score = sender_baseline + recipient_adjustment + Σ(flagged_factor × points)   (clamped to 0..100)
```

- **Sender baseline** keys on the trust the gate already stamped (`provenance.Trust*`, ADR 0030/0031) — never a re-read of `From`. `map[trust]→points`, with the `unknown` level required as the fail-safe floor.
- **Recipient adjustment** (to/cc/bcc) and the **factor point-table** are config. The point-table is authoritative: a flagged factor with no entry contributes zero (keeping the detector's factor set aligned with the table is the assessor slice's concern).
- **Bands** are labeled intervals over the number (0-33 low / 33-66 medium / 66-100 high), cutoffs config.
- **Human-surface threshold** default is HIGH (70): low+medium → agent-handled, high → held.

### Staged API (gates the assessor *invocation*, not just the sum)

```go
cheap := s.CheapScore(trust, recipient)   // no-model prefix: baseline + recipient; reports Gated
var factors []riskscore.Factor
if !cheap.Gated {                          // cheap-first: only pay for the assessor when it can change the outcome
    factors = assessor.Flags(...)          // the later, fallible RPC lives in the orchestration layer
}
result := s.Compose(cheap, factors)        // short-circuits on a gated prefix; else composes + bands + dispositions
```

The engine stays pure — the RPC error domain (timeouts/errors) is owned by the orchestration layer (slice 4), which routes a failed assessment through the fail-safe. `Compose` also short-circuits defensively if handed a gated prefix (tally stops at the cheap total, ADR 0032 §4), so a known-bad sender is held without the assessor ever running.

### Clamp resolution (review carry-over)

The additive total can exceed 100, so it is **clamped into [0, 100] before banding** — the score stays a real 0-100 number and bands stay bounded intervals. Covered by a `130 → 100 → high/held` test.

### Fail-safe

`NotCleared(reason)` holds regardless of score — the orchestration routes an absent/unreachable/errored/timed-out assessment here, never auto-passing it.

### Config

`Parse([]byte)` unmarshals YAML, overlays onto `DefaultConfig` **per key** (partial configs are valid), then validates (ordered band cutoffs, threshold in range, non-negative weights, known recipient positions, required `unknown` floor).

### Tests

testify, **97.4%** coverage: band boundaries, over-100 clamp, short-circuit stops the tally, cheap-first gating, unknown-trust fail-safe floor, unknown-factor zero, `NotCleared`, config parse/merge/validation. gofmt / go vet / `go test -race` / golangci-lint v2.11.4 all clean locally.

### Explicitly deferred to later slices

Content extraction (bounded/inert body+attachment text), the isolated zero-access assessor client (factor detection / the model call), and the ingest/serve routing hook + disposition surface.

### Gate

Implementation PR — 2-of-2 review, no operator gate (ADR 0032 is Accepted; the operator gate was the ADR).
