### PR TITLE
ADR 0032 eager-at-ingest assessment + invisible/tombstone read-face

### DIFF
--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -76,6 +76,9 @@ func (failingInbound) Add(inbound.Delivery) (inbound.Message, error) {
 func (failingInbound) AddSynced(inbound.Delivery) (bool, inbound.Message, error) {
 	return false, inbound.Message{}, errors.New("inbound store down")
 }
+func (failingInbound) AddSyncedAssessed(inbound.Delivery, *inbound.Assessment) (bool, inbound.Message, error) {
+	return false, inbound.Message{}, errors.New("inbound store down")
+}
 func (failingInbound) AddSyncedPending(inbound.Delivery) (bool, inbound.Message, error) {
 	return false, inbound.Message{}, errors.New("inbound store down")
 }

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -37,11 +37,13 @@ type Syncer struct {
 }
 
 // AssessHook, when set, runs the injection assessment on a message's fetched
-// content at ingest and returns the disposition to persist alongside it (ADR
-// 0032). It runs once per message on the sync thread, off the agent-read path.
-// A nil hook (the default) disables assessment entirely: FetchContent behaves
-// exactly as before, storing no assessment. A nil *inbound.Assessment return
-// likewise means "not assessed" → normal flow.
+// content at ingest — during the sync pull, before the message is exposed to the
+// agent — and returns the disposition to persist alongside it (ADR 0032
+// Amendment 1, eager-at-ingest). It runs once per message on the sync thread, off
+// the agent-read path. A nil hook (the default) disables assessment entirely: the
+// pull stores headers-only pending records and the body is fetched lazily on read
+// (ADR 0019), with no assessment. A nil *inbound.Assessment return likewise means
+// "not assessed" → normal flow.
 type AssessHook func(inbox, from string, raw []byte, env *inbound.Envelope) *inbound.Assessment
 
 // SetAssessHook installs the injection-assessment hook (ADR 0032). Leaving it
@@ -185,15 +187,22 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 		return 0, ceiling, nil // nothing to fetch; advance the cursor to the ceiling
 	}
 
-	// Headers-only: ENVELOPE + RFC822.SIZE (stored as metadata so the read face
-	// serves FETCH ENVELOPE / RFC822Size / header SEARCH without the body) but no
-	// BODY[] — the body is fetched on demand when first read (lazy, ADR 0019).
-	cmd := c.Fetch(set, &imap.FetchOptions{
+	// Metadata always: ENVELOPE + RFC822.SIZE (stored so the read face serves FETCH
+	// ENVELOPE / RFC822Size / header SEARCH without the body). The body too when
+	// assessment is enabled, so the message is assessed and its disposition settled
+	// at ingest, before it is ever exposed to the agent (ADR 0032 Amendment 1,
+	// eager-at-ingest). With assessment off this stays headers-only and the body is
+	// fetched on demand when first read (lazy, ADR 0019).
+	opts := &imap.FetchOptions{
 		UID:        true,
 		Flags:      true, // custom keywords/labels (ADR 0020)
 		Envelope:   true,
 		RFC822Size: true,
-	})
+	}
+	if s.assess != nil {
+		opts.BodySection = []*imap.FetchItemBodySection{{}}
+	}
+	cmd := c.Fetch(set, opts)
 
 	stored, highest := 0, last
 	for {
@@ -213,9 +222,21 @@ func (s *Syncer) pull(c *imapclient.Client, uidValidity, uidNext, last uint32) (
 		d := deliveryOf(s.owner, s.inbox, m)
 		d.UpstreamUID = uid
 		d.UIDValidity = uidValidity
-		// Store headers-only (pending); the body is fetched on demand. Idempotent
-		// on (owner, UIDVALIDITY, UID): a re-fetched message is a no-op.
-		added, _, err := s.store.AddSyncedPending(d)
+		// Eager assessment (ADR 0032 Amendment 1): with a hook installed, assess the
+		// fetched body and store the message present + decided in one atomic write,
+		// so no reader ever sees a visible-unassessed record. The screener returns a
+		// fail-safe held (not-cleared) disposition when the body can't be assessed —
+		// a terminal failure, distinct from a transient fetch error, which aborts the
+		// pull below without advancing the cursor so the next sync retries. With no
+		// hook, store headers-only pending as before (lazy, ADR 0019). Idempotent on
+		// (owner, UIDVALIDITY, UID): a re-fetched message is a no-op.
+		var added bool
+		if s.assess != nil {
+			a := s.assess(s.inbox, d.From, d.Raw, d.Envelope)
+			added, _, err = s.store.AddSyncedAssessed(d, a)
+		} else {
+			added, _, err = s.store.AddSyncedPending(d)
+		}
 		if err != nil {
 			_ = cmd.Close()
 			return stored, highest, fmt.Errorf("imapsync: store uid %d: %w", uid, err)
@@ -391,14 +412,11 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 		}
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found: %w", id, m.UpstreamUID, inbound.ErrContentUnavailable)
 	}
-	// Assess the fetched content once, at ingest, off the agent-read path (ADR
-	// 0032). With no hook installed this is nil and the write is exactly the prior
-	// SetContent — no behavior change when assessment is off.
-	var assessment *inbound.Assessment
-	if s.assess != nil {
-		assessment = s.assess(inbox, m.From, raw, m.Envelope)
-	}
-	return s.store.SetContentAssessed(owner, inbox, id, raw, assessment)
+	// This lazy read-time fetch runs only when assessment is OFF (ADR 0019). With
+	// assessment ON, a message is assessed and stored present at ingest (pull, ADR
+	// 0032 Amendment 1), so it is never pending here — the assessment does not run
+	// on the agent-read path. Store the fetched body without assessment.
+	return s.store.SetContent(owner, inbox, id, raw)
 }
 
 // WriteKeywords replicates a message's keyword set to the upstream backend over a

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -243,36 +243,58 @@ func TestFetchContentFillsPending(t *testing.T) {
 }
 
 // The assessment hook runs once, at content fetch, and persists its disposition.
