### PR TITLE
ADR 0032 change B — withhold held body, serve placeholder

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -1232,7 +1232,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 		ServeStamp: func(inbox string, raw []byte) ([]byte, error) {
 			return provenance.Sanitize(raw, provResolver(inbox, provenance.From(raw)))
 		},
-	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner, syncNow)
+	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner, syncNow, cli.AssessmentEnabled)
 	if err != nil {
 		return err
 	}

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -89,7 +89,7 @@ type IMAPServer struct {
 // before.
 // syncNow triggers a debounced on-demand upstream pull of an inbox on STATUS
 // (ADR 0028); nil disables on-demand sync (STATUS stays a plain query).
-func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool, mailOwner func(inbox string) string, syncNow SyncTrigger) (*IMAPServer, error) {
+func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore, fetch ContentFetch, writeKeywords KeywordWriter, filters map[string]*filter.Filter, guard *bounceguard.Guard, holdSpoof bool, mailOwner func(inbox string) string, syncNow SyncTrigger, assessmentEnabled bool) (*IMAPServer, error) {
 	if cfg.TLSConfig == nil && !cfg.AllowInsecure {
 		return nil, errors.New("listener: IMAP TLS required (set TLSConfig, or AllowInsecure for local testing)")
 	}
@@ -101,7 +101,7 @@ func NewIMAPServer(cfg IMAPServerConfig, auth *Auth, store inbound.InboundStore,
 	}
 	srv := imapserver.New(&imapserver.Options{
 		NewSession: func(_ *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
-			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner, syncNow: syncNow, serveStamp: cfg.ServeStamp}, nil, nil
+			return &imapSession{auth: auth, store: store, fetch: fetch, writeKeywords: writeKeywords, filters: filters, guard: guard, holdSpoof: holdSpoof, mailOwner: mailOwner, syncNow: syncNow, serveStamp: cfg.ServeStamp, assessmentOn: assessmentEnabled}, nil, nil
 		},
 		TLSConfig:    cfg.TLSConfig,
 		InsecureAuth: cfg.AllowInsecure,
@@ -135,6 +135,7 @@ type imapSession struct {
 	mailOwner     func(inbox string) string // synced-mail owner key per inbox (ADR 0027); nil = key by the connecting agent
 	syncNow       SyncTrigger               // debounced on-demand pull on STATUS (ADR 0028); nil = disabled
 	serveStamp    ServeStamp                // serve-path provenance re-stamp (ADR 0030 slice 5); nil = serve as stored
+	assessmentOn  bool                      // injection assessment enabled (ADR 0032): gates the placeholder read-face
 	owner         string
 	selectedInbox string // the inbox name of the SELECTed mailbox (ADR 0023)
 	authed        bool
@@ -246,11 +247,24 @@ func (s *imapSession) listAndFilter(inbox string) (full, visible []inbound.Messa
 			}
 		}
 		// Injection assessment is a second security floor (ADR 0032), independent of
-		// the user filter: an assessment-held message stays hidden until the operator
-		// approves it, exactly like a filter Hold. A single HoldDecision releases the
-		// message past every hold source, so approving reveals it here too.
-		if m.HeldByAssessment() && m.HoldDecision != inbound.HoldApproved {
-			continue
+		// the user filter. Unlike a filter Hold, an assessment-held message is not
+		// hidden outright (ADR 0032 change B): the operator prefers the agent see a
+		// message genuinely awaiting approval over a silent gap. So an UNDECIDED
+		// assessment hold is shown with the system placeholder body (substituted at
+		// content-serve time, rawResolver), a REJECTED one stays hidden (the operator
+		// dropped it), and an APPROVED one falls through to the user filter with its
+		// real body. A single HoldDecision releases past every hold source, so an
+		// approve reveals the real content here too.
+		if m.HeldByAssessment() {
+			switch m.HoldDecision {
+			case inbound.HoldApproved:
+				// exposed — apply the user filter to the real message below
+			case inbound.HoldRejected:
+				continue // operator dropped it: stays hidden, fail-safe
+			default:
+				visible = append(visible, m) // undecided: placeholder-visible
+				continue
+			}
 		}
 		if flt == nil {
 			visible = append(visible, m)
@@ -459,7 +473,8 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 		// fields serve from stored metadata when present, and only a body request
 		// (or a record with no stored metadata) triggers getRaw. A resolve failure
 		// surfaces as an IMAP error, never empty/wrong content.
-		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options, s.rawResolver(*m))
+		getRaw, isHeld := s.rawResolver(*m)
+		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options, getRaw, isHeld, s.assessmentOn)
 	})
 	return ferr
 }
