### PR TITLE
feat(screener): ADR 0032 slice 4a — assessment orchestrator (pure)

### DIFF
--- a/internal/screener/screener.go
+++ b/internal/screener/screener.go
@@ -1,0 +1,137 @@
+// Package screener is the injection-assessment orchestrator (ADR 0032 slice 4a):
+// the routing-hook logic that ties the deterministic scorer, the isolated
+// assessor, and content extraction into a single disposition for one incoming
+// message. It is pure — no ingest or serve plumbing — so the security decision
+// (pass to the agent vs hold for a human) is reviewable and testable in one place.
+//
+// The order is cheap-first (ADR 0032 §5): the no-model sender-baseline + recipient
+// terms run first, and the expensive content assessor is invoked only when those
+// have not already crossed the human-surface threshold. A known-bad sender is
+// held without the assessor — or content extraction — ever running.
+//
+// Fail-safe (ADR 0032): any failure on the assessment path — content that will
+// not extract, or an assessor that errors or times out — resolves to a
+// not-cleared hold, never an auto-pass.
+package screener
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/yaad-index/darbaan/internal/assessor"
+	"github.com/yaad-index/darbaan/internal/mailtext"
+	"github.com/yaad-index/darbaan/internal/riskscore"
+)
+
+// ExtractFunc extracts assessable text from raw message bytes. It matches
+// mailtext.Extract and is injectable for testing.
+type ExtractFunc func(raw []byte, lim mailtext.Limits) (mailtext.Content, error)
+
+// Outcome is the result of screening one message.
+type Outcome struct {
+	// Result is the composed score, band, disposition, contributing factors, and
+	// (on a fail-safe hold) the NotCleared marker. Callers key routing on
+	// Result.Disposition and Result.NotCleared — never on the band/score of a
+	// not-cleared hold, which has no composed score.
+	Result riskscore.Result
+	// Summary is the assessor's sanitized, system-defined summary. It is set only
+	// when the content assessor actually ran (not on a short-circuit hold or a
+	// fail-safe not-cleared), and never contains message bytes.
+	Summary string
+}
+
+// Screener orchestrates one message's assessment.
+type Screener struct {
+	scorer   *riskscore.Scorer
+	assessor *assessor.Assessor
+	extract  ExtractFunc
+	limits   mailtext.Limits
+}
+
+// Option configures a Screener.
+type Option func(*Screener)
+
+// WithLimits sets the extraction limits (default mailtext.DefaultLimits).
+func WithLimits(l mailtext.Limits) Option { return func(s *Screener) { s.limits = l } }
+
+// WithExtractor overrides the content extractor (default mailtext.Extract).
+func WithExtractor(fn ExtractFunc) Option { return func(s *Screener) { s.extract = fn } }
+
+// New returns a Screener. Both the scorer and the assessor are required: once
+// assessment is running, an absent component is a configuration error, never a
+// silent pass. ValidateAlignment(detector, scorer.Config()) is a wiring-time
+// check the caller runs at startup (fail closed on a detector/config mismatch).
+func New(scorer *riskscore.Scorer, asr *assessor.Assessor, opts ...Option) (*Screener, error) {
+	if scorer == nil {
+		return nil, fmt.Errorf("screener: nil scorer")
+	}
+	if asr == nil {
+		return nil, fmt.Errorf("screener: nil assessor")
+	}
+	s := &Screener{scorer: scorer, assessor: asr, extract: mailtext.Extract, limits: mailtext.DefaultLimits()}
+	for _, o := range opts {
+		o(s)
+	}
+	return s, nil
+}
+
+// Screen assesses one incoming message and returns its disposition. trust is the
+// level the gate already stamped (provenance.Trust*, ADR 0030/0031) — never a
+// re-read of From — and recipient is the position the assessed mailbox held.
+//
+// Cheap-first: the sender-baseline + recipient terms are scored first; if they
+// alone reach the threshold the message is held immediately, and neither content
+// extraction nor the assessor runs. Otherwise the content is extracted and
+// assessed, and the factors are composed into the final score. Any failure on
+// that path is a fail-safe not-cleared hold.
+func (s *Screener) Screen(ctx context.Context, raw []byte, trust string, recipient riskscore.Recipient) Outcome {
+	cheap := s.scorer.CheapScore(trust, recipient)
+	if cheap.Gated {
+		// Short-circuit: held on the cheap terms alone; the assessor never runs.
+		return Outcome{Result: s.scorer.Compose(cheap, nil)}
+	}
+	content, err := s.extract(raw, s.limits)
+	if err != nil {
+		return Outcome{Result: riskscore.NotCleared(fmt.Sprintf("held: content could not be extracted for assessment: %v", err))}
+	}
+	assessment, err := s.assessor.Assess(ctx, content)
+	if err != nil {
+		return Outcome{Result: riskscore.NotCleared(fmt.Sprintf("held: assessment did not complete: %v", err))}
+	}
+	return Outcome{
+		Result:  s.scorer.Compose(cheap, assessment.Factors),
+		Summary: assessment.Summary,
+	}
+}
+
+// ResolveRecipient returns the position the mailbox self held on a message with
+// the given To and Cc recipient addresses. To wins over Cc. A mailbox found in
+// neither — delivered via Bcc, an alias, or a list — is treated as the most
+// cautious position, Bcc, since bulk/hidden delivery is a mild risk signal
+// (ADR 0032 §3) and an unresolved position should never earn the safest score.
+func ResolveRecipient(self string, to, cc []string) riskscore.Recipient {
+	self = normalizeAddr(self)
+	if self != "" {
+		if containsAddr(to, self) {
+			return riskscore.RecipientTo
+		}
+		if containsAddr(cc, self) {
+			return riskscore.RecipientCc
+		}
+	}
+	return riskscore.RecipientBcc
+}
+
+func containsAddr(list []string, self string) bool {
+	for _, a := range list {
+		if normalizeAddr(a) == self {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeAddr(a string) string {
+	return strings.ToLower(strings.TrimSpace(a))
+}

--- a/internal/screener/screener_test.go
+++ b/internal/screener/screener_test.go
@@ -1,0 +1,175 @@
+package screener
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yaad-index/darbaan/internal/assessor"
+	"github.com/yaad-index/darbaan/internal/mailtext"
+	"github.com/yaad-index/darbaan/internal/provenance"
+	"github.com/yaad-index/darbaan/internal/riskscore"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var declaredAll = []riskscore.Factor{
+	riskscore.FactorInstruction,
+	riskscore.FactorSecretsRequest,
+	riskscore.FactorAttachmentDirectives,
+}
+
+// spyDetector records whether Detect ran and returns a configured result.
+type spyDetector struct {
+	ret   []riskscore.Factor
+	err   error
+	calls int
+}
+
+func (d *spyDetector) Detect(_ context.Context, _ mailtext.Content) ([]riskscore.Factor, error) {
+	d.calls++
+	return d.ret, d.err
+}
+func (d *spyDetector) Factors() []riskscore.Factor { return declaredAll }
+
+func mustScorer(t *testing.T, mutate func(*riskscore.Config)) *riskscore.Scorer {
+	t.Helper()
+	cfg := riskscore.DefaultConfig()
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	s, err := riskscore.New(cfg)
+	require.NoError(t, err)
+	return s
+}
+
+func mustScreener(t *testing.T, sc *riskscore.Scorer, det assessor.Detector, opts ...Option) *Screener {
+	t.Helper()
+	asr, err := assessor.New(det)
+	require.NoError(t, err)
+	s, err := New(sc, asr, opts...)
+	require.NoError(t, err)
+	return s
+}
+
+func okContent(_ []byte, _ mailtext.Limits) (mailtext.Content, error) {
+	return mailtext.Content{Body: "some body"}, nil
+}
+
+func TestNewRequiresComponents(t *testing.T) {
+	asr, err := assessor.New(&spyDetector{})
+	require.NoError(t, err)
+	sc := mustScorer(t, nil)
+
+	_, err = New(nil, asr)
+	assert.Error(t, err)
+	_, err = New(sc, nil)
+	assert.Error(t, err)
+}
+
+// TestScreenShortCircuitSkipsAssessor proves cheap-first: when the cheap terms
+// gate, neither the extractor nor the assessor runs.
+func TestScreenShortCircuitSkipsAssessor(t *testing.T) {
+	sc := mustScorer(t, func(c *riskscore.Config) {
+		c.SenderBaselines[provenance.TrustUntrusted] = 75 // ≥ threshold 70
+	})
+	det := &spyDetector{ret: []riskscore.Factor{riskscore.FactorInstruction}}
+	extractCalls := 0
+	s := mustScreener(t, sc, det, WithExtractor(func(raw []byte, lim mailtext.Limits) (mailtext.Content, error) {
+		extractCalls++
+		return okContent(raw, lim)
+	}))
+
+	out := s.Screen(context.Background(), []byte("raw"), provenance.TrustUntrusted, riskscore.RecipientTo)
+	assert.Equal(t, riskscore.DispositionHeld, out.Result.Disposition)
+	assert.True(t, out.Result.ShortCircuited)
+	assert.Equal(t, 0, det.calls, "the assessor must not run on a short-circuit")
+	assert.Equal(t, 0, extractCalls, "extraction must not run on a short-circuit")
+	assert.Empty(t, out.Summary)
+}
+
+func TestScreenAgentHandled(t *testing.T) {
+	sc := mustScorer(t, nil)
+	det := &spyDetector{ret: nil} // assessed clean
+	s := mustScreener(t, sc, det, WithExtractor(okContent))
+
+	out := s.Screen(context.Background(), []byte("raw"), provenance.TrustTrusted, riskscore.RecipientTo)
+	assert.Equal(t, riskscore.DispositionAgentHandled, out.Result.Disposition)
+	assert.Equal(t, riskscore.BandLow, out.Result.Band)
+	assert.Equal(t, 1, det.calls, "the assessor runs when the cheap terms do not gate")
+	assert.NotEmpty(t, out.Summary)
+}
+
+func TestScreenMaliciousHeld(t *testing.T) {
+	sc := mustScorer(t, nil) // unknown baseline 30 + instruction 40 = 70 → held
+	det := &spyDetector{ret: []riskscore.Factor{riskscore.FactorInstruction}}
+	s := mustScreener(t, sc, det, WithExtractor(okContent))
+
+	out := s.Screen(context.Background(), []byte("raw"), provenance.TrustUnknown, riskscore.RecipientTo)
+	assert.Equal(t, riskscore.DispositionHeld, out.Result.Disposition)
+	assert.Equal(t, 70, out.Result.Score)
+	assert.Contains(t, out.Result.Factors, riskscore.FactorInstruction)
+	assert.Contains(t, out.Summary, string(riskscore.FactorInstruction))
+}
+
+func TestScreenExtractionErrorIsNotCleared(t *testing.T) {
+	sc := mustScorer(t, nil)
+	det := &spyDetector{}
+	s := mustScreener(t, sc, det, WithExtractor(func([]byte, mailtext.Limits) (mailtext.Content, error) {
+		return mailtext.Content{}, errors.New("boom")
+	}))
+
+	out := s.Screen(context.Background(), []byte("raw"), provenance.TrustTrusted, riskscore.RecipientTo)
+	assert.Equal(t, riskscore.DispositionHeld, out.Result.Disposition)
+	assert.True(t, out.Result.NotCleared)
+	assert.Equal(t, 0, det.calls, "a failed extraction never reaches the assessor")
+	assert.Empty(t, out.Summary)
+}
+
+func TestScreenAssessorErrorIsNotCleared(t *testing.T) {
+	sc := mustScorer(t, nil)
+	det := &spyDetector{err: errors.New("detector down")}
+	s := mustScreener(t, sc, det, WithExtractor(okContent))
+
+	out := s.Screen(context.Background(), []byte("raw"), provenance.TrustTrusted, riskscore.RecipientTo)
+	assert.Equal(t, riskscore.DispositionHeld, out.Result.Disposition)
+	assert.True(t, out.Result.NotCleared)
+}
+
+// TestScreenRealExtractorEmptyRaw exercises the default (real) extractor: an
+// unparseable/empty message fails extraction and is held, not passed.
+func TestScreenRealExtractorEmptyRaw(t *testing.T) {
+	sc := mustScorer(t, nil)
+	det := &spyDetector{}
+	s := mustScreener(t, sc, det) // default mailtext.Extract
+
+	out := s.Screen(context.Background(), nil, provenance.TrustTrusted, riskscore.RecipientTo)
+	assert.Equal(t, riskscore.DispositionHeld, out.Result.Disposition)
+	assert.True(t, out.Result.NotCleared)
+	assert.Equal(t, 0, det.calls)
+}
+
+func TestWithLimitsPlumbedToExtractor(t *testing.T) {
+	sc := mustScorer(t, nil)
+	det := &spyDetector{}
+	lim := mailtext.Limits{MaxPartText: 123, MaxTotalText: 456, MaxParts: 7, MaxDepth: 3}
+	var got mailtext.Limits
+	s := mustScreener(t, sc, det, WithLimits(lim), WithExtractor(func(_ []byte, l mailtext.Limits) (mailtext.Content, error) {
+		got = l
+		return mailtext.Content{}, nil
+	}))
+	s.Screen(context.Background(), []byte("raw"), provenance.TrustTrusted, riskscore.RecipientTo)
+	assert.Equal(t, lim, got)
+}
+
+func TestResolveRecipient(t *testing.T) {
+	to := []string{"Me@example.com", "other@example.com"}
+	cc := []string{"cc@example.com"}
+
+	assert.Equal(t, riskscore.RecipientTo, ResolveRecipient("me@example.com", to, cc), "case-insensitive To match")
+	assert.Equal(t, riskscore.RecipientCc, ResolveRecipient("cc@example.com", to, cc))
+	assert.Equal(t, riskscore.RecipientBcc, ResolveRecipient("hidden@example.com", to, cc), "not in To/Cc → cautious Bcc")
+	assert.Equal(t, riskscore.RecipientBcc, ResolveRecipient("", to, cc), "empty self → cautious Bcc")
+	assert.Equal(t, riskscore.RecipientTo, ResolveRecipient(" me@example.com ", to, cc), "trimmed")
+}


### PR DESCRIPTION
## ADR 0032 implementation — slice 4a: assessment orchestrator

The routing-hook logic, split out from the live wiring so the security decision has a clean review surface. New package `internal/screener`: a **pure** component that composes the scorer, the isolated assessor, and content extraction into one disposition for an incoming message — pass to the agent, or hold for a human. **No ingest or serve plumbing** — that's slice 4b, which wires against this stable interface.

### `Screen(ctx, raw, trust, recipient) → Outcome`

**Cheap-first** (ADR 0032 §5): the no-model sender-baseline + recipient terms score first. If they alone reach the human-surface threshold, the message is held immediately and **neither content extraction nor the assessor runs** — a known-bad sender is held without ever invoking the assessor. Otherwise the content is extracted and assessed, and the factors compose the final score.

**Fail-safe** (ADR 0032): content that won't extract, or an assessor that errors or times out, resolves to `riskscore.NotCleared` (held) — never an auto-pass. `New` requires a non-nil scorer **and** assessor: once assessment is running, an absent component is a configuration error, not a silent pass.

`trust` is the level the gate already stamped (`provenance.Trust*`, ADR 0030/0031) — **never a re-read of From**. The `Outcome` carries the `riskscore.Result` (score/band/disposition/factors/not-cleared) plus the assessor's sanitized `Summary` (set only when the assessor actually ran; never message bytes).

### Recipient resolution

`ResolveRecipient(self, to, cc)` maps the mailbox against the envelope addresses: To beats Cc, and a mailbox in neither (Bcc, alias, list) is treated as the **cautious Bcc** position — an unresolved position never earns the safest score.

### Carry-over placement

- (a) cheap-first + short-circuit → `Screen`
- (b) error / absent → `NotCleared` → `Screen` + `New`
- (c) `ValidateAlignment(det, cfg)` stays a **wiring-time** check the startup path runs (slice 4b) — it needs the detector, which lives at construction in `main`
- (d) trust from the stamp → `Screen`'s `trust` param (4b feeds it from the `ProvenanceResolver`)
- (e) not-cleared has no band/score → `Outcome` documents keying on `Disposition`/`NotCleared`; the 4b disposition surface renders accordingly

### Tests

testify, **100%** coverage: cheap-first short-circuit (assessor **and** extractor both skipped, proven with a spy), agent-handled and held paths, extraction-error and assessor-error fail-safes, the real extractor on unparseable input, recipient resolution, and limit plumbing. gofmt / vet / `go test -race` / golangci-lint v2.11.4 all clean.

### Next

Slice 4b wires `Screen` into `imapsync.FetchContent`, routes "held" through the existing hold-for-human queue, and adds config + `main` construction with `ValidateAlignment` fail-closed at startup — **behind a default-OFF enable flag** (merge must not change live mail behavior until the operator activates it; startup-abort on misconfig regardless of flag state).

### Gate

Implementation PR — 2-of-2 review, no operator gate (ADR 0032 is Accepted; activation of the feature on a live inbox is the operator's separate call, handled in 4b).