-// With no hook installed, no assessment is written — FetchContent is unchanged.
-func TestFetchContentAssessHook(t *testing.T) {
+// With no assess hook, sync stores headers-only pending records and the body is
+// fetched lazily on read, with no assessment (ADR 0019 unchanged).
+func TestSyncNoAssessHookLazy(t *testing.T) {
 	addr, user := startUpstream(t)
-	appendMsg(t, user, "Subject: a\r\n\r\nbody one") // uid 1
-	appendMsg(t, user, "Subject: b\r\n\r\nbody two") // uid 2
+	appendMsg(t, user, "Subject: a\r\n\r\nbody one")
 
 	store := newInbound(t)
 	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
-	_, m1, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1})
-	require.NoError(t, err)
-	_, m2, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 2, UIDValidity: 1})
+	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
 
-	// No hook: assessment off → nothing persisted.
-	off, err := syncer.FetchContent("agent", inbound.DefaultInbox, m1.ID)
+	list, err := store.List("agent", inbound.DefaultInbox)
 	require.NoError(t, err)
-	assert.Nil(t, off.Assessment, "with no hook installed, no assessment is written")
+	require.Len(t, list, 1)
+	assert.True(t, list[0].Pending, "no hook → headers-only pending record")
+	assert.Nil(t, list[0].Assessment)
 
-	// Hook installed: the fetched content is assessed and the disposition persisted.
+	filled, err := syncer.FetchContent("agent", inbound.DefaultInbox, list[0].ID)
+	require.NoError(t, err)
+	assert.Contains(t, string(filled.Raw), "body one")
+	assert.Nil(t, filled.Assessment, "the lazy read-time fetch never assesses")
+}
+
+// Eager-at-ingest (ADR 0032 Amendment 1): with the hook installed, sync fetches
+// the body, assesses it, and stores the message present + decided in one write —
+// never a visible-unassessed pending record — and the body is persisted for the
+// operator hold surface.
+func TestSyncEagerAssessAtIngest(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: danger\r\n\r\nattacker body")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
 	var gotRaw []byte
 	syncer.SetAssessHook(func(inbox, from string, raw []byte, _ *inbound.Envelope) *inbound.Assessment {
 		gotRaw = raw
 		return &inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"}
 	})
-	on, err := syncer.FetchContent("agent", inbound.DefaultInbox, m2.ID)
+	_, err := syncer.Sync(context.Background())
 	require.NoError(t, err)
-	require.NotNil(t, on.Assessment)
-	assert.Equal(t, inbound.AssessmentHeld, on.Assessment.Disposition)
-	assert.True(t, on.HeldByAssessment())
-	assert.Contains(t, string(gotRaw), "body two", "the hook receives the fetched content")
+
+	list, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.Len(t, list, 1)
+	assert.False(t, list[0].Pending, "eager → stored present, not pending")
+	require.NotNil(t, list[0].Assessment)
+	assert.True(t, list[0].HeldByAssessment())
+	assert.Contains(t, string(gotRaw), "attacker body", "the hook receives the fetched body at ingest")
+
+	got, err := store.Get("agent", inbound.DefaultInbox, list[0].ID)
+	require.NoError(t, err)
+	assert.Contains(t, string(got.Raw), "attacker body", "body persisted for the operator hold surface")
 }
 
 // A pending record whose UIDVALIDITY no longer matches upstream errors cleanly

