### PR TITLE
fix: add outbound re-send verb, surface send failures, guard send-attempt state

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -1304,6 +1304,7 @@ type QueueCmd struct {
 	Ls      QueueLsCmd      `cmd:"" help:"List held messages."`
 	Show    QueueShowCmd    `cmd:"" help:"Dump a held message's raw RFC 822."`
 	Approve QueueApproveCmd `cmd:"" help:"Approve a held message (runs the chain in serve)."`
+	Resend  QueueResendCmd  `cmd:"" help:"Retry the upstream send of an approved message whose send failed."`
 	Reject  QueueRejectCmd  `cmd:"" help:"Reject a held message."`
 }
 
@@ -1324,10 +1325,14 @@ func (*QueueLsCmd) Run(cli *CLI) error {
 		return nil
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "ID\tSTATUS\tAGENT\tFROM\tSUBJECT\tRCPT\tSIZE\tRECEIVED")
+	_, _ = fmt.Fprintln(w, "ID\tSTATUS\tAGENT\tINBOX\tFROM\tSUBJECT\tRCPT\tSIZE\tRECEIVED\tSEND ERR")
 	for _, m := range metas {
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\n",
-			m.ID, m.Status, sanitizeField(m.Agent), sanitizeField(m.From), truncate(sanitizeField(m.Subject), 40), len(m.Rcpt), m.Size, m.ReceivedAt.Format(time.RFC3339))
+		// SendErr can carry the upstream server's response text, so sanitize it like
+		// the other operator-table fields (C22) before display (C21).
+		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%s\t%s\n",
+			m.ID, m.Status, sanitizeField(m.Agent), sanitizeField(m.Inbox), sanitizeField(m.From),
+			truncate(sanitizeField(m.Subject), 40), len(m.Rcpt), m.Size, m.ReceivedAt.Format(time.RFC3339),
+			truncate(sanitizeField(m.SendErr), 40))
 	}
 	return w.Flush()
 }
@@ -1402,6 +1407,24 @@ func (c *QueueApproveCmd) Run(cli *CLI) error {
 		return err
 	}
 	out, err := client.Approve(context.Background(), c.ID)
+	if err != nil {
+		return err
+	}
+	return printOutcome(out)
+}
+
+// QueueResendCmd retries the upstream send of an approved message whose previous
+// send failed (C4), recovering a message stranded in `approved` with a send error.
+type QueueResendCmd struct {
+	ID string `arg:"" help:"Message id."`
+}
+
+func (c *QueueResendCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	out, err := client.ReSend(context.Background(), c.ID)
 	if err != nil {
 		return err
 	}

--- a/internal/admin/change_sender_test.go
+++ b/internal/admin/change_sender_test.go
@@ -54,6 +54,92 @@ func TestReSendRecoversStrandedApproved(t *testing.T) {
 	assert.Empty(t, sent.SendErr)
 }
 
+// C4 (review fix): a re-send of an approved-AS message that stranded must deliver
+// the operator's chosen identity — recomputed from the persisted AsInbox — not
+// silently revert to the original From.
+func TestReSendApprovedAsRecomputesIdentity(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: inbound.DefaultInbox, From: "assistant@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: assistant@x.test\r\nTo: d@y.test\r\nSubject: hi\r\n\r\nbody\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	fail := true
+	var sentVia string
+	var sent sluice.Message
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(msg sluice.Message) error { sentVia = "default"; sent = msg; return nil }),
+		"work": senderFunc(func(msg sluice.Message) error {
+			if fail {
+				return errors.New("dial tcp: connection refused") // transient
+			}
+			sentVia = "work"
+			sent = msg
+			return nil
+		}),
+	})
+	svc.SetInboxIdentities(map[string]string{inbound.DefaultInbox: "default@x.test", "work": "work@x.test"})
+
+	// ApproveAs work, but the send fails transiently → stranded approved-as.
+	out, err := svc.ApproveAs(context.Background(), m.ID, "work")
+	require.NoError(t, err)
+	require.Equal(t, string(sluice.StatusApproved), out.Status)
+	stranded, err := q.Get(m.ID)
+	require.NoError(t, err)
+	require.Equal(t, "work", stranded.AsInbox, "the as-choice is persisted for recovery")
+	require.NotEmpty(t, stranded.SendErr)
+
+	// Re-send delivers via the chosen inbox with the rewritten From — never the original.
+	fail = false
+	out, err = svc.ReSend(context.Background(), m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(sluice.StatusSent), out.Status)
+	assert.Equal(t, "work", sentVia, "re-send routes through the chosen inbox's sender")
+	assert.Equal(t, "work@x.test", sent.From, "envelope From recomputed to the chosen identity")
+	assert.Contains(t, string(sent.Released), "From: work@x.test", "header From recomputed")
+	assert.NotContains(t, string(sent.Released), "assistant@x.test")
+
+	// The stored record still keeps the original From (send-time rewrite only).
+	stored, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "assistant@x.test", stored.From)
+}
+
+// C4 (review fix): if the approved-as inbox no longer resolves (removed from config
+// while the message was stranded), the re-send is refused fail-closed rather than
+// delivered under the original identity.
+func TestReSendApprovedAsRefusesVanishedInbox(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: inbound.DefaultInbox, From: "assistant@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: assistant@x.test\r\nTo: d@y.test\r\n\r\nbody\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { return nil }),
+		"work":               senderFunc(func(sluice.Message) error { return errors.New("dial tcp: connection refused") }),
+	})
+	svc.SetInboxIdentities(map[string]string{inbound.DefaultInbox: "default@x.test", "work": "work@x.test"})
+
+	// Strand it as approved-as work.
+	_, err = svc.ApproveAs(context.Background(), m.ID, "work")
+	require.NoError(t, err)
+
+	// The work inbox is removed from config before the operator retries.
+	svc.SetInboxIdentities(map[string]string{inbound.DefaultInbox: "default@x.test"})
+
+	_, err = svc.ReSend(context.Background(), m.ID)
+	assert.ErrorIs(t, err, admin.ErrUnknownInbox)
+
+	stored, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, stored.Status, "refused re-send leaves it approved, not delivered under the wrong identity")
+}
+
 // C4: re-send only acts on an approved message with a recorded send error; a
 // pending or already-sent message is refused with ErrNotResendable.
 func TestReSendRejectsNonResendable(t *testing.T) {

--- a/internal/admin/change_sender_test.go
+++ b/internal/admin/change_sender_test.go
@@ -2,6 +2,7 @@ package admin_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,72 @@ import (
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
+
+// C4: a message stranded in `approved` by a transient send failure can be
+// recovered by the re-send verb — a plain re-approve would hit ErrNotPending.
+func TestReSendRecoversStrandedApproved(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: inbound.DefaultInbox, From: "a@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: a@x.test\r\n\r\nb\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	fail := true
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error {
+			if fail {
+				return errors.New("dial tcp: connection refused") // transient, not permanent
+			}
+			return nil
+		}),
+	})
+
+	// First approve strands it: the transient failure keeps it approved with a SendErr.
+	out, err := svc.ApproveID(context.Background(), m.ID)
+	require.NoError(t, err)
+	require.Equal(t, string(sluice.StatusApproved), out.Status)
+	stranded, err := q.Get(m.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, stranded.SendErr)
+
+	// Re-send now delivers and clears the error.
+	fail = false
+	out, err = svc.ReSend(context.Background(), m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(sluice.StatusSent), out.Status)
+	sent, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusSent, sent.Status)
+	assert.Empty(t, sent.SendErr)
+}
+
+// C4: re-send only acts on an approved message with a recorded send error; a
+// pending or already-sent message is refused with ErrNotResendable.
+func TestReSendRejectsNonResendable(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: inbound.DefaultInbox, From: "a@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: a@x.test\r\n\r\nb\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { return nil }),
+	})
+
+	// Pending → not resendable.
+	_, err = svc.ReSend(context.Background(), m.ID)
+	assert.ErrorIs(t, err, admin.ErrNotResendable)
+
+	// Clean approve → sent → not resendable.
+	_, err = svc.ApproveID(context.Background(), m.ID)
+	require.NoError(t, err)
+	_, err = svc.ReSend(context.Background(), m.ID)
+	assert.ErrorIs(t, err, admin.ErrNotResendable)
+}
 
 // ApproveAs sends via the chosen inbox's sender, rewrites both the envelope and
 // the header From to that inbox's identity, and leaves the stored record as

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -95,6 +95,12 @@ func (c *Client) ApproveAs(ctx context.Context, id, inbox string) (Outcome, erro
 	return c.action(ctx, "/queue/"+id+"/approve-as/"+inbox, nil)
 }
 