@@ -467,51 +482,116 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 // rawFunc lazily resolves a message's raw content.
 type rawFunc func() ([]byte, error)
 
-// rawResolver returns a memoized resolver for a message's raw content: it calls
+// heldFunc reports whether the resolved content is the ADR-0032 held placeholder
+// (see rawResolver). It shares rawFunc's single memoized resolve, so calling
+// either forces at most one content fetch.
+type heldFunc func() (bool, error)
+
+// heldSubjectMask replaces a held message's Subject on the read face (ADR
+// 0032 change B): the assessment scores the body + attachments, not the Subject,
+// so a subject-borne directive would otherwise still reach the agent via ENVELOPE
+// while the body is withheld. Masked while undecided; the real Subject returns on
+// operator Expose (approve).
+const heldSubjectMask = "[held for review]"
+
+// heldPlaceholderRaw is the system-authored body the read face serves in place of
+// a message the injection assessment holds pending operator approval (ADR 0032
+// change B). It carries no sender bytes, so it is safe for the agent to consume.
+// The X-Darbaan-Assessment header is a stable, system-set marker the agent client
+// can key on (presence ⟺ placeholder): a real body is Sanitized at the write
+// chokepoint and re-stamped on serve, both of which strip the whole X-Darbaan-*
+// namespace (provenance.rewrite), so a sender cannot spoof this marker onto real
+// mail — and the placeholder deliberately bypasses that serve-path stamp so its
+// marker survives.
+var heldPlaceholderRaw = []byte("From: Darbaan <darbaan@localhost>\r\n" +
+	"Subject: " + heldSubjectMask + "\r\n" +
+	"X-Darbaan-Assessment: held\r\n" +
+	"Content-Type: text/plain; charset=utf-8\r\n" +
+	"\r\n" +
+	"This message was flagged as a possible injection and is held by Darbaan pending operator approval. Its content is withheld from the agent until an operator approves it.\r\n")
+
+// mightBeHeld reports whether a message could serve the held placeholder, so the
+// read face only forces a resolve (to learn the authoritative disposition) for
+// these — with assessment enabled a pending record is not yet assessed and may
+// become held on this very fetch (the first-read window ADR 0032 change B
+// closes), and an already held-and-not-approved record is held now. Everything
+// else (assessed agent-handled, held-and-approved, or never assessed) serves its
+// real content without a forced resolve. When assessment is off, a pending record
+// can never become held, so the lazy-metadata path is preserved unchanged: only
+// an already-stored hold (from an earlier assessment-on run) still forces.
+func mightBeHeld(m inbound.Message, assessmentOn bool) bool {
+	return (assessmentOn && m.Pending) || (m.HeldByAssessment() && m.HoldDecision != inbound.HoldApproved)
+}
+
+// rawResolver returns a memoized resolver for a message's raw content plus a
+// companion that reports whether that content is the held placeholder. It calls
 // the content fetcher at most once, and only when a field actually needs the body
 // (BodyStructure/BodySection, or ENVELOPE/size/header on a record with no stored