--- a/internal/inbound/bbolt.go
+++ b/internal/inbound/bbolt.go
@@ -127,7 +127,7 @@ func (s *bboltStore) Add(d Delivery) (Message, error) {
 	var msg Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		var e error
-		msg, _, e = s.put(tx, d, false)
+		msg, _, e = s.put(tx, d, false, nil)
 		return e
 	})
 	if err != nil {
@@ -138,20 +138,28 @@ func (s *bboltStore) Add(d Delivery) (Message, error) {
 
 // AddSynced stores an upstream-pulled message (with content) idempotently.
 func (s *bboltStore) AddSynced(d Delivery) (bool, Message, error) {
-	return s.addSynced(d, false)
+	return s.addSynced(d, false, nil)
 }
 
 // AddSyncedPending stores a headers-only (pending) record idempotently — no
 // content blob; SetContent fills it later (lazy sync, ADR 0019).
 func (s *bboltStore) AddSyncedPending(d Delivery) (bool, Message, error) {
-	return s.addSynced(d, true)
+	return s.addSynced(d, true, nil)
+}
+
+// AddSyncedAssessed stores a present, already-assessed record in one write —
+// body blob + disposition together (ADR 0032 Amendment 1, eager-at-ingest) — so
+// no reader ever observes a visible-unassessed message. Idempotent like
+// AddSynced.
+func (s *bboltStore) AddSyncedAssessed(d Delivery, a *Assessment) (bool, Message, error) {
+	return s.addSynced(d, false, a)
 }
 
 // addSynced is the shared dedup path: if the upstream (owner, UIDValidity,
 // UpstreamUID) is already indexed it's a no-op (added=false, returns the
 // existing record), so a crash-mid-sync re-fetch never duplicates (#87);
 // otherwise it stores the message (pending or present) and indexes it.
-func (s *bboltStore) addSynced(d Delivery, pending bool) (bool, Message, error) {
+func (s *bboltStore) addSynced(d Delivery, pending bool, a *Assessment) (bool, Message, error) {
 	if d.UpstreamUID == 0 {
 		return false, Message{}, fmt.Errorf("inbound: AddSynced requires a non-zero upstream UID")
 	}
@@ -172,7 +180,7 @@ func (s *bboltStore) addSynced(d Delivery, pending bool) (bool, Message, error) 
 			}
 			return nil
 		}
-		m, key, err := s.put(tx, d, pending)
+		m, key, err := s.put(tx, d, pending, a)
 		if err != nil {
 			return err
 		}
@@ -252,7 +260,7 @@ func (s *bboltStore) putBlob(inbox, id string, raw []byte) ([]byte, error) {
 // put builds and persists a new message. For a present message it writes the
 // content blob first (ADR 0018 ordering); a pending message has no blob yet.
 // Returns the message and its bbolt key. The caller is inside a write txn.
-func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byte, error) {
+func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool, a *Assessment) (Message, []byte, error) {
 	b := tx.Bucket(bucketInbound)
 	seq, err := b.NextSequence()
 	if err != nil {
@@ -273,6 +281,7 @@ func (s *bboltStore) put(tx *bbolt.Tx, d Delivery, pending bool) (Message, []byt
 		Envelope:    d.Envelope,
 		Size:        d.Size,
 		Keywords:    d.Keywords,
+		Assessment:  a, // eager-at-ingest disposition (ADR 0032 A1); nil = not assessed
 	}
 	key := seqkey.Encode(seq)
 	blobbed := false

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -189,6 +189,12 @@ type InboundStore interface {
 	// content — for lazy sync (ADR 0019). Same idempotency as AddSynced; the
 	// Delivery's Raw is ignored. SetContent fills the body later.
 	AddSyncedPending(Delivery) (added bool, m Message, err error)
+	// AddSyncedAssessed stores a message present AND already-assessed in one atomic
+	// write — metadata, body, and the injection-assessment disposition together
+	// (ADR 0032 Amendment 1, eager-at-ingest). Same idempotency as AddSynced. Used
+	// when assessment is enabled so a message is decided before it is ever exposed,
+	// leaving no visible-unassessed window. Delivery.Raw is the fetched body.
+	AddSyncedAssessed(d Delivery, a *Assessment) (added bool, m Message, err error)
 	// SetContent fills a pending message's body (write the content blob, mark it
 	// present) and returns the now-complete message. Scoped to (owner, inbox).
 	SetContent(owner, inbox, id string, raw []byte) (Message, error)

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -245,12 +245,24 @@ func (s *imapSession) listAndFilter(inbox string) (full, visible []inbound.Messa
 				continue
 			}
 		}
-		// Injection assessment is a second security floor (ADR 0032), independent of
-		// the user filter: an assessment-held message stays hidden until the operator
-		// approves it, exactly like a filter Hold. A single HoldDecision releases the
-		// message past every hold source, so approving reveals it here too.
-		if m.HeldByAssessment() && m.HoldDecision != inbound.HoldApproved {
-			continue
+		// Injection assessment is a second security floor (ADR 0032 Amendment 1),
+		// independent of the user filter. Because the disposition is settled at
+		// ingest (eager), this is a pure read of decided state: an UNDECIDED hold is
+		// invisible (the agent shouldn't see it before a human decides), a REJECTED
+		// hold shows a system tombstone (see the serve path — the agent learns a
+		// message was received and reviewed out, with no attacker bytes), and an
+		// APPROVED hold flows through to the user filter with its real body. A single
+		// HoldDecision releases the message past every hold source.
+		if m.HeldByAssessment() {
+			switch m.HoldDecision {
+			case inbound.HoldApproved:
+				// exposed — apply the user filter to the real message below
+			case inbound.HoldRejected:
+				visible = append(visible, m) // tombstone-visible
+				continue
+			default:
+				continue // undecided → invisible
+			}
 		}
 		if flt == nil {
 			visible = append(visible, m)
@@ -458,14 +470,53 @@ func (s *imapSession) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, optio
 		// fetchMessage resolves content lazily: ENVELOPE / RFC822Size / header
 		// fields serve from stored metadata when present, and only a body request
 		// (or a record with no stored metadata) triggers getRaw. A resolve failure
-		// surfaces as an IMAP error, never empty/wrong content.
-		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options, s.rawResolver(*m))
+		// surfaces as an IMAP error, never empty/wrong content. A rejected-hold
+		// message serves the system tombstone for every content field (ADR 0032 A1).
+		tombstone := isTombstone(*m)
+		getRaw := s.rawResolver(*m)
+		if tombstone {
+			getRaw = tombstoneResolver
+		}
+		ferr = fetchMessage(w.CreateMessage(seqNum), *m, options, getRaw, tombstone)
 	})
 	return ferr
 }
 
 // rawFunc lazily resolves a message's raw content.
 type rawFunc func() ([]byte, error)
+
+// tombstoneSubject / tombstoneRaw are the system-authored stand-in served for a
+// REJECTED assessment hold (ADR 0032 Amendment 1): the agent sees that a message
+// was received and reviewed out, carrying no attacker-controlled bytes. Undecided
+// holds are invisible and approved holds serve the real message, so the tombstone
+// is the only placeholder in the model.
+const tombstoneSubject = "[message reviewed out]"
+
+var tombstoneRaw = []byte("From: Darbaan <darbaan@localhost>\r\n" +
+	"Subject: " + tombstoneSubject + "\r\n" +
+	"Content-Type: text/plain; charset=utf-8\r\n" +
+	"\r\n" +
+	"A message was received here and was reviewed out by the operator. Its content is not delivered to the agent.\r\n")
+
+// tombstoneEnvelope is the system envelope served for a rejected hold, so a FETCH
+// ENVELOPE (which serves from stored metadata, not the body) never leaks the real
+// message's attacker-controlled Subject/From.
+func tombstoneEnvelope() *imap.Envelope {
+	return &imap.Envelope{
+		Subject: tombstoneSubject,
+		From:    []imap.Address{{Name: "Darbaan", Mailbox: "darbaan", Host: "localhost"}},
+	}
+}
+
+// isTombstone reports whether m serves the rejected-hold tombstone rather than its
+// real content (ADR 0032 Amendment 1). Keyed on the decided disposition, which is
+// authoritative at read time because assessment is eager-at-ingest.
+func isTombstone(m inbound.Message) bool {
+	return m.HeldByAssessment() && m.HoldDecision == inbound.HoldRejected
+}
+
+// tombstoneResolver is a rawFunc that always yields the system tombstone body.
+func tombstoneResolver() ([]byte, error) { return tombstoneRaw, nil }
 
 // rawResolver returns a memoized resolver for a message's raw content: it calls
 // the content fetcher at most once, and only when a field actually needs the body
@@ -682,7 +733,13 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 		// criteria on records without stored metadata. If a candidate's content
 		// can't be resolved, skip it (degrade, don't [SERVERBUG] the whole SEARCH)
 		// — but log it: a skipped candidate is a silently-missing result.
-		ok, err := matchSearch(seqNum, m, criteria, s.rawResolver(*m))
+		// A rejected-hold message matches against its tombstone, not its real body,
+		// so SEARCH never leaks held content (ADR 0032 A1).
+		getRaw := s.rawResolver(*m)
+		if isTombstone(*m) {
+			getRaw = tombstoneResolver
+		}
+		ok, err := matchSearch(seqNum, m, criteria, getRaw)
 		if err != nil {
 			slog.Warn("imap search skipped message", "id", m.ID, "err", err)
 			continue
@@ -926,7 +983,7 @@ func (s *imapSession) Idle(_ *imapserver.UpdateWriter, stop <-chan struct{}) err
 	return nil
 }
 
-func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions, getRaw rawFunc) error {
+func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions, getRaw rawFunc, tombstone bool) error {
 	w.WriteUID(uidOf(m))
 	if options.Flags {
 		w.WriteFlags(flagList(m))
@@ -935,19 +992,36 @@ func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options 
 		w.WriteInternalDate(m.ReceivedAt)
 	}
 	if options.RFC822Size {
-		size, err := sizeOf(&m, getRaw)
-		if err != nil {
-			return err
+		// A tombstone reports the tombstone's length (getRaw yields it), not the
+		// stored size of the withheld real message (ADR 0032 A1).
+		if tombstone {
+			raw, err := getRaw()
+			if err != nil {
+				return err
+			}
+			w.WriteRFC822Size(int64(len(raw)))
+		} else {
+			size, err := sizeOf(&m, getRaw)
+			if err != nil {
+				return err
+			}
+			w.WriteRFC822Size(size)
 		}
-		w.WriteRFC822Size(size)
 	}
 	if options.Envelope {
-		env, err := envelopeFor(m, getRaw)
-		if err != nil {
-			return err
-		}
-		if env != nil {
-			w.WriteEnvelope(env)
+		// A tombstone serves a system envelope, so ENVELOPE (which reads stored
+		// metadata, not the body) never leaks the rejected message's real
+		// Subject/From (ADR 0032 A1).
+		if tombstone {
+			w.WriteEnvelope(tombstoneEnvelope())
+		} else {
+			env, err := envelopeFor(m, getRaw)
+			if err != nil {
+				return err
+			}
+			if env != nil {
+				w.WriteEnvelope(env)
+			}
 		}
 	}
 	if options.BodyStructure != nil {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -615,8 +615,9 @@ func TestIMAPFilterHidesMessages(t *testing.T) {
 	assert.Equal(t, "keep", msgs[0].Envelope.Subject) // only the allowed one is served
 }
 
-// An assessment-held message (ADR 0032) is hidden from the read face until the
-// operator approves it, exactly like a filter Hold; one approval reveals it.
+// An UNDECIDED assessment hold is invisible to the agent until the operator
+// decides; one approval reveals the real message (ADR 0032 Amendment 1). The
+// rejected→tombstone case is covered separately.
 func TestIMAPAssessmentHold(t *testing.T) {
 	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
 	require.NoError(t, err)
@@ -655,6 +656,46 @@ func TestIMAPAssessmentHold(t *testing.T) {
 	sel2, err := c2.Select("INBOX", nil).Wait()
 	require.NoError(t, err)
 	assert.Equal(t, uint32(2), sel2.NumMessages, "one approval reveals the held message")
+}
+
+// A REJECTED assessment hold is visible but serves a system tombstone — subject,
+// body, and size are all system-authored, never the real attacker-controlled
+// content (ADR 0032 Amendment 1).
+func TestIMAPAssessmentRejectedTombstone(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, held, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "danger", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "danger"},
+	})
+	require.NoError(t, err)
+	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, held.ID,
+		[]byte("Subject: danger\r\n\r\nattacker-body-do-this"),
+		&inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"})
+	require.NoError(t, err)
+	_, err = store.SetHoldDecision("agent", inbound.DefaultInbox, held.ID, inbound.HoldRejected)
+	require.NoError(t, err)
+
+	addr := startIMAPFull(t, store, nil, nil, nil)
+	c, err := imapclient.DialInsecure(addr, nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(1), sel.NumMessages, "a rejected hold is visible as a tombstone")
+
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		Envelope: true, BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "[message reviewed out]", msgs[0].Envelope.Subject, "tombstone subject, not the real one")
+	body := string(msgs[0].FindBodySection(&imap.FetchItemBodySection{}))
+	assert.Contains(t, body, "reviewed out by the operator", "tombstone body served")
+	assert.NotContains(t, body, "attacker-body-do-this", "real content withheld")
 }
 
 // A message held by BOTH assessment and a filter Hold stays hidden, and the


### PR DESCRIPTION
## What

Implements ADR 0032 Amendment 1 (#228), **superseding #226** (the lazy-trigger + placeholder-visible approach). The assessment now runs eagerly at the sync pull, so a message is decided before it is ever exposed to the agent — the first-read window is closed at its root, not patched at the read face.

## Ingest (`internal/imapsync` pull)

- When the assess hook is installed, the pull fetches `BODY[]` alongside `ENVELOPE`/`SIZE`, runs the screener, and stores the message **present + decided in one atomic write** via the new `store.AddSyncedAssessed` (metadata + body + disposition together) — so no reader ever observes a visible-unassessed record.
- With no hook, the pull stays headers-only/pending and the body is fetched lazily on read (ADR 0019 unchanged).
- Assessment leaves the agent-read path: `FetchContent` no longer assesses.
- **Fail-safe:** a transient upstream fetch failure aborts the pull without advancing the cursor, so the next sync retries (at-least-once); a terminal failure surfaces as the screener's fail-safe held (not-cleared) disposition.

## Read face (`internal/listener`)

A decided hold is a pure read of stored state (eager ⇒ the SELECT snapshot is authoritative, so no read-time resolve/race handling):
- **undecided → invisible**
- **approved → real body**
- **rejected → system tombstone** (subject, body, and size all system-authored, no attacker bytes), served for every content field including SEARCH.

## Store (`internal/inbound`)

New `AddSyncedAssessed(d, a)` — the atomic metadata+body+disposition write; `addSynced`/`put` thread the assessment. `AddSynced`/`AddSyncedPending` unchanged (nil assessment).

## Tests

- `TestSyncEagerAssessAtIngest` — hook installed → message stored present + held, body persisted for the operator surface, hook got the body.
- `TestSyncNoAssessHookLazy` — no hook → headers-only pending + lazy fill, no assessment (ADR 0019 preserved).
- `TestIMAPAssessmentRejectedTombstone` — rejected hold serves the tombstone, never the real content; existing undecided-invisible + approved-real tests pass unchanged.
- gofmt / vet / `go test -race ./...` / golangci-lint v2.11.4 all clean.

Lands atomically with #227 (Change A) — the operator hold surface's fenced body needs eager so an undecided hold has content to review. Closes #226.