### PR TITLE
fix: harden outbound approve/queue path — pre-commit ApproveAs, transient enqueue, sanitize operator tables

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -1327,7 +1327,7 @@ func (*QueueLsCmd) Run(cli *CLI) error {
 	_, _ = fmt.Fprintln(w, "ID\tSTATUS\tAGENT\tFROM\tSUBJECT\tRCPT\tSIZE\tRECEIVED")
 	for _, m := range metas {
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
-			m.ID, m.Status, m.Agent, m.From, truncate(m.Subject, 40), len(m.Rcpt), m.Size, m.ReceivedAt.Format(time.RFC3339))
+			m.ID, m.Status, sanitizeField(m.Agent), sanitizeField(m.From), truncate(sanitizeField(m.Subject), 40), len(m.Rcpt), m.Size, m.ReceivedAt.Format(time.RFC3339))
 	}
 	return w.Flush()
 }
@@ -1338,6 +1338,30 @@ func truncate(s string, n int) string {
 		return string(r[:n-1]) + "…"
 	}
 	return s
+}
+
+// sanitizeField neutralizes attacker-controlled header text (From/Subject) before
+// it reaches the operator's terminal on the decision surface (C22). A MIME
+// encoded-word can decode to CR/LF/ESC or Unicode bidi/zero-width runes that
+// rewrite what the human sees while they choose whether to expose a message; every
+// such rune is replaced with U+FFFD. Apply before truncate so the rune budget
+// counts cleaned text.
+func sanitizeField(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch {
+		case r < 0x20, r == 0x7f: // C0 controls + DEL
+			return '�'
+		case r >= 0x80 && r <= 0x9f: // C1 controls
+			return '�'
+		case r == 0x200e || r == 0x200f, // LRM / RLM
+			r >= 0x202a && r <= 0x202e, // LRE / RLE / PDF / LRO / RLO
+			r >= 0x2066 && r <= 0x2069: // LRI / RLI / FSI / PDI
+			return '�'
+		case r == 0x200b || r == 0x200c || r == 0x200d || r == 0xfeff: // ZWSP / ZWNJ / ZWJ / BOM
+			return '�'
+		}
+		return r
+	}, s)
 }
 
 // QueueShowCmd dumps a held message's raw RFC 822.
