### PR TITLE
fix: close ADR 0032 tombstone SEARCH/FLAGS leak + assess pre-flip backlog

### DIFF
--- a/cmd/darbaan/assessment_test.go
+++ b/cmd/darbaan/assessment_test.go
@@ -105,3 +105,24 @@ func TestBuildAssessHookEnabledProducesHeldAssessment(t *testing.T) {
 	assert.Equal(t, inbound.AssessmentHeld, a.Disposition) // unknown baseline + injection factors → held
 	assert.NotEmpty(t, a.Summary)
 }
+
+// C42/C6: the hook resolves per-sender trust on the NORMALIZED address parsed from
+// the raw From header (as the store's content-write chokepoint does), not the
+// caller's display-form `from` argument — so ADR 0031 per-sender rules can match.
+func TestBuildAssessHookResolvesTrustFromRawAddress(t *testing.T) {
+	cli := &CLI{AssessmentEnabled: true, AssessmentTimeout: time.Second}
+	var gotAddr string
+	resolve := func(inbox, from string) provenance.Stamp {
+		gotAddr = from
+		return provenance.Stamp{Trust: provenance.TrustTrusted}
+	}
+	hook, err := cli.buildAssessHook(nil, resolve, riskscore.DefaultConfig())
+	require.NoError(t, err)
+	require.NotNil(t, hook)
+
+	raw := []byte("From: Alice <ALICE@example.com>\r\nSubject: x\r\n\r\nhello")
+	// The caller passes a display-form From; the hook must ignore it and key trust
+	// on the raw's normalized RFC5321 address instead.
+	_ = hook(inbound.DefaultInbox, "Alice <ALICE@example.com>", raw, &inbound.Envelope{})
+	assert.Equal(t, "alice@example.com", gotAddr, "trust resolved on the normalized raw address, not the display form")
+}

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -551,8 +551,13 @@ func (cli *CLI) buildAssessHook(inboxes []inboxcfg.Inbox, resolve inbound.Proven
 	}
 	slog.Warn("injection assessment ENABLED (ADR 0032): high-risk inbound mail is held for the operator")
 	identity := inboxIdentities(inboxes)
-	return func(inbox, from string, raw []byte, env *inbound.Envelope) *inbound.Assessment {
-		trust := resolve(inbox, from).Trust
+	// Resolve trust on the normalized RFC5321 sender address parsed from the raw
+	// (as the store's content-write chokepoint does), NOT the caller's display-form
+	// "Name <addr>" From — ADR 0031 per-sender rules match the bare address, so a
+	// display form would never match and would silently fail open (C42/C6). The
+	// caller's `from` argument is therefore unused here.
+	return func(inbox, _ string, raw []byte, env *inbound.Envelope) *inbound.Assessment {
+		trust := resolve(inbox, provenance.From(raw)).Trust
 		var to, cc []string
 		if env != nil {
 			to = envAddrStrings(env.To)

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -412,11 +412,33 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 		}
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found: %w", id, m.UpstreamUID, inbound.ErrContentUnavailable)
 	}
-	// This lazy read-time fetch runs only when assessment is OFF (ADR 0019). With
-	// assessment ON, a message is assessed and stored present at ingest (pull, ADR
-	// 0032 Amendment 1), so it is never pending here — the assessment does not run
-	// on the agent-read path. Store the fetched body without assessment.
-	return s.store.SetContent(owner, inbox, id, raw)
+	// Steady state: with assessment ON a message is assessed and stored present at
+	// ingest (pull, ADR 0032 Amendment 1), so it is never pending here. The
+	// exception is the flag-flip TRANSITION backlog — records synced while
+	// assessment was OFF are still pending when the flag is later enabled, and a
+	// naive SetContent would store their bodies un-assessed, a visible-unassessed
+	// leak the Amendment forbids. So when a hook is installed, assess this pre-flip
+	// record's freshly-fetched body here as a fallback and store it present +
+	// decided, exactly as the ingest path would have. If that assessment HOLDS the
+	// message, do not surface its body on THIS in-flight read — the next SELECT
+	// re-reads the now-decided disposition and hides (undecided) or tombstones
+	// (rejected) it; clearing Raw keeps the triggering FETCH from serving a body the
+	// operator has not exposed. With no hook (assessment off) this is the plain lazy
+	// path, byte-identical to before (ADR 0019).
+	if s.assess == nil {
+		return s.store.SetContent(owner, inbox, id, raw)
+	}
+	a := s.assess(s.inbox, m.From, raw, m.Envelope)
+	full, err := s.store.SetContentAssessed(owner, inbox, id, raw, a)
+	if err != nil {
+		return inbound.Message{}, err
+	}
+	if full.HeldByAssessment() && full.HoldDecision != inbound.HoldApproved {
+		s.logger.Warn("assessed a pre-flip backlog record on read; holding for the operator",
+			"id", id, "inbox", inbound.NormInbox(inbox))
+		full.Raw = nil // withhold the un-exposed body from the triggering fetch
+	}
+	return full, nil
 }
 
 // WriteKeywords replicates a message's keyword set to the upstream backend over a

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -341,7 +341,13 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 		return inbound.Message{}, err
 	}
 	if !m.Pending {
-		return m, nil // already present — no upstream contact
+		// Already present — no upstream contact. Still gate the body: a held-and-
+		// unapproved record (stored present by the transition fallback below, or by
+		// eager ingest) must never yield its real body on the read path, even on a
+		// REPEAT fetch — the IMAP snapshot may predate the hold decision, so this is
+		// the authoritative withhold, not just the triggering fetch. The operator
+		// surface reads the stored body via store.Get and is unaffected.
+		return withheldIfHeld(m), nil
 	}
 
 	c, err := s.dial()