+// ReSend retries the upstream delivery of an approved message whose previous send
+// failed (C4). Only valid for a message stranded in `approved` with a send error.
+func (c *Client) ReSend(ctx context.Context, id string) (Outcome, error) {
+	return c.action(ctx, "/queue/"+id+"/resend", nil)
+}
+
 // Inboxes lists the configured inbox identities for the Change-sender picker
 // (ADR 0023 slice 5).
 func (c *Client) Inboxes(ctx context.Context) ([]InboxIdentity, error) {

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -216,7 +216,9 @@ func (s *Server) handleApproveAs(w http.ResponseWriter, r *http.Request) {
 // from the 404 for an unknown id.
 func (s *Server) handleResend(w http.ResponseWriter, r *http.Request) {
 	out, err := s.svc.ReSend(r.Context(), r.PathValue("id"))
-	if errors.Is(err, ErrNotResendable) {
+	// Both are 409: the message is either not in a re-sendable state, or its
+	// approved-as inbox no longer resolves (removed from config while stranded).
+	if errors.Is(err, ErrNotResendable) || errors.Is(err, ErrUnknownInbox) {
 		writeErr(w, http.StatusConflict, err)
 		return
 	}

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -60,6 +60,7 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 	s.register(mux, "GET /queue/{id}", s.handleShow)
 	s.register(mux, "POST /queue/{id}/approve", s.handleApprove)
 	s.register(mux, "POST /queue/{id}/approve-as/{inbox}", s.handleApproveAs)
+	s.register(mux, "POST /queue/{id}/resend", s.handleResend)
 	s.register(mux, "POST /queue/{id}/reject", s.handleReject)
 
 	// Configured inbox identities for the Change-sender picker (ADR 0023 slice 5).
@@ -205,6 +206,18 @@ func (s *Server) handleApproveAs(w http.ResponseWriter, r *http.Request) {
 	out, err := s.svc.ApproveAs(r.Context(), r.PathValue("id"), r.PathValue("inbox"))
 	if errors.Is(err, ErrUnknownInbox) {
 		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	writeAction(w, out, err)
+}
+
+// handleResend retries the upstream send of an approved-but-stranded message (C4).
+// ErrNotResendable is a 409 (the message is not in a re-sendable state), distinct
+// from the 404 for an unknown id.
+func (s *Server) handleResend(w http.ResponseWriter, r *http.Request) {
+	out, err := s.svc.ReSend(r.Context(), r.PathValue("id"))
+	if errors.Is(err, ErrNotResendable) {
+		writeErr(w, http.StatusConflict, err)
 		return
 	}
 	writeAction(w, out, err)

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -323,7 +323,7 @@ func (s *Service) Show(id string) (sluice.Message, error) { return s.store.Get(i
 
 // decide runs the approval chain for one message and commits the outcome —
 // nothing more (pure). Everything downstream lives in Approve/Reject.
-func (s *Service) decide(ctx context.Context, id string, human approver.Verdict) (sluice.Message, error) {
+func (s *Service) decide(ctx context.Context, id string, human approver.Verdict, asInbox string) (sluice.Message, error) {
 	msg, err := s.store.Get(id)
 	if err != nil {
 		return sluice.Message{}, err
@@ -353,7 +353,7 @@ func (s *Service) decide(ctx context.Context, id string, human approver.Verdict)
 	}
 	switch outcome.Disposition {
 	case approver.Approve:
-		return s.store.Approve(id, outcome.DecidedBy, outcome.Released)
+		return s.store.Approve(id, outcome.DecidedBy, outcome.Released, asInbox)
 	case approver.Reject:
 		return s.store.Reject(id, outcome.DecidedBy, outcome.Reason, outcome.Retryable)
 	default:
@@ -413,7 +413,7 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 		}
 	}
 
-	m, err := s.decide(ctx, id, approver.Verdict{Disposition: approver.Approve})
+	m, err := s.decide(ctx, id, approver.Verdict{Disposition: approver.Approve}, asInbox)
 	if err != nil {
 		return Outcome{}, err
 	}
@@ -431,7 +431,7 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 	}
 
 	sendErr := s.senderFor(sendInbox).Send(ctx, sendMsg)
-	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr)
+	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, false)
 	if rerr != nil {
 		return Outcome{}, rerr
 	}
@@ -469,10 +469,21 @@ var ErrNotResendable = errors.New("admin: message is not awaiting re-send (needs
 // SendErr: decide() refuses non-pending messages, so a plain re-approve returns
 // ErrNotPending. Allowed only when Status==approved && SendErr!=""; it re-runs the
 // send and records the attempt (the RecordSendAttempt guard, C26, keeps this the
-// only way SendErr/Sent can be re-stamped). The message is delivered as stored —
-// the ADR 0023 slice 5 ApproveAs identity rewrite is send-time only and was never
-// persisted, so a re-send of an approved-as message goes through its stamped inbox
-// with its original From.
+// only way SendErr/Sent can be re-stamped).
+//
+// An approved-as message (AsInbox set) is re-sent AS APPROVED: the identity rewrite
+// is recomputed from the persisted inbox choice — the same computation the approve
+// path did at send time — so a re-send never silently reverts to the original From.
+// If that inbox no longer resolves to an identity (removed from config while the
+// message was stranded), the re-send is refused fail-closed rather than delivered
+// under the wrong identity.
+//
+// NOTE: the approved+SendErr check and the send are not atomic, so two concurrent
+// re-sends of the same id can both deliver (duplicate mail). The RecordSendAttempt
+// guard keeps the loser from corrupting the record (a failure can't stamp a sent
+// message), but full de-duplication needs an in-flight marker — tracked as a #232
+// follow-up; clearing SendErr before the attempt is NOT an option (it reintroduces
+// the stranded-invisible state).
 func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
 	m, err := s.store.Get(id)
 	if err != nil {
@@ -481,10 +492,28 @@ func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
 	if m.Status != sluice.StatusApproved || m.SendErr == "" {
 		return Outcome{}, fmt.Errorf("%w: message %s is %s", ErrNotResendable, id, m.Status)
 	}
-	slog.Info("resend", "message_id", m.ID, "inbox", inbound.NormInbox(m.Inbox))
 
-	sendErr := s.senderFor(m.Inbox).Send(ctx, m)
-	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr)
+	sendInbox, sendMsg := m.Inbox, m
+	var identity string
+	if m.AsInbox != "" {
+		identity = s.identities[inbound.NormInbox(m.AsInbox)]
+		if identity == "" {
+			// The chosen inbox lost its identity while the message was stranded;
+			// refuse rather than deliver from the original From (fail-closed).
+			return Outcome{}, fmt.Errorf("%w: approved-as inbox %q no longer resolves to an identity", ErrUnknownInbox, m.AsInbox)
+		}
+		rewritten, rwErr := rewriteFrom(sendBody(m), identity)
+		if rwErr != nil {
+			return Outcome{}, fmt.Errorf("admin: rewrite From to %q: %w", identity, rwErr)
+		}
+		sendInbox = m.AsInbox
+		sendMsg.From = identity      // envelope MAIL FROM
+		sendMsg.Released = rewritten // send-time rewrite only; the stored record is untouched
+	}
+	slog.Info("resend", "message_id", m.ID, "inbox", inbound.NormInbox(sendInbox), "identity", identity)
+
+	sendErr := s.senderFor(sendInbox).Send(ctx, sendMsg)
+	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, true)
 	if rerr != nil {
 		return Outcome{}, rerr
 	}
@@ -509,7 +538,7 @@ func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
 // RejectID rejects a held message: commit, then deliver the DSN bounce
 // (downstream of commit, never mistaken for a reject failure, ADR 0006).
 func (s *Service) RejectID(ctx context.Context, id, reason string, retryable bool) (Outcome, error) {
-	m, err := s.decide(ctx, id, approver.Verdict{Disposition: approver.Reject, Reason: reason, Retryable: retryable})
+	m, err := s.decide(ctx, id, approver.Verdict{Disposition: approver.Reject, Reason: reason, Retryable: retryable}, "")
 	if err != nil {
 		return Outcome{}, err
 	}

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -460,6 +460,52 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 	return out, nil
 }
 
+// ErrNotResendable is returned by ReSend when the message is not an approved
+// message carrying a recorded send error — the only state a manual re-send acts on.
+var ErrNotResendable = errors.New("admin: message is not awaiting re-send (needs an approved message with a recorded send error)")
+
+// ReSend retries the upstream delivery of an approved message whose previous send
+// failed (C4). It is the only recovery for a message stranded in `approved` with a
+// SendErr: decide() refuses non-pending messages, so a plain re-approve returns
+// ErrNotPending. Allowed only when Status==approved && SendErr!=""; it re-runs the
+// send and records the attempt (the RecordSendAttempt guard, C26, keeps this the
+// only way SendErr/Sent can be re-stamped). The message is delivered as stored —
+// the ADR 0023 slice 5 ApproveAs identity rewrite is send-time only and was never
+// persisted, so a re-send of an approved-as message goes through its stamped inbox
+// with its original From.
+func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
+	m, err := s.store.Get(id)
+	if err != nil {
+		return Outcome{}, err
+	}
+	if m.Status != sluice.StatusApproved || m.SendErr == "" {
+		return Outcome{}, fmt.Errorf("%w: message %s is %s", ErrNotResendable, id, m.Status)
+	}
+	slog.Info("resend", "message_id", m.ID, "inbox", inbound.NormInbox(m.Inbox))
+
+	sendErr := s.senderFor(m.Inbox).Send(ctx, m)
+	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr)
+	if rerr != nil {
+		return Outcome{}, rerr
+	}
+	out := Outcome{ID: m.ID, Status: string(final.Status), Detail: "re-send attempted"}
+	switch {
+	case sendErr == nil:
+		out.Detail = "re-sent upstream"
+	case isSendPending(sendErr):
+		out.Detail = "re-send: no real Sender configured — nothing left Darbaan"
+	case backend.IsPermanent(sendErr):
+		if bErr := s.deliverBounce(m, "upstream delivery failed permanently", false); bErr != nil {
+			out.Warn = fmt.Sprintf("re-send failed permanently AND bounce delivery failed: %v", bErr)
+		} else {
+			out.Warn = "upstream re-send failed permanently — bounced to agent"
+		}
+	default:
+		out.Warn = "upstream re-send failed (transient); stays approved for another re-send"
+	}
+	return out, nil
+}
+
 // RejectID rejects a held message: commit, then deliver the DSN bounce
 // (downstream of commit, never mistaken for a reject failure, ADR 0006).
 func (s *Service) RejectID(ctx context.Context, id, reason string, retryable bool) (Outcome, error) {

--- a/internal/admincfg/admincfg.go
+++ b/internal/admincfg/admincfg.go
@@ -52,6 +52,7 @@ var RouteScopes = map[string]string{
 	"GET /queue/{id}":                     ScopeQueueRead,
 	"POST /queue/{id}/approve":            ScopeQueueDecide,
 	"POST /queue/{id}/approve-as/{inbox}": ScopeQueueDecide,
+	"POST /queue/{id}/resend":             ScopeQueueDecide,
 	"POST /queue/{id}/reject":             ScopeQueueDecide,
 	"GET /holds":                          ScopeHoldsRead,
 	"GET /holds/{id}/content":             ScopeHoldsRead,

--- a/internal/admincfg/admincfg_test.go
+++ b/internal/admincfg/admincfg_test.go
@@ -87,6 +87,7 @@ func TestRouteScopesComplete(t *testing.T) {
 		"GET /queue/{id}",
 		"POST /queue/{id}/approve",
 		"POST /queue/{id}/approve-as/{inbox}",
+		"POST /queue/{id}/resend",
 		"POST /queue/{id}/reject",
 		"GET /holds",
 		"GET /holds/{id}/content",

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -198,7 +198,7 @@ func (s *bboltStore) Get(id string) (Message, error) {
 	return s.withRaw(rec)
 }
 
-func (s *bboltStore) Approve(id, decidedBy string, released []byte) (Message, error) {
+func (s *bboltStore) Approve(id, decidedBy string, released []byte, asInbox string) (Message, error) {
 	return s.transitionFromPending(id, "approve", decidedBy, func(m *Message) {
 		m.Status = StatusApproved
 		m.DecidedBy = decidedBy
@@ -207,6 +207,10 @@ func (s *bboltStore) Approve(id, decidedBy string, released []byte) (Message, er
 		if len(released) > 0 {
 			m.Released = released
 		}
+		// Record the ApproveAs identity choice as decision metadata (ADR 0023 slice
+		// 5): the stored body is unchanged, but a re-send recomputes the From
+		// rewrite from this inbox instead of silently reverting to the original.
+		m.AsInbox = asInbox
 	})
 }
 
@@ -219,7 +223,7 @@ func (s *bboltStore) Reject(id, decidedBy, reason string, retryable bool) (Messa
 	})
 }
 
-func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error) {
+func (s *bboltStore) RecordSendAttempt(id string, sendErr error, resend bool) (Message, error) {
 	detail := "sent"
 	var out Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
@@ -227,11 +231,14 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 		if err != nil {
 			return err
 		}
-		// A send is only ever recorded against an approved message (or re-recorded
-		// against an already-sent one, idempotently). Guard so the re-send verb
-		// (or any future caller) can never stamp Sent/SendErr onto a pending or
-		// rejected record (C26).
-		if rec.Status != StatusApproved && rec.Status != StatusSent {
+		// A send is only ever recorded against an approved message. An already-sent
+		// message admits only an idempotent SUCCESS re-record — never a failure
+		// stamp, so a losing concurrent second attempt can't turn a delivered
+		// message into sent-with-error (C26 + review). Pending/rejected are refused.
+		switch {
+		case rec.Status == StatusApproved:
+		case rec.Status == StatusSent && sendErr == nil:
+		default:
 			return fmt.Errorf("%w: message %s is %s", ErrNotApproved, id, rec.Status)
 		}
 		if sendErr != nil {
@@ -251,7 +258,13 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 	if sendErr != nil {
 		detail = sendErr.Error()
 	}
-	s.writeAudit(audit.Record{Event: "send_attempt", Agent: out.Agent, Inbox: out.Inbox, MessageID: id, Detail: detail})
+	// A re-send is a distinct, operator-triggered delivery — audit it under its own
+	// event so it is not indistinguishable from the first send in the durable log.
+	event := "send_attempt"
+	if resend {
+		event = "resend_attempt"
+	}
+	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, Inbox: out.Inbox, MessageID: id, Detail: detail})
 	return out, nil
 }
 

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -167,12 +167,14 @@ func (s *bboltStore) List() ([]Meta, error) {
 			metas = append(metas, Meta{
 				ID:         rec.ID,
 				Agent:      rec.Agent,
+				Inbox:      rec.Inbox,
 				From:       rec.From,
 				Rcpt:       rec.Rcpt,
 				Subject:    subject,
 				Size:       size,
 				ReceivedAt: rec.ReceivedAt,
 				Status:     rec.Status,
+				SendErr:    rec.SendErr,
 			})
 			return nil
 		})
@@ -224,6 +226,13 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error) (Message, error
 		rec, key, err := loadStored(tx, id)
 		if err != nil {
 			return err
+		}
+		// A send is only ever recorded against an approved message (or re-recorded
+		// against an already-sent one, idempotently). Guard so the re-send verb
+		// (or any future caller) can never stamp Sent/SendErr onto a pending or
+		// rejected record (C26).
+		if rec.Status != StatusApproved && rec.Status != StatusSent {
+			return fmt.Errorf("%w: message %s is %s", ErrNotApproved, id, rec.Status)
 		}
 		if sendErr != nil {
 			rec.SendErr = sendErr.Error() // stays approved for a manual re-send

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -71,6 +71,12 @@ type Message struct {
 	Retryable bool   `json:"retryable,omitempty"`
 	Released  []byte `json:"released,omitempty"` // edited body approved instead of Raw (ADR 0004); nil = original
 	SendErr   string `json:"send_err,omitempty"` // result of the last send attempt
+	// AsInbox is the inbox whose identity an ApproveAs chose (ADR 0023 slice 5),
+	// recorded as decision metadata at approve commit. The stored body stays as
+	// submitted — the identity rewrite is recomputed from this inbox at send time —
+	// so a re-send delivers what the operator approved rather than the original
+	// From. "" means the message was approved to send as-stamped.
+	AsInbox string `json:"as_inbox,omitempty"`
 }
 
 // Meta is the listing view of a queued message: everything but the raw body.
@@ -116,15 +122,19 @@ type MessageStore interface {
 	List() ([]Meta, error)
 	// Get returns the full message (including the raw body), or ErrNotFound.
 	Get(id string) (Message, error)
-	// Approve marks a pending message approved, recording the deciding approver
-	// and (when edited) the released body. It does not send. ErrNotPending if
-	// the message is not pending.
-	Approve(id, decidedBy string, released []byte) (Message, error)
+	// Approve marks a pending message approved, recording the deciding approver,
+	// (when edited) the released body, and (when an ApproveAs chose one) the
+	// asInbox whose identity to send from — decision metadata only; the stored
+	// body is unchanged. It does not send. ErrNotPending if not pending.
+	Approve(id, decidedBy string, released []byte, asInbox string) (Message, error)
 	// Reject marks a pending message rejected with a reason and retryable flag.
 	Reject(id, decidedBy, reason string, retryable bool) (Message, error)
 	// RecordSendAttempt records the result of attempting to release an approved
-	// message to the upstream Sender.
-	RecordSendAttempt(id string, sendErr error) (Message, error)
+	// message to the upstream Sender. resend marks an operator-triggered re-send
+	// (a distinct audit event from the first delivery). It refuses any record
+	// against a non-approved message, and against an already-sent message admits
+	// only an idempotent success — never a failure stamp onto a sent record.
+	RecordSendAttempt(id string, sendErr error, resend bool) (Message, error)
 	// Close releases the underlying resources.
 	Close() error
 }

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -26,6 +26,12 @@ var ErrNotFound = errors.New("sluice: message not found")
 // longer pending — fail-closed against double decisions.
 var ErrNotPending = errors.New("sluice: message is not pending")
 
+// ErrNotApproved is returned by RecordSendAttempt when the message is in a state
+// that must never receive a send stamp (pending or rejected). A send is only ever
+// recorded against an approved message (or re-recorded against an already-sent one,
+// idempotently).
+var ErrNotApproved = errors.New("sluice: message is not approved")
+
 // Status is the disposition of a queued message. New messages are Pending; the
 // approval pipeline transitions them to Approved or Rejected. Default-deny means
 // nothing leaves on Approved either until a real Sender is wired (ADR 0003) —
@@ -74,12 +80,14 @@ type Message struct {
 type Meta struct {
 	ID         string
 	Agent      string
+	Inbox      string // routed inbox (ADR 0023); "" reads as default
 	From       string
 	Rcpt       []string
 	Subject    string
 	Size       int
 	ReceivedAt time.Time
 	Status     Status
+	SendErr    string // the last send attempt's error, so a stranded approved message is visible
 }
 
 // subjectFromRaw extracts the Subject header from a stored message for display

--- a/internal/sluice/sluice_test.go
+++ b/internal/sluice/sluice_test.go
@@ -101,7 +101,7 @@ func TestApproveTransitionsAndAudits(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	approved, err := q.Approve(m.ID, "manual", nil)
+	approved, err := q.Approve(m.ID, "manual", nil, "")
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusApproved, approved.Status)
 	assert.Equal(t, "manual", approved.DecidedBy)
@@ -115,7 +115,7 @@ func TestApproveStoresEditedBody(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	approved, err := q.Approve(m.ID, "manual", []byte("edited"))
+	approved, err := q.Approve(m.ID, "manual", []byte("edited"), "")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("edited"), approved.Released)
 }
@@ -137,10 +137,10 @@ func TestDoubleDecisionRejected(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	_, err = q.Approve(m.ID, "manual", nil)
+	_, err = q.Approve(m.ID, "manual", nil, "")
 	require.NoError(t, err)
 
-	_, err = q.Approve(m.ID, "manual", nil)
+	_, err = q.Approve(m.ID, "manual", nil, "")
 	require.ErrorIs(t, err, sluice.ErrNotPending)
 	_, err = q.Reject(m.ID, "manual", "too late", false)
 	require.ErrorIs(t, err, sluice.ErrNotPending)
@@ -150,10 +150,10 @@ func TestRecordSendAttemptStoresError(t *testing.T) {
 	q, al := newStore(t)
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
-	_, err = q.Approve(m.ID, "manual", nil)
+	_, err = q.Approve(m.ID, "manual", nil, "")
 	require.NoError(t, err)
 
-	out, err := q.RecordSendAttempt(m.ID, errors.New("upstream send pending"))
+	out, err := q.RecordSendAttempt(m.ID, errors.New("upstream send pending"), false)
 	require.NoError(t, err)
 	assert.Equal(t, "upstream send pending", out.SendErr)
 	require.NoError(t, al.Verify())
@@ -168,25 +168,35 @@ func TestRecordSendAttemptRejectsNonApproved(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pending → refused.
-	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"))
+	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"), false)
 	require.ErrorIs(t, err, sluice.ErrNotApproved)
 
 	// Rejected → refused.
 	_, err = q.Reject(m.ID, "manual", "no", false)
 	require.NoError(t, err)
-	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"))
+	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"), false)
 	require.ErrorIs(t, err, sluice.ErrNotApproved)
 
 	// Approved → allowed; and idempotent once sent.
 	m2, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("two")})
 	require.NoError(t, err)
-	_, err = q.Approve(m2.ID, "manual", nil)
+	_, err = q.Approve(m2.ID, "manual", nil, "")
 	require.NoError(t, err)
-	sent, err := q.RecordSendAttempt(m2.ID, nil)
+	sent, err := q.RecordSendAttempt(m2.ID, nil, false)
 	require.NoError(t, err)
 	require.Equal(t, sluice.StatusSent, sent.Status)
-	_, err = q.RecordSendAttempt(m2.ID, nil) // idempotent on an already-sent message
+	_, err = q.RecordSendAttempt(m2.ID, nil, false) // idempotent on an already-sent message
 	require.NoError(t, err)
+
+	// A failure recorded against an already-sent message is refused — a losing
+	// concurrent second attempt can never turn a delivered message into
+	// sent-with-error (review note).
+	_, err = q.RecordSendAttempt(m2.ID, errors.New("late failure"), true)
+	require.ErrorIs(t, err, sluice.ErrNotApproved)
+	after, err := q.Get(m2.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusSent, after.Status)
+	assert.Empty(t, after.SendErr, "a sent message keeps no send error")
 }
 
 // C21: the listing view surfaces the routed inbox and the last send error, so an
@@ -195,9 +205,9 @@ func TestListSurfacesInboxAndSendErr(t *testing.T) {
 	q, _ := newStore(t)
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Inbox: "work", From: "f", Raw: []byte("Subject: s\r\n\r\nb")})
 	require.NoError(t, err)
-	_, err = q.Approve(m.ID, "manual", nil)
+	_, err = q.Approve(m.ID, "manual", nil, "")
 	require.NoError(t, err)
-	_, err = q.RecordSendAttempt(m.ID, errors.New("451 temporary failure"))
+	_, err = q.RecordSendAttempt(m.ID, errors.New("451 temporary failure"), false)
 	require.NoError(t, err)
 
 	metas, err := q.List()
@@ -244,7 +254,7 @@ func TestTransitionsSucceedWhenAuditFails(t *testing.T) {
 
 	t.Run("approve", func(t *testing.T) {
 		q, id := seedFailing(t)
-		out, err := q.Approve(id, "manual", nil)
+		out, err := q.Approve(id, "manual", nil, "")
 		require.NoError(t, err)
 		assert.Equal(t, sluice.StatusApproved, out.Status)
 	})
@@ -258,9 +268,9 @@ func TestTransitionsSucceedWhenAuditFails(t *testing.T) {
 
 	t.Run("record send attempt", func(t *testing.T) {
 		q, id := seedFailing(t)
-		_, err := q.Approve(id, "manual", nil)
+		_, err := q.Approve(id, "manual", nil, "")
 		require.NoError(t, err)
-		out, err := q.RecordSendAttempt(id, errors.New("upstream send pending"))
+		out, err := q.RecordSendAttempt(id, errors.New("upstream send pending"), false)
 		require.NoError(t, err)
 		assert.Equal(t, "upstream send pending", out.SendErr)
 	})

--- a/internal/sluice/sluice_test.go
+++ b/internal/sluice/sluice_test.go
@@ -159,6 +159,54 @@ func TestRecordSendAttemptStoresError(t *testing.T) {
 	require.NoError(t, al.Verify())
 }
 
+// C26: a send is only ever recorded against an approved message (idempotently once
+// sent). A pending or rejected message must refuse the stamp, so the re-send verb
+// can never resurrect a non-approved record.
+func TestRecordSendAttemptRejectsNonApproved(t *testing.T) {
+	q, _ := newStore(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+
+	// Pending → refused.
+	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"))
+	require.ErrorIs(t, err, sluice.ErrNotApproved)
+
+	// Rejected → refused.
+	_, err = q.Reject(m.ID, "manual", "no", false)
+	require.NoError(t, err)
+	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"))
+	require.ErrorIs(t, err, sluice.ErrNotApproved)
+
+	// Approved → allowed; and idempotent once sent.
+	m2, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("two")})
+	require.NoError(t, err)
+	_, err = q.Approve(m2.ID, "manual", nil)
+	require.NoError(t, err)
+	sent, err := q.RecordSendAttempt(m2.ID, nil)
+	require.NoError(t, err)
+	require.Equal(t, sluice.StatusSent, sent.Status)
+	_, err = q.RecordSendAttempt(m2.ID, nil) // idempotent on an already-sent message
+	require.NoError(t, err)
+}
+
+// C21: the listing view surfaces the routed inbox and the last send error, so an
+// approved-but-stranded message (and which inbox it routed through) is visible.
+func TestListSurfacesInboxAndSendErr(t *testing.T) {
+	q, _ := newStore(t)
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Inbox: "work", From: "f", Raw: []byte("Subject: s\r\n\r\nb")})
+	require.NoError(t, err)
+	_, err = q.Approve(m.ID, "manual", nil)
+	require.NoError(t, err)
+	_, err = q.RecordSendAttempt(m.ID, errors.New("451 temporary failure"))
+	require.NoError(t, err)
+
+	metas, err := q.List()
+	require.NoError(t, err)
+	require.Len(t, metas, 1)
+	assert.Equal(t, "work", metas[0].Inbox)
+	assert.Equal(t, "451 temporary failure", metas[0].SendErr)
+}
+
 // failingAudit always errors on Append, to prove audit is best-effort.
 type failingAudit struct{}
 

--- a/internal/sluice/tiering_internal_test.go
+++ b/internal/sluice/tiering_internal_test.go
@@ -120,7 +120,7 @@ func TestLegacyInlineRecordFallback(t *testing.T) {
 	assert.Equal(t, len(legacy.Raw), metas[0].Size)
 
 	// A legacy message still transitions, and the verdict reads back its raw.
-	approved, err := q.Approve("1", "op", nil)
+	approved, err := q.Approve("1", "op", nil, "")
 	require.NoError(t, err)
 	assert.Equal(t, StatusApproved, approved.Status)
 	assert.Equal(t, legacy.Raw, approved.Raw)


### PR DESCRIPTION
Part of #232 — the "un-stranding" half. Addresses **C4, C21, C26**. The two remaining guards (**C25** sender-refuse, **C27** header-From vs envelope-From) land in a final PR that `Closes #232`.

The root problem: an approved message whose upstream send failed transiently had **no recovery**. `decide()` refuses a non-pending message, so a re-approve returns `ErrNotPending`, and the message sat in `approved` forever — invisibly, since the listing never showed the send error.

### C4 (HIGH) — admin re-send verb
The promised re-send did not exist. This adds:
- `POST /queue/{id}/resend` (scope `queue:decide`), `Client.ReSend`, and a `queue resend <id>` CLI command.
- Allowed **only** for an approved message carrying a send error; it retries `senderFor().Send` and records the attempt (audited via `RecordSendAttempt`).
- The message is delivered **as stored** — the ADR 0023 slice 5 `ApproveAs` identity rewrite is send-time only and was never persisted, so a re-send of an approved-as message goes through its stamped inbox with its original From. Documented on the method.

### C21 (MEDIUM) — observability
`Meta` omitted `Inbox` and `SendErr`, so a failed send (and which inbox it routed through) was invisible in `queue ls`. Added both to `sluice.Meta`, populated in `List()`, and surfaced as new columns. `SendErr` can carry the upstream server's response text, so it is sanitized like the other operator-table fields (C22).

### C26 (LOW) — RecordSendAttempt status guard
`RecordSendAttempt` stamped `Sent`/`SendErr` onto any state — safe only by its single call site, a footgun for the new re-send verb. It now returns `ErrNotApproved` unless the message is `approved` (idempotent once `sent`).

### Tests
- Re-send recovers a message stranded by a transient failure (approved+SendErr → re-send → sent, error cleared); a pending or already-sent message is refused with `ErrNotResendable`.
- `RecordSendAttempt` refuses pending/rejected records and is idempotent on sent.
- `List()` surfaces `Inbox` and `SendErr`.

### Cross-package touch
`internal/admincfg` — one route→scope entry for `POST /queue/{id}/resend` (`queue:decide`), plus its line in the route-completeness test. The scope model requires every admin route to ship with its mapped scope.

Rebased onto `main` after #241 merged; the diff is exactly these 10 files. Verified locally: `gofmt`, `go build`, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 — all clean.