-// metadata). Present records resolve from a local blob; a pending record fetches
-// upstream once, then is cached present.
-func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
+// metadata) or the held state is queried. Present records resolve from a local
+// blob; a pending record fetches upstream once, then is cached present.
+//
+// ADR 0032 change B: the fetch is also where a pending message is assessed, so
+// the very read that holds a message must not hand back its body. When the
+// freshly-resolved message is held and not operator-approved, the resolver serves
+// heldPlaceholderRaw (bypassing serveStamp — the placeholder is system-authored,
+// carries no sender bytes, and its X-Darbaan-Assessment marker must survive) and
+// reports held. Persistence is unaffected: the real raw + assessment are already
+// stored, so the human hold surface still shows real content and, after Expose,
+// the predicate flips and the real body serves on a subsequent FETCH. Note the
+// tradeoff: an agent that already read the placeholder will not re-FETCH the same
+// UID without a re-SELECT or explicit FETCH, so the real body reaches it only on a
+// fresh read — the placeholder signals "pending," which is the expected behavior.
+func (s *imapSession) rawResolver(m inbound.Message) (rawFunc, heldFunc) {
 	var (
 		raw  []byte
+		held bool
 		err  error
 		done bool
 	)
-	return func() ([]byte, error) {
-		if !done {
-			done = true
-			var full inbound.Message
-			switch full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); {
-			case err == nil:
-				raw = full.Raw
-				// Serve-path backstop (ADR 0030 slice 5): re-run the same sanitize +
-				// stamp as the write chokepoint, keyed strictly on the session's
-				// server-side selected inbox (never anything from the blob), so a
-				// pre-ADR/legacy blob serves with its real trust and the stamp stays
-				// fresh on a config change. Idempotent on an already-stamped blob. A
-				// blob that can't be safely re-stamped serves empty rather than
-				// un-sanitized — real stored blobs are sanitized at write, so this is
-				// a near-dead edge.
-				if s.serveStamp != nil {
-					if stamped, serr := s.serveStamp(s.selectedInbox, raw); serr == nil {
-						raw = stamped
-					} else {
-						raw = nil
-					}
-				}
-			case errors.Is(err, inbound.ErrContentUnavailable):
-				// The upstream content can't be resolved (a stale local→upstream UID
-				// mapping, #190). Serve an empty body rather than erroring: the FETCH
-				// response stays well-formed and the command completes, so one
-				// unresolvable UID can't stall the client's whole poll. The event is
-				// surfaced by the syncer at WARN and the stale mapping is dropped there;
-				// the message's stored ENVELOPE / SIZE / FLAGS still serve normally.
-				raw, err = nil, nil
-			}
+	resolve := func() {
+		if done {
+			return
 		}
-		return raw, err
+		done = true
+		var full inbound.Message
+		switch full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); {
+		case err == nil:
+			if full.HeldByAssessment() && full.HoldDecision != inbound.HoldApproved {
+				// Withhold the real body: serve the system placeholder instead, and do
+				// NOT run serveStamp — the placeholder is authoritative as-is and its
+				// marker header must not be stripped.
+				raw, held = heldPlaceholderRaw, true
+				return
+			}
+			raw = full.Raw
+			// Serve-path backstop (ADR 0030 slice 5): re-run the same sanitize +
+			// stamp as the write chokepoint, keyed strictly on the session's
+			// server-side selected inbox (never anything from the blob), so a
+			// pre-ADR/legacy blob serves with its real trust and the stamp stays
+			// fresh on a config change. Idempotent on an already-stamped blob. A
+			// blob that can't be safely re-stamped serves empty rather than
+			// un-sanitized — real stored blobs are sanitized at write, so this is
+			// a near-dead edge.
+			if s.serveStamp != nil {
+				if stamped, serr := s.serveStamp(s.selectedInbox, raw); serr == nil {
+					raw = stamped
+				} else {
+					raw = nil
+				}
+			}
+		case errors.Is(err, inbound.ErrContentUnavailable):
+			// The upstream content can't be resolved (a stale local→upstream UID
+			// mapping, #190). Serve an empty body rather than erroring: the FETCH
+			// response stays well-formed and the command completes, so one
+			// unresolvable UID can't stall the client's whole poll. The event is
+			// surfaced by the syncer at WARN and the stale mapping is dropped there;
+			// the message's stored ENVELOPE / SIZE / FLAGS still serve normally.
+			raw, err = nil, nil
+		}
 	}
+	getRaw := func() ([]byte, error) { resolve(); return raw, err }
+	isHeld := func() (bool, error) { resolve(); return held, err }
+	return getRaw, isHeld
 }
 
 func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, _ *imap.StoreOptions) error {
@@ -682,7 +762,8 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 		// criteria on records without stored metadata. If a candidate's content
 		// can't be resolved, skip it (degrade, don't [SERVERBUG] the whole SEARCH)
 		// — but log it: a skipped candidate is a silently-missing result.
-		ok, err := matchSearch(seqNum, m, criteria, s.rawResolver(*m))
+		getRaw, _ := s.rawResolver(*m)
+		ok, err := matchSearch(seqNum, m, criteria, getRaw)
 		if err != nil {
 			slog.Warn("imap search skipped message", "id", m.ID, "err", err)
 			continue
@@ -926,7 +1007,7 @@ func (s *imapSession) Idle(_ *imapserver.UpdateWriter, stop <-chan struct{}) err
 	return nil
 }
 
-func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions, getRaw rawFunc) error {
+func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions, getRaw rawFunc, isHeld heldFunc, assessmentOn bool) error {
 	w.WriteUID(uidOf(m))
 	if options.Flags {
 		w.WriteFlags(flagList(m))
@@ -934,10 +1015,34 @@ func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options 
 	if options.InternalDate {
 		w.WriteInternalDate(m.ReceivedAt)
 	}
+	// ADR 0032 change B: a held message serves the system placeholder for
+	// every content-bearing field — body, size, and a masked Subject — so neither
+	// the body NOR a subject-borne directive reaches the agent pre-approval. Learn
+	// the authoritative held state once, forcing the resolve only for a message
+	// that could be held and only when a leak-sensitive field is requested (an
+	// unassessed pending record is assessed by this very resolve, closing the
+	// first-read window even for an ENVELOPE- or SIZE-only fetch).
+	held := false
+	if mightBeHeld(m, assessmentOn) && (options.RFC822Size || options.Envelope || options.BodyStructure != nil || len(options.BodySection) > 0) {
+		h, err := isHeld()
+		if err != nil {
+			return err
+		}
+		held = h
+	}
 	if options.RFC822Size {
 		size, err := sizeOf(&m, getRaw)
 		if err != nil {
 			return err
+		}
+		if held {
+			// getRaw now yields the placeholder; report its length, not the stored
+			// size of the withheld real message.
+			raw, err := getRaw()
+			if err != nil {
+				return err
+			}
+			size = int64(len(raw))
 		}
 		w.WriteRFC822Size(size)
 	}
@@ -947,6 +1052,9 @@ func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options 
 			return err
 		}
 		if env != nil {
+			if held {
+				env.Subject = heldSubjectMask
+			}
 			w.WriteEnvelope(env)
 		}
 	}