@@ -436,9 +442,21 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 	if full.HeldByAssessment() && full.HoldDecision != inbound.HoldApproved {
 		s.logger.Warn("assessed a pre-flip backlog record on read; holding for the operator",
 			"id", id, "inbox", inbound.NormInbox(inbox))
-		full.Raw = nil // withhold the un-exposed body from the triggering fetch
 	}
-	return full, nil
+	return withheldIfHeld(full), nil
+}
+
+// withheldIfHeld blanks a message's body when the injection assessment holds it
+// and the operator has not approved exposure, so the lazy content path never
+// yields an un-exposed held body on ANY fetch — including a repeat fetch of a
+// record already stored present (ADR 0032 Amendment 1). The real body stays in the
+// store for the operator hold surface (read via store.Get); a later SELECT re-reads
+// the decided state and hides (undecided) or tombstones (rejected) it.
+func withheldIfHeld(m inbound.Message) inbound.Message {
+	if m.HeldByAssessment() && m.HoldDecision != inbound.HoldApproved {
+		m.Raw = nil
+	}
+	return m
 }
 
 // WriteKeywords replicates a message's keyword set to the upstream backend over a

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -297,6 +297,62 @@ func TestSyncEagerAssessAtIngest(t *testing.T) {
 	assert.Contains(t, string(got.Raw), "attacker body", "body persisted for the operator hold surface")
 }
 