@@ -1432,7 +1456,7 @@ func (*HoldsLsCmd) Run(cli *CLI) error {
 	_, _ = fmt.Fprintln(w, "ID\tFROM\tSUBJECT\tRECEIVED")
 	for _, m := range held {
 		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
-			m.ID, m.From, truncate(m.Subject, 40), m.ReceivedAt.Format(time.RFC3339))
+			m.ID, sanitizeField(m.From), truncate(sanitizeField(m.Subject), 40), m.ReceivedAt.Format(time.RFC3339))
 	}
 	if err := w.Flush(); err != nil {
 		return err

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -1346,6 +1346,14 @@ func truncate(s string, n int) string {
 // rewrite what the human sees while they choose whether to expose a message; every
 // such rune is replaced with U+FFFD. Apply before truncate so the rune budget
 // counts cleaned text.
+//
+// U+200C (ZWNJ) is deliberately passed through: it is a semantic joiner in Persian
+// (and other scripts) that changes word meaning (mi-ravad vs miravad), so
+// neutralizing it corrupts legitimate subjects for the very operators reading this
+// surface. It carries no reordering or escape-injection capability, so it is not a
+// terminal-hijack vector — unlike the bidi controls (U+061C ALM, LRM/RLM, the
+// LRE..RLO embeddings/overrides, and the isolates) and the remaining zero-width
+// runes, which stay neutralized.
 func sanitizeField(s string) string {
 	return strings.Map(func(r rune) rune {
 		switch {
@@ -1353,11 +1361,12 @@ func sanitizeField(s string) string {
 			return '�'
 		case r >= 0x80 && r <= 0x9f: // C1 controls
 			return '�'
-		case r == 0x200e || r == 0x200f, // LRM / RLM
+		case r == 0x061c, // ALM (Arabic Letter Mark)
+			r == 0x200e || r == 0x200f, // LRM / RLM
 			r >= 0x202a && r <= 0x202e, // LRE / RLE / PDF / LRO / RLO
 			r >= 0x2066 && r <= 0x2069: // LRI / RLI / FSI / PDI
 			return '�'
-		case r == 0x200b || r == 0x200c || r == 0x200d || r == 0xfeff: // ZWSP / ZWNJ / ZWJ / BOM
+		case r == 0x200b || r == 0x200d || r == 0xfeff: // ZWSP / ZWJ / BOM (ZWNJ U+200C passes through)
 			return '�'
 		}
 		return r

--- a/cmd/darbaan/sanitize_test.go
+++ b/cmd/darbaan/sanitize_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// C22: sanitizeField must neutralize every control / bidi / zero-width rune an
+// attacker can smuggle through a MIME encoded-word From/Subject, so the operator's
+// terminal shows only inert text on the decision surface. The invisible runes are
+// written as \u escapes so no hidden byte lives in this source.
+func TestSanitizeFieldStripsTerminalControlRunes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"CRLF", "spoofed\r\nInjected: header"},
+		{"ESC-CSI", "clear\x1b[2Jscreen"},
+		{"NUL+BEL+DEL", "a\x00b\x07c\x7f"},
+		{"C1-control", "a\x85b"},
+		{"bidi-override-RLO", "user\u202egnp.exe"},
+		{"bidi-isolate", "a\u2066b\u2069c"},
+		{"zero-width", "acme\u200bcorp\u200d.example"},
+		{"BOM", "\ufeffheader"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeField(tc.in)
+			for _, r := range got {
+				assert.Falsef(t, isDangerousRune(r), "rune %U survived sanitization in %q", r, got)
+			}
+		})
+	}
+}
+
+// Ordinary text (including non-ASCII letters and legitimate spaces) passes through
+// unchanged - sanitization must not mangle real subjects/senders.
+func TestSanitizeFieldPreservesOrdinaryText(t *testing.T) {
+	for _, s := range []string{
+		"Alice <alice@example.com>",
+		"Re: quarterly report \U00002014cafe resume",
+		"invoice \U000053d1\U00007968",
+		"emoji ok \U0001f381",
+	} {
+		assert.Equal(t, s, sanitizeField(s))
+	}
+	// A control rune is replaced with U+FFFD exactly where it stood.
+	assert.Equal(t, "a\ufffdb", sanitizeField("a\nb"))
+	assert.NotContains(t, sanitizeField("x\ry"), "\r")
+}
+
+// isDangerousRune mirrors the classes sanitizeField neutralizes, for the
+// post-condition assertion above.
+func isDangerousRune(r rune) bool {
+	switch {
+	case r < 0x20, r == 0x7f:
+		return true
+	case r >= 0x80 && r <= 0x9f:
+		return true
+	case r == 0x200e || r == 0x200f,
+		r >= 0x202a && r <= 0x202e,
+		r >= 0x2066 && r <= 0x2069:
+		return true
+	case r == 0x200b || r == 0x200c || r == 0x200d || r == 0xfeff:
+		return true
+	}
+	return false
+}

--- a/cmd/darbaan/sanitize_test.go
+++ b/cmd/darbaan/sanitize_test.go
@@ -23,6 +23,7 @@ func TestSanitizeFieldStripsTerminalControlRunes(t *testing.T) {
 		{"bidi-isolate", "a\u2066b\u2069c"},
 		{"zero-width", "acme\u200bcorp\u200d.example"},
 		{"BOM", "\ufeffheader"},
+		{"ALM-bidi", "a\u061cb"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -42,6 +43,9 @@ func TestSanitizeFieldPreservesOrdinaryText(t *testing.T) {
 		"Re: quarterly report \U00002014cafe resume",
 		"invoice \U000053d1\U00007968",
 		"emoji ok \U0001f381",
+		// U+200C (ZWNJ) is a semantic Persian joiner and must pass through
+		// unchanged (mi<ZWNJ>ravad), not become a replacement char.
+		"mi\u200cravad",
 	} {
 		assert.Equal(t, s, sanitizeField(s))
 	}
@@ -58,11 +62,12 @@ func isDangerousRune(r rune) bool {
 		return true
 	case r >= 0x80 && r <= 0x9f:
 		return true
-	case r == 0x200e || r == 0x200f,
+	case r == 0x061c,
+		r == 0x200e || r == 0x200f,
 		r >= 0x202a && r <= 0x202e,
 		r >= 0x2066 && r <= 0x2069:
 		return true
-	case r == 0x200b || r == 0x200c || r == 0x200d || r == 0xfeff:
+	case r == 0x200b || r == 0x200d || r == 0xfeff:
 		return true
 	}
 	return false

--- a/internal/admin/change_sender_test.go
+++ b/internal/admin/change_sender_test.go
@@ -56,6 +56,44 @@ func TestApproveAsUnknownInbox(t *testing.T) {
 
 	_, err = svc.ApproveAs(context.Background(), m.ID, "nope")
 	assert.ErrorIs(t, err, admin.ErrUnknownInbox)
+
+	// C5: the failed ApproveAs must not have committed the approve verdict — the
+	// message stays pending and re-approvable, never stranded in `approved` with
+	// no send attempted.
+	stored, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusPending, stored.Status, "unknown-inbox ApproveAs must leave the message pending")
+
+	// And a plain approve still works afterwards (the strand would have made this
+	// fail with ErrNotPending). The default StubSender leaves it `approved` (no real
+	// upstream), which is the un-stranded success we care about here.
+	out, err := svc.ApproveID(context.Background(), m.ID)
+	require.NoError(t, err)
+	assert.NotEqual(t, sluice.StatusPending, sluice.Status(out.Status), "re-approve must move the message off pending")
+	assert.NotErrorIs(t, err, sluice.ErrNotPending)
+}
+
+// C5: when the rewrite fails (a malformed header block that textproto cannot
+// parse) the approve verdict must not commit — the message stays pending.
+func TestApproveAsRewriteFailureStaysPending(t *testing.T) {
+	q, _ := seedStore(t)
+	// A header line with no colon is not a valid field; textproto.ReadHeader
+	// rejects it, so rewriteFrom fails.
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", From: "a@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("this-is-not-a-header\r\n\r\nbody\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetInboxIdentities(map[string]string{"work": "work@x.test"})
+
+	_, err = svc.ApproveAs(context.Background(), m.ID, "work")
+	require.Error(t, err)
+
+	stored, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusPending, stored.Status, "rewrite-failure ApproveAs must leave the message pending")
 }
 
 // Inboxes lists only inboxes with a non-empty identity, sorted by name.

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -383,6 +383,36 @@ func (s *Service) ApproveAs(ctx context.Context, id, asInbox string) (Outcome, e
 // it is sent via asInbox's sender — the send-time rewrite never mutates the
 // stored record.
 func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, error) {
+	// ApproveAs rewrites the From identity at send time. Resolve the target inbox
+	// and pre-compute the rewrite BEFORE committing the approve verdict (C5): an
+	// unknown inbox or a malformed header must fail with the message still pending
+	// and re-approvable, never leave it stranded in `approved` with no send
+	// attempted (decide() then refuses the retry as ErrNotPending).
+	var identity string
+	var rewritten []byte
+	if asInbox != "" {
+		identity = s.identities[inbound.NormInbox(asInbox)]
+		if identity == "" {
+			return Outcome{}, fmt.Errorf("%w: %q", ErrUnknownInbox, asInbox)
+		}
+		pending, err := s.store.Get(id)
+		if err != nil {
+			return Outcome{}, err
+		}
+		if pending.Status != sluice.StatusPending {
+			return Outcome{}, fmt.Errorf("%w: message %s is %s", sluice.ErrNotPending, id, pending.Status)
+		}
+		// The committed body is byte-identical to the pending body: v1 has no
+		// amendment flow, so the human Approve verdict carries no Amended and
+		// Approve never overwrites Released. The rewrite computed here is exactly
+		// what will be sent. (If an amendment flow is ever added, this must move
+		// to operate on the post-decide body.)
+		rewritten, err = rewriteFrom(sendBody(pending), identity)
+		if err != nil {
+			return Outcome{}, fmt.Errorf("admin: rewrite From to %q: %w", identity, err)
+		}
+	}
+
 	m, err := s.decide(ctx, id, approver.Verdict{Disposition: approver.Approve})
 	if err != nil {
 		return Outcome{}, err
@@ -393,16 +423,7 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 	out := Outcome{ID: m.ID, Status: string(sluice.StatusApproved), Detail: fmt.Sprintf("approved by %s", m.DecidedBy)}
 
 	sendInbox, sendMsg := m.Inbox, m
-	var identity string
 	if asInbox != "" {
-		identity = s.identities[inbound.NormInbox(asInbox)]
-		if identity == "" {
-			return Outcome{}, fmt.Errorf("%w: %q", ErrUnknownInbox, asInbox)
-		}
-		rewritten, rwErr := rewriteFrom(sendBody(m), identity)
-		if rwErr != nil {
-			return Outcome{}, fmt.Errorf("admin: rewrite From to %q: %w", identity, rwErr)
-		}
 		sendInbox = asInbox
 		sendMsg.From = identity      // envelope MAIL FROM
 		sendMsg.Released = rewritten // the sender prefers Released over Raw (send-time only)

--- a/internal/listener/smtp.go
+++ b/internal/listener/smtp.go
@@ -3,8 +3,8 @@ package listener
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"time"
 
@@ -147,7 +147,15 @@ func (s *session) Data(r io.Reader) error {
 		Rcpt:  s.rcpt,
 		Raw:   raw,
 	}); err != nil {
-		return fmt.Errorf("trap submission: %w", err)
+		// A queue write can fail transiently (locked DB, disk hiccup). Return a
+		// 4xx so a correct client retries instead of dropping the mail, and keep
+		// the internal error server-side only — never leak it to the agent (C12).
+		slog.Error("trap submission failed", "agent", s.agent, "inbox", s.inbox, "error", err)
+		return &smtp.SMTPError{
+			Code:         451,
+			EnhancedCode: smtp.EnhancedCode{4, 3, 0},
+			Message:      "temporary queue failure",
+		}
 	}
 	return nil
 }

--- a/internal/listener/smtp_test.go
+++ b/internal/listener/smtp_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"errors"
 	"math/big"
 	"net"
 	"path/filepath"
@@ -220,6 +221,39 @@ func TestSubmitRoutesFromToInbox(t *testing.T) {
 	metas, err = q.List()
 	require.NoError(t, err)
 	assert.Len(t, metas, 1)
+}
+
+// failingEnqueuer simulates a transient queue-write failure (locked DB / disk
+// hiccup) and carries an internal error string that must never reach the agent.
+type failingEnqueuer struct{}
+
+func (failingEnqueuer) Enqueue(sluice.Submission) (sluice.Message, error) {
+	return sluice.Message{}, errors.New("bbolt: database is locked (internal detail)")
+}
+
+// C12: a failed Enqueue must map to a transient 4xx so a correct client retries
+// instead of dropping the mail, and the internal error detail must not leak to
+// the agent.
+func TestSubmitQueueFailureIsTransientAndOpaque(t *testing.T) {
+	addr := startServer(t, listener.ServerConfig{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{selfSigned(t)}},
+	}, failingEnqueuer{})
+
+	c, err := smtp.DialStartTLS(addr, &tls.Config{InsecureSkipVerify: true})
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Auth(sasl.NewPlainClient("", testUser, testPass)))
+
+	const raw = "From: agent@local\r\nTo: d@x.test\r\n\r\nbody\r\n"
+	err = c.SendMail("agent@local", []string{"d@x.test"}, strings.NewReader(raw))
+	require.Error(t, err)
+
+	var se *smtp.SMTPError
+	require.ErrorAs(t, err, &se)
+	assert.Equal(t, 451, se.Code, "transient queue failure must be a 4xx (retry), not a 5xx (drop)")
+	assert.Equal(t, smtp.EnhancedCode{4, 3, 0}, se.EnhancedCode)
+	assert.NotContains(t, se.Message, "database is locked", "internal error must not leak to the agent")
+	assert.NotContains(t, se.Message, "internal detail")
 }
 
 func TestPlaintextRequiresAuth(t *testing.T) {


### PR DESCRIPTION
Part of #232 — the "outbound leaks" half of the queue/outbound-correctness issue. Addresses **C5, C12, C22**. The un-stranding half (**C4** re-send verb, **C21** Meta observability, **C25/C26/C27**) follows in a second PR so review stays small.

### C5 (HIGH) — ApproveAs validated the target inbox *after* committing the verdict
`ApproveAs` resolved `identities[asInbox]` and ran `rewriteFrom` only after `decide()` had already moved the message `pending → approved`. An unknown inbox or a malformed header returned 400/500 implying nothing happened, but the message had left `pending` with no send attempted, and the retry hit `ErrNotPending` — stranded.

Fix: resolve the identity and pre-compute the rewrite **before** `decide()`; on any error the message stays `pending` and re-approvable. The committed body is byte-identical to the pending body in v1 (no amendment flow, so the human Approve verdict carries no `Amended` and `Approve` never overwrites `Released`), so the pre-computed rewrite is exactly what is sent.

### C12 (HIGH) — failed `Enqueue` returned a permanent SMTP error
A wrapped enqueue error became go-smtp's `554 5.0.0`, so a correct client drops the message on a transient local failure (locked DB / disk hiccup), and the internal error string leaked to the agent.

Fix: return a transient `451 4.3.0 "temporary queue failure"` and log the detail server-side only.

### C22 (MEDIUM) — `queue ls` / `holds ls` printed unsanitized From/Subject
A MIME encoded-word subject/sender could smuggle CR/LF/ESC or Unicode bidi/zero-width runes into the operator's terminal on the very surface where the human decides whether to expose a message.

Fix: `sanitizeField` replaces every control (C0/C1/DEL), bidi-directional, and zero-width rune with U+FFFD before display; applied to From/Subject (and the agent column) in both tables.

### Tests
- ApproveAs unknown-inbox **and** rewrite-failure both leave the message `pending` and re-approvable.
- A failed `Enqueue` yields a `451` with the internal detail withheld.
- `sanitizeField` strips every dangerous rune class and preserves ordinary UTF-8 text.

Verified locally: `gofmt`, `go build`, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 — all clean.