--- a/internal/listener/imap_ondemand_e2e_test.go
+++ b/internal/listener/imap_ondemand_e2e_test.go
@@ -93,7 +93,7 @@ func TestOnDemandSyncEndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
 		listener.SingleAuth("agent", "pw"), store, nil, nil,
-		map[string]*filter.Filter{inbound.DefaultInbox: nil}, nil, false, nil, syncNow)
+		map[string]*filter.Filter{inbound.DefaultInbox: nil}, nil, false, nil, syncNow, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(ln) }()
 	t.Cleanup(func() { _ = srv.Close() })

--- a/internal/listener/imap_status_sync_test.go
+++ b/internal/listener/imap_status_sync_test.go
@@ -24,7 +24,7 @@ func startIMAPSyncTrigger(t *testing.T, store inbound.InboundStore, syncNow list
 	require.NoError(t, err)
 	filters := map[string]*filter.Filter{inbound.DefaultInbox: nil}
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil, syncNow)
+		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil, syncNow, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -23,7 +23,7 @@ func startIMAPServeStamp(t *testing.T, store inbound.InboundStore, ss listener.S
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true, ServeStamp: ss},
-		listener.SingleAuth("agent", "pw"), store, nil, nil, map[string]*filter.Filter{inbound.DefaultInbox: nil}, nil, false, nil, nil)
+		listener.SingleAuth("agent", "pw"), store, nil, nil, map[string]*filter.Filter{inbound.DefaultInbox: nil}, nil, false, nil, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -59,7 +59,22 @@ func startIMAPFull(t *testing.T, store inbound.InboundStore, fetch listener.Cont
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false, nil, nil)
+		listener.SingleAuth("agent", "pw"), store, fetch, wk, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false, nil, nil, false)
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return l.Addr().String()
+}
+
+// startIMAPAssess wires the read face with injection assessment enabled (ADR
+// 0032 change B), so a pending record forces a resolve to learn its disposition
+// and a held record serves the placeholder.
+func startIMAPAssess(t *testing.T, store inbound.InboundStore, fetch listener.ContentFetch, flt *filter.Filter) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
+		listener.SingleAuth("agent", "pw"), store, fetch, nil, map[string]*filter.Filter{inbound.DefaultInbox: flt}, nil, false, nil, nil, true)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -71,7 +86,7 @@ func startIMAPMulti(t *testing.T, store inbound.InboundStore, filters map[string
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil, nil)
+		listener.SingleAuth("agent", "pw"), store, nil, nil, filters, nil, false, nil, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -83,7 +98,7 @@ func startIMAPAuth(t *testing.T, store inbound.InboundStore, filters map[string]
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		auth, store, nil, nil, filters, nil, false, nil, nil)
+		auth, store, nil, nil, filters, nil, false, nil, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })
@@ -615,17 +630,23 @@ func TestIMAPFilterHidesMessages(t *testing.T) {
 	assert.Equal(t, "keep", msgs[0].Envelope.Subject) // only the allowed one is served
 }
 