+// Flag-flip transition backlog (ADR 0032 Amendment 1, C43): a record synced while
+// assessment was OFF is still pending when the flag is later enabled. FetchContent
+// must assess its body as a fallback rather than storing it un-assessed. The hold
+// disposition persists, the real body is kept for the operator surface, and the
+// triggering fetch does NOT surface the un-exposed body.
+func TestFetchContentAssessesPreFlipBacklog(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: danger\r\n\r\nattacker body do this") // upstream UID 1
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	syncer.SetAssessHook(func(inbox, from string, raw []byte, _ *inbound.Envelope) *inbound.Assessment {
+		return &inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"}
+	})
+
+	// Pre-flip: a headers-only pending record, as synced before the hook existed.
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "danger", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+	require.True(t, m.Pending)
+
+	got, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Assessment, "the pre-flip record is assessed on read, not stored un-assessed")
+	assert.True(t, got.HeldByAssessment())
+	assert.Empty(t, got.Raw, "an un-exposed held body is withheld from the triggering fetch")
+
+	// The record is now present + decided in the store, and the real body is kept
+	// for the operator hold surface (HeldContent reads it via store.Get).
+	stored, err := store.Get("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.False(t, stored.Pending, "no longer a visible-unassessed pending record")
+	assert.True(t, stored.HeldByAssessment())
+	assert.Contains(t, string(stored.Raw), "attacker body", "real body persisted for the operator surface")
+}
+
+// A pre-flip pending record the fallback assessment CLEARS (agent-handled) fills
+// its body normally — the transition fallback only withholds a held body.
+func TestFetchContentPreFlipClearedFlows(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: ok\r\n\r\nharmless body")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	syncer.SetAssessHook(func(inbox, from string, raw []byte, _ *inbound.Envelope) *inbound.Assessment {
+		return &inbound.Assessment{Disposition: inbound.AssessmentAgentHandled}
+	})
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "ok", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+
+	got, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Pending)
+	assert.False(t, got.HeldByAssessment())
+	assert.Contains(t, string(got.Raw), "harmless body", "a cleared message flows to the agent as before")
+}
+
 // A pending record whose UIDVALIDITY no longer matches upstream errors cleanly
 // (stale UID) rather than serving wrong/empty content.
 func TestFetchContentStaleUIDValidity(t *testing.T) {

--- a/internal/imapsync/imapsync_test.go
+++ b/internal/imapsync/imapsync_test.go
@@ -332,6 +332,41 @@ func TestFetchContentAssessesPreFlipBacklog(t *testing.T) {
 	assert.Contains(t, string(stored.Raw), "attacker body", "real body persisted for the operator surface")
 }
 
+// The held body is withheld on EVERY read-path fetch, not just the triggering one
+// (review C43 bypass): once the record is stored present, a repeat FetchContent
+// must not serve the real body via the !Pending early return. It flows only after
+// the operator approves exposure.
+func TestFetchContentHeldBodyWithheldOnRepeatFetch(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "Subject: danger\r\n\r\nattacker body do this")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	syncer.SetAssessHook(func(inbox, from string, raw []byte, _ *inbound.Envelope) *inbound.Assessment {
+		return &inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"}
+	})
+	_, m, err := store.AddSyncedPending(inbound.Delivery{Owner: "agent", Subject: "danger", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+
+	first, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.Empty(t, first.Raw, "held body withheld from the triggering fetch")
+
+	// The record is now present in the store; a REPEAT fetch (the !Pending early
+	// return) must still withhold — this is the bypass the review caught.
+	second, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.True(t, second.HeldByAssessment())
+	assert.Empty(t, second.Raw, "held body still withheld on a repeat fetch (no !Pending bypass)")
+
+	// Once the operator approves exposure, the body flows.
+	_, err = store.SetHoldDecision("agent", inbound.DefaultInbox, m.ID, inbound.HoldApproved)
+	require.NoError(t, err)
+	approved, err := syncer.FetchContent("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	assert.Contains(t, string(approved.Raw), "attacker body", "approved → body flows")
+}
+
 // A pre-flip pending record the fallback assessment CLEARS (agent-handled) fills
 // its body normally — the transition fallback only withholds a held body.
 func TestFetchContentPreFlipClearedFlows(t *testing.T) {

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -564,6 +564,18 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 			var full inbound.Message
 			switch full, err = s.fetch(m.Owner, s.selectedInbox, m.ID); {
 			case err == nil:
+				// Authoritative hold gate (ADR 0032 A1): the selected snapshot is taken
+				// at SELECT and can predate a hold decision (e.g. a pre-flip record
+				// assessed on its first read, or any mid-session hold), so isTombstone on
+				// the snapshot may be false for a now-held record. Re-check the freshly
+				// fetched record and never serve the real body of a message held by
+				// assessment and not operator-approved — whatever the ContentFetch wiring.
+				// A REJECTED hold is already served as a tombstone by the caller; this
+				// closes the UNDECIDED (invisible) stale-snapshot race.
+				if full.HeldByAssessment() && full.HoldDecision != inbound.HoldApproved {
+					raw = nil
+					break
+				}
 				raw = full.Raw
 				// Serve-path backstop (ADR 0030 slice 5): re-run the same sanitize +
 				// stamp as the write chokepoint, keyed strictly on the session's

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -498,13 +498,42 @@ var tombstoneRaw = []byte("From: Darbaan <darbaan@localhost>\r\n" +
 	"\r\n" +
 	"A message was received here and was reviewed out by the operator. Its content is not delivered to the agent.\r\n")
 
+// tombstoneInboundEnvelope is the system envelope for a rejected hold in the
+// store's IMAP-free form. It is the single source of truth for the tombstone's
+// Subject/From, shared by the FETCH ENVELOPE path (via tombstoneEnvelope) and the
+// SEARCH match path (via tombstoneMessage), so the two can never drift.
+func tombstoneInboundEnvelope() *inbound.Envelope {
+	return &inbound.Envelope{
+		Subject: tombstoneSubject,
+		From:    []inbound.Address{{Name: "Darbaan", Mailbox: "darbaan", Host: "localhost"}},
+	}
+}
+
 // tombstoneEnvelope is the system envelope served for a rejected hold, so a FETCH
 // ENVELOPE (which serves from stored metadata, not the body) never leaks the real
 // message's attacker-controlled Subject/From.
 func tombstoneEnvelope() *imap.Envelope {
-	return &imap.Envelope{
-		Subject: tombstoneSubject,
-		From:    []imap.Address{{Name: "Darbaan", Mailbox: "darbaan", Host: "localhost"}},
+	return toIMAPEnvelope(tombstoneInboundEnvelope())
+}
+
+// tombstoneMessage returns a synthetic record standing in for a rejected-hold
+// message wherever the read face MATCHES or REPORTS metadata — SEARCH criteria and
+// FETCH FLAGS — so neither becomes an oracle over the withheld message's
+// attacker-controlled envelope, size, or keywords (ADR 0032 Amendment 1). It
+// mirrors the FETCH tombstone content path: the system envelope, the tombstone
+// body's length as Size, and no keywords. UID (via ID), received date, and the
+// agent's \Seen read-state are Darbaan-tracked (not attacker content) and are
+// preserved, so mailbox positioning and read-tracking stay correct and consistent
+// between the SEARCH and FETCH tombstone views.
+func tombstoneMessage(m inbound.Message) inbound.Message {
+	return inbound.Message{
+		ID:         m.ID,
+		Owner:      m.Owner,
+		Inbox:      m.Inbox,
+		ReceivedAt: m.ReceivedAt,
+		Seen:       m.Seen,
+		Size:       int64(len(tombstoneRaw)),
+		Envelope:   tombstoneInboundEnvelope(),
 	}
 }
 
@@ -733,13 +762,19 @@ func (s *imapSession) Search(numKind imapserver.NumKind, criteria *imap.SearchCr
 		// criteria on records without stored metadata. If a candidate's content
 		// can't be resolved, skip it (degrade, don't [SERVERBUG] the whole SEARCH)
 		// — but log it: a skipped candidate is a silently-missing result.
-		// A rejected-hold message matches against its tombstone, not its real body,
-		// so SEARCH never leaks held content (ADR 0032 A1).
+		// A rejected-hold message is matched against a SYNTHETIC tombstone record
+		// (system envelope, tombstone-body size, no keywords) and its body against
+		// the tombstone, so SEARCH never becomes an oracle over the withheld
+		// message's real subject/sender/size/keywords (ADR 0032 A1). Mirrors the
+		// FETCH tombstone path; the response still keys on the real seq/UID position.
+		match := m
 		getRaw := s.rawResolver(*m)
 		if isTombstone(*m) {
+			t := tombstoneMessage(*m)
+			match = &t
 			getRaw = tombstoneResolver
 		}
-		ok, err := matchSearch(seqNum, m, criteria, getRaw)
+		ok, err := matchSearch(seqNum, match, criteria, getRaw)
 		if err != nil {
 			slog.Warn("imap search skipped message", "id", m.ID, "err", err)
 			continue
@@ -986,7 +1021,14 @@ func (s *imapSession) Idle(_ *imapserver.UpdateWriter, stop <-chan struct{}) err
 func fetchMessage(w *imapserver.FetchResponseWriter, m inbound.Message, options *imap.FetchOptions, getRaw rawFunc, tombstone bool) error {
 	w.WriteUID(uidOf(m))
 	if options.Flags {
-		w.WriteFlags(flagList(m))
+		// A tombstone advertises only system flags (the agent's \Seen read-state) —
+		// never the withheld message's real keywords/labels — matching the SEARCH
+		// tombstone match record (ADR 0032 A1).
+		if tombstone {
+			w.WriteFlags(flagList(tombstoneMessage(m)))
+		} else {
+			w.WriteFlags(flagList(m))
+		}
 	}
 	if options.InternalDate {
 		w.WriteInternalDate(m.ReceivedAt)

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -766,6 +766,50 @@ func TestIMAPAssessmentTombstoneSearchAndFlagsNoLeak(t *testing.T) {
 		"real keyword withheld from tombstone FLAGS")
 }
 
+// Defense-in-depth (review C43 bypass): if a message is held by assessment but the
+// session's SELECT snapshot predates that decision, the serve path must still
+// withhold its real body — rawResolver re-checks the freshly-fetched hold state, so
+// a stale snapshot can't serve an un-exposed held body on a repeat fetch.
+func TestIMAPStaleSnapshotHeldBodyWithheld(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, m, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "ok", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "ok"},
+	})
+	require.NoError(t, err)
+	// Present + CLEARED, so the message is visible at SELECT (not held in the snapshot).
+	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, m.ID,
+		[]byte("Subject: ok\r\n\r\nsecret-body"),
+		&inbound.Assessment{Disposition: inbound.AssessmentAgentHandled})
+	require.NoError(t, err)
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, nil, nil), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), sel.NumMessages, "visible at SELECT — the snapshot predates the hold")
+
+	// The message is re-assessed HELD after SELECT: the session's snapshot is now stale.
+	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, m.ID,
+		[]byte("Subject: ok\r\n\r\nsecret-body"),
+		&inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"})
+	require.NoError(t, err)
+
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	body := string(msgs[0].FindBodySection(&imap.FetchItemBodySection{}))
+	assert.NotContains(t, body, "secret-body", "a held-unapproved body is withheld even from a stale snapshot")
+	assert.Empty(t, strings.TrimSpace(body), "served an inert empty body, not the real content")
+}
+
 // A message held by BOTH assessment and a filter Hold stays hidden, and the
 // single HoldDecision releases it past both sources (the documented model).
 func TestIMAPAssessmentAndFilterHold(t *testing.T) {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -698,6 +698,74 @@ func TestIMAPAssessmentRejectedTombstone(t *testing.T) {
 	assert.NotContains(t, body, "attacker-body-do-this", "real content withheld")
 }
 
+// A REJECTED tombstone must not leak the withheld message's real metadata through
+// SEARCH or FETCH FLAGS: matching Subject/From, size (LARGER/SMALLER), and custom
+// keywords all resolve against the system tombstone, never the attacker-controlled
+// record — closing the SEARCH/FLAGS oracle (ADR 0032 Amendment 1, C41). The prior
+// tests cover the FETCH ENVELOPE/BODY/SIZE tombstone; this covers the match paths.
+func TestIMAPAssessmentTombstoneSearchAndFlagsNoLeak(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, held, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "attack-subject", UpstreamUID: 1, UIDValidity: 1,
+		Size:     100000, // real size, far larger than the tombstone
+		Keywords: []string{"secretlabel"},
+		Envelope: &inbound.Envelope{
+			Subject: "attack-subject",
+			From:    []inbound.Address{{Mailbox: "attacker", Host: "evil.test"}},
+		},
+	})
+	require.NoError(t, err)
+	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, held.ID,
+		[]byte("Subject: attack-subject\r\n\r\nattacker-body-do-this"),
+		&inbound.Assessment{Disposition: inbound.AssessmentHeld, Summary: "flagged"})
+	require.NoError(t, err)
+	_, err = store.SetHoldDecision("agent", inbound.DefaultInbox, held.ID, inbound.HoldRejected)
+	require.NoError(t, err)
+
+	c, err := imapclient.DialInsecure(startIMAPFull(t, store, nil, nil, nil), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	sel, err := c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), sel.NumMessages, "a rejected hold is visible as a tombstone")
+
+	search := func(cr *imap.SearchCriteria) []uint32 {
+		res, serr := c.Search(cr, nil).Wait()
+		require.NoError(t, serr)
+		return res.AllSeqNums()
+	}
+
+	// SUBJECT/FROM over the REAL values must NOT match — the oracle is closed...
+	assert.Empty(t, search(&imap.SearchCriteria{
+		Header: []imap.SearchCriteriaHeaderField{{Key: "Subject", Value: "attack-subject"}},
+	}), "real subject not searchable")
+	assert.Empty(t, search(&imap.SearchCriteria{
+		Header: []imap.SearchCriteriaHeaderField{{Key: "From", Value: "attacker"}},
+	}), "real sender not searchable")
+	// ...while the tombstone's own subject IS what's searchable (what's served).
+	assert.Equal(t, []uint32{1}, search(&imap.SearchCriteria{
+		Header: []imap.SearchCriteriaHeaderField{{Key: "Subject", Value: "reviewed out"}},
+	}), "tombstone subject is what's searchable")
+
+	// LARGER/SMALLER resolve against the small tombstone size, never the real
+	// 100000 — so the withheld message's size can't be probed.
+	assert.Empty(t, search(&imap.SearchCriteria{Larger: 10000}),
+		"real (large) size not probeable via LARGER")
+	assert.Equal(t, []uint32{1}, search(&imap.SearchCriteria{Smaller: 10000}),
+		"tombstone is small — matches SMALLER, confirming the real size is masked")
+
+	// FETCH FLAGS must not carry the withheld message's real keyword.
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{Flags: true}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.NotContains(t, msgs[0].Flags, imap.Flag("secretlabel"),
+		"real keyword withheld from tombstone FLAGS")
+}
+
 // A message held by BOTH assessment and a filter Hold stays hidden, and the
 // single HoldDecision releases it past both sources (the documented model).
 func TestIMAPAssessmentAndFilterHold(t *testing.T) {


### PR DESCRIPTION
Follow-up hardening for the ADR 0032 Amendment 1 eager/invisible/tombstone model now live on the gate. Three fixes, one focused PR, with tests.

## C41 — HIGH / security (`internal/listener/imap.go`)
A **rejected** assessment hold correctly served a system tombstone for FETCH ENVELOPE / BODY / SIZE, but two paths still read the **real** record:
- `SEARCH` matched `matchHeader` against the stored `m.Envelope` (SUBJECT/FROM/TO) and `sizeOf` against the real `m.Size` (LARGER/SMALLER).
- FETCH `FLAGS` served `flagList(m)` with the real keywords.

So `SEARCH SUBJECT/FROM/LARGER/SMALLER` and FETCH `FLAGS` were an **oracle** over a withheld message's attacker-controlled subject, sender, size, and labels.

**Fix:** a shared `tombstoneMessage` helper builds a synthetic record — system envelope, tombstone-body `Size`, no keywords — and both the SEARCH match path and the FETCH flag path use it, so the SEARCH and FETCH tombstone views can't drift. UID, received date, and `\Seen` (Darbaan-tracked, not attacker content) stay real so positioning and read-tracking are unaffected.

**Tests:** `TestIMAPAssessmentTombstoneSearchAndFlagsNoLeak` — SEARCH SUBJECT/FROM over the real values returns nothing, the tombstone subject matches, LARGER/SMALLER resolve to the small tombstone size, and FETCH FLAGS omit the real keyword.

## C43 — MEDIUM / adr-deviation (`internal/imapsync/imapsync.go`)
Records synced while assessment was OFF stay `Pending`. Once the flag is enabled they were still listable and their bodies fetched lazily via `FetchContent` and stored with plain `SetContent` — **un-assessed**, violating the Amendment's "no inbound message is ever visible-unassessed."

**Fix:** when a hook is installed, `FetchContent` assesses a pending record's freshly-fetched body as a fallback and stores it present + decided (the ingest path's outcome, applied late). If the fallback **holds** the message, its body is withheld from the triggering fetch (`Raw` cleared) and the next SELECT hides (undecided) or tombstones (rejected) it; the real body is still persisted for the operator hold surface. Assessment-off is byte-identical to before.

**Residual (documented, not a regression):** this closes the un-assessed-body hole for the pre-flip backlog at read time. A pre-flip record's *metadata* (envelope) remains listable until its first read re-dispositions it — inherent to the lazy path. A proactive startup backfill would additionally mask that metadata window; happy to file/do it as a fast-follow if we want the stronger guarantee (it's a heavier change on the live gate — a mass upstream re-fetch of the backlog — so I kept it out of this security-first PR).

**Tests:** `TestFetchContentAssessesPreFlipBacklog` (held → assessed, body withheld from the fetch, real body persisted) and `TestFetchContentPreFlipClearedFlows` (cleared → flows normally).

## C42/C6 — low, same-path fold (`cmd/darbaan/main.go`)
The assess hook resolved per-sender trust on the caller's **display-form** `Name <addr>` From, so ADR 0031 per-sender rules never matched (fail-open). Now it resolves on the normalized RFC5321 address parsed from the raw, exactly as the store's content-write chokepoint does.

**Test:** `TestBuildAssessHookResolvesTrustFromRawAddress`.

## Cross-package touch
Primary change is `internal/listener` (C41). `internal/imapsync` (C43) and `cmd/darbaan` (C42/C6) are touched for the same ADR 0032 amendment surface; no shared types change (the `AssessHook` signature is unchanged).

## Verification
`gofmt` · `go build ./...` · `go vet` · `go test -race ./...` · `golangci-lint v2.11.4` — all clean.