-// An assessment-held message (ADR 0032) is hidden from the read face until the
-// operator approves it, exactly like a filter Hold; one approval reveals it.
+// An assessment-held message (ADR 0032 change B) stays visible on the read face
+// but serves a system placeholder body + masked Subject until the operator
+// approves it; one approval reveals the real content. Undecided → placeholder,
+// approved → real.
 func TestIMAPAssessmentHold(t *testing.T) {
 	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = store.Close() })
 
-	_, _, err = store.AddSyncedPending(inbound.Delivery{
+	_, keep, err := store.AddSyncedPending(inbound.Delivery{
 		Owner: "agent", Subject: "keep", UpstreamUID: 1, UIDValidity: 1,
 		Envelope: &inbound.Envelope{Subject: "keep"},
 	})
+	require.NoError(t, err)
+	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, keep.ID,
+		[]byte("Subject: keep\r\n\r\nkeepbody"),
+		&inbound.Assessment{Disposition: inbound.AssessmentAgentHandled})
 	require.NoError(t, err)
 	_, held, err := store.AddSyncedPending(inbound.Delivery{
 		Owner: "agent", Subject: "danger", UpstreamUID: 2, UIDValidity: 1,
@@ -633,19 +654,42 @@ func TestIMAPAssessmentHold(t *testing.T) {
 	})
 	require.NoError(t, err)
 	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, held.ID,
-		[]byte("Subject: danger\r\n\r\nx"),
+		[]byte("Subject: danger\r\n\r\nattacker-body-do-this"),
 		&inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"})
 	require.NoError(t, err)
 
-	addr := startIMAPFull(t, store, nil, nil, nil) // no user filter
+	addr := startIMAPAssess(t, store, nil, nil) // no user filter
 	c, err := imapclient.DialInsecure(addr, nil)
 	require.NoError(t, err)
 	defer func() { _ = c.Close() }()
 	require.NoError(t, c.Login("agent", "pw").Wait())
 	sel, err := c.Select("INBOX", nil).Wait()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(1), sel.NumMessages, "assessment-held message hidden pending a decision")
+	assert.Equal(t, uint32(2), sel.NumMessages, "held message stays visible with a placeholder, not hidden")
 
+	// The held message's body is withheld: masked Subject + placeholder body
+	// carrying the system marker, and never the attacker bytes.
+	msgs, err := c.Fetch(imap.SeqSetNum(2), &imap.FetchOptions{
+		Envelope: true, BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "[held for review]", msgs[0].Envelope.Subject, "Subject masked while held")
+	body := string(msgs[0].FindBodySection(&imap.FetchItemBodySection{}))
+	assert.Contains(t, body, "held by Darbaan", "placeholder body served")
+	assert.Contains(t, body, "X-Darbaan-Assessment: held", "system marker on placeholder")
+	assert.NotContains(t, body, "attacker-body-do-this", "real body withheld")
+
+	// The un-held neighbour still serves its real body + Subject.
+	keepMsgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		Envelope: true, BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, keepMsgs, 1)
+	assert.Equal(t, "keep", keepMsgs[0].Envelope.Subject)
+	assert.Contains(t, string(keepMsgs[0].FindBodySection(&imap.FetchItemBodySection{})), "keepbody")
+
+	// Approve → the real Subject + body serve on a fresh fetch.
 	_, err = store.SetHoldDecision("agent", inbound.DefaultInbox, held.ID, inbound.HoldApproved)
 	require.NoError(t, err)
 	c2, err := imapclient.DialInsecure(addr, nil)
@@ -654,11 +698,19 @@ func TestIMAPAssessmentHold(t *testing.T) {
 	require.NoError(t, c2.Login("agent", "pw").Wait())
 	sel2, err := c2.Select("INBOX", nil).Wait()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(2), sel2.NumMessages, "one approval reveals the held message")
+	assert.Equal(t, uint32(2), sel2.NumMessages)
+	after, err := c2.Fetch(imap.SeqSetNum(2), &imap.FetchOptions{
+		Envelope: true, BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, "danger", after[0].Envelope.Subject, "real Subject returns on approve")
+	assert.Contains(t, string(after[0].FindBodySection(&imap.FetchItemBodySection{})), "attacker-body-do-this", "real body serves on approve")
 }
 
-// A message held by BOTH assessment and a filter Hold stays hidden, and the
-// single HoldDecision releases it past both sources (the documented model).
+// A message held by BOTH assessment and a filter Hold serves the assessment
+// placeholder (visible), and the single HoldDecision releases it past both
+// sources to its real body (the documented one-decision-releases-all model).
 func TestIMAPAssessmentAndFilterHold(t *testing.T) {
 	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
 	require.NoError(t, err)
@@ -676,7 +728,7 @@ func TestIMAPAssessmentAndFilterHold(t *testing.T) {
 
 	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
 	require.NoError(t, err)
-	addr := startIMAPFull(t, store, nil, nil, flt)
+	addr := startIMAPAssess(t, store, nil, flt)
 
 	c, err := imapclient.DialInsecure(addr, nil)
 	require.NoError(t, err)
@@ -684,7 +736,7 @@ func TestIMAPAssessmentAndFilterHold(t *testing.T) {
 	require.NoError(t, c.Login("agent", "pw").Wait())
 	sel, err := c.Select("INBOX", nil).Wait()
 	require.NoError(t, err)
-	assert.Equal(t, uint32(0), sel.NumMessages, "held by both → hidden")
+	assert.Equal(t, uint32(1), sel.NumMessages, "held by both → placeholder-visible (assessment floor)")
 
 	_, err = store.SetHoldDecision("agent", inbound.DefaultInbox, both.ID, inbound.HoldApproved)
 	require.NoError(t, err)
@@ -695,6 +747,62 @@ func TestIMAPAssessmentAndFilterHold(t *testing.T) {
 	sel2, err := c2.Select("INBOX", nil).Wait()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(1), sel2.NumMessages, "one approval releases it past both hold sources")
+}
+
+// The first-read window (ADR 0032 change B): a message is still pending
+// (unassessed) at SELECT, so it is visible; the client's own body FETCH is what
+// assesses + holds it. That very fetch must serve the placeholder, not the real
+// body — the leak the live test caught. The real raw is still persisted for the
+// human hold surface.
+func TestIMAPAssessmentFirstReadWindow(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, pend, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "danger", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "danger"},
+	})
+	require.NoError(t, err)
+
+	// fetch mirrors Syncer.FetchContent with a live assess hook that holds: it
+	// persists the real raw + a held assessment and returns the resulting message.
+	realRaw := []byte("Subject: danger\r\n\r\nattacker-body-do-this")
+	fetch := func(owner, inbox, id string) (inbound.Message, error) {
+		return store.SetContentAssessed(owner, inbox, id, realRaw,
+			&inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"})
+	}
+
+	addr := startIMAPAssess(t, store, fetch, nil)
+	c, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), sel.NumMessages, "still pending at SELECT → visible")
+
+	// The fetch that assesses + holds must hand back the placeholder, never the
+	// attacker body, and mask the Subject.
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		Envelope: true, BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "[held for review]", msgs[0].Envelope.Subject)
+	body := string(msgs[0].FindBodySection(&imap.FetchItemBodySection{}))
+	assert.Contains(t, body, "held by Darbaan")
+	assert.NotContains(t, body, "attacker-body-do-this", "first-read leak closed")
+
+	// The real raw is persisted for the human hold surface even though it was
+	// withheld from the agent.
+	got, err := store.Get("agent", inbound.DefaultInbox, pend.ID)
+	require.NoError(t, err)
+	// The stored blob is sanitized/stamped at the write chokepoint, so it is not
+	// byte-identical to realRaw, but it still carries the real body for the human
+	// hold surface.
+	assert.Contains(t, string(got.Raw), "attacker-body-do-this", "real content persisted for the operator")
+	assert.True(t, got.HeldByAssessment())
 }
 
 // A hold-for-human message is hidden until approved, then becomes visible (ADR
@@ -772,7 +880,7 @@ func TestIMAPBadAuthRejected(t *testing.T) {
 
 func TestIMAPRequiresTLS(t *testing.T) {
 	_, err := listener.NewIMAPServer(listener.IMAPServerConfig{},
-		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false, nil, nil)
+		listener.SingleAuth("agent", "pw"), seedInbound(t), nil, nil, nil, nil, false, nil, nil, false)
 	require.Error(t, err)
 }
 
@@ -781,7 +889,7 @@ func startIMAPDecoupled(t *testing.T, store inbound.InboundStore, filters map[st
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	srv, err := listener.NewIMAPServer(listener.IMAPServerConfig{AllowInsecure: true},
-		auth, store, nil, nil, filters, nil, false, mailOwner, nil)
+		auth, store, nil, nil, filters, nil, false, mailOwner, nil, false)
 	require.NoError(t, err)
 	go func() { _ = srv.Serve(l) }()
 	t.Cleanup(func() { _ = srv.Close() })


### PR DESCRIPTION
## What

Closes the injection-assessment **first-read window**. A message still *pending* (unassessed) at SELECT is visible, so the client's own body FETCH is what assesses and holds it — and that same fetch previously returned the real `Raw`, handing the flagged body to the agent before any operator decision (only *later* reads were hidden).

## Approach

Placeholder-**visible**, one predicate `HeldByAssessment() && HoldDecision != HoldApproved` (`NotCleared` sets `Disposition=held`, so it covers both hold cases). The read face serves a system placeholder for a held-and-not-approved message across every content-bearing field:

- **rawResolver** substitutes a system-authored placeholder body and reports held-state via a companion resolver sharing the single memoized fetch. The placeholder **bypasses serveStamp** so its `X-Darbaan-Assessment: held` marker survives.
- **fetchMessage** masks the Subject → `[held for review]` and reports the placeholder length as `RFC822Size`. It forces the resolve only for a message that could be held, and only when a leak-sensitive field is requested — so an ENVELOPE- or SIZE-only fetch is covered too (closing the subject-borne vector, since assessment scores body+attachments, not Subject).
- **listAndFilter** three-way on an assessment hold: undecided → show placeholder, rejected → hide (operator dropped it), approved → real body.

Persistence is unchanged: the real raw + assessment are still written, so the human hold surface shows real content and, after Expose, the real body serves on a fresh FETCH.

## Fail-safe / scope

- Gated on assessment being enabled: an assessment-off deployment keeps the lazy-metadata read path **byte-identical** (a pending record can't become held).
- Scope is assessment holds only — `filter.Hold` and the bounce-spoof guard keep their existing HIDE semantics this pass.
- The `X-Darbaan-Assessment` marker is safe by construction: `provenance.rewrite` strips the whole `X-Darbaan-*` namespace (a literal prefix match) at the write chokepoint and on serve, so any sender-set copy is removed and presence of the marker on a served message implies the placeholder.

## Cross-package touch

`cmd/darbaan/main.go` — one line: pass `AssessmentEnabled` into `NewIMAPServer` so the read face knows whether to force the held-check resolve. No behavior change when the flag is off.

## Known residual (documented, out of scope)

Post-Expose, the real body serves on a *new* FETCH, but an agent that already read the placeholder won't auto-re-FETCH the same UID without a re-SELECT — noted in a `rawResolver` comment. The client-side re-fetch of exposed UIDs is tracked separately.

## Tests

- `TestIMAPAssessmentFirstReadWindow` — the keystone: still-pending-at-SELECT message, the triggering fetch serves the placeholder (masked Subject + placeholder body, never the attacker bytes), real raw persisted for the operator.
- `TestIMAPAssessmentHold` / `TestIMAPAssessmentAndFilterHold` — updated to placeholder-visible + approve→real.
- gofmt / vet / `go test -race ./...` / golangci-lint v2.11.4 all clean.

The Telegram hold-notification enrichment (assessment reason + fenced body) follows in a sibling PR, riding one point release with this.