### PR TITLE
fix: refuse send on removed inbox sender, reject header/envelope From mismatch

### DIFF
--- a/internal/admin/change_sender_test.go
+++ b/internal/admin/change_sender_test.go
@@ -140,6 +140,65 @@ func TestReSendApprovedAsRefusesVanishedInbox(t *testing.T) {
 	assert.Equal(t, sluice.StatusApproved, stored.Status, "refused re-send leaves it approved, not delivered under the wrong identity")
 }
 
+// C25: a message stamped with an inbox whose sender was removed from config is
+// refused rather than silently delivered through the default account — it stays
+// approved, warned, and re-sendable (SendErr set) once the inbox is restored.
+func TestApproveRefusesSendWhenInboxSenderRemoved(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: "work", From: "a@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: a@x.test\r\n\r\nb\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	var defaultUsed bool
+	// The "work" inbox's sender is gone; only the default remains.
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { defaultUsed = true; return nil }),
+	})
+
+	out, err := svc.ApproveID(context.Background(), m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(sluice.StatusApproved), out.Status, "a refused send stays approved")
+	assert.NotEmpty(t, out.Warn, "the operator is warned")
+	assert.False(t, defaultUsed, "must NOT fall back to the default account")
+
+	stored, err := q.Get(m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, sluice.StatusApproved, stored.Status)
+	assert.NotEmpty(t, stored.SendErr, "the refusal is visible and re-sendable")
+}
+
+// C25: the same refusal guards the re-send path — a plain-approved message whose
+// inbox sender vanished while stranded is refused, not delivered via the default.
+func TestReSendRefusesWhenInboxSenderRemoved(t *testing.T) {
+	q, _ := seedStore(t)
+	m, err := q.Enqueue(sluice.Submission{
+		Agent: "agent", Inbox: "work", From: "a@x.test", Rcpt: []string{"d@y.test"},
+		Raw: []byte("From: a@x.test\r\n\r\nb\r\n"),
+	})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { return nil }),
+		"work":               senderFunc(func(sluice.Message) error { return errors.New("dial tcp: connection refused") }),
+	})
+
+	// Strand it (transient failure), then the work sender is removed from config.
+	_, err = svc.ApproveID(context.Background(), m.ID)
+	require.NoError(t, err)
+	svc.SetSenders(map[string]backend.Sender{
+		inbound.DefaultInbox: senderFunc(func(sluice.Message) error { return nil }),
+	})
+
+	out, err := svc.ReSend(context.Background(), m.ID)
+	require.NoError(t, err)
+	assert.Equal(t, string(sluice.StatusApproved), out.Status, "refused re-send stays approved")
+	assert.NotEmpty(t, out.Warn)
+}
+
 // C4: re-send only acts on an approved message with a recorded send error; a
 // pending or already-sent message is refused with ErrNotResendable.
 func TestReSendRejectsNonResendable(t *testing.T) {

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -151,13 +151,22 @@ func (s *Service) SetSenders(senders map[string]backend.Sender) {
 	}
 }
 
-// senderFor returns the upstream sender for a message's inbox, falling back to the
-// default inbox's sender when the message carries no/unknown inbox (ADR 0023).
-func (s *Service) senderFor(inbox string) backend.Sender {
-	if snd := s.senders[inbound.NormInbox(inbox)]; snd != nil {
-		return snd
-	}
-	return s.senders[inbound.DefaultInbox]
+// errNoSender marks a refused send: the message's stamped inbox has no configured
+// sender, so it was removed from config while the message was held (C25). It is a
+// config fault, never permanent — the message stays approved and re-sendable once
+// the inbox is restored, and it never bounces the agent.
+var errNoSender = errors.New("admin: inbox has no configured sender")
+
+// senderFor returns the upstream sender for a message's inbox (ADR 0023). ok=false
+// means the inbox has no configured sender: a message stamped with a named inbox
+// that was removed from config while held (C25). The caller must refuse the send
+// rather than silently deliver it through the default account under the wrong
+// identity. The default inbox is keyed under DefaultInbox and NormInbox folds the
+// empty inbox to it, so a default-routed message resolves here directly — the old
+// fall-through to the default sender only ever masked the removed-inbox case.
+func (s *Service) senderFor(inbox string) (backend.Sender, bool) {
+	snd := s.senders[inbound.NormInbox(inbox)]
+	return snd, snd != nil
 }
 
 // SetInboundHolds wires the inbound hold-for-human queue (ADR 0021/0023): the
@@ -430,7 +439,7 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 		slog.Info("approved-as", "message_id", m.ID, "inbox", inbound.NormInbox(asInbox), "identity", identity)
 	}
 
-	sendErr := s.senderFor(sendInbox).Send(ctx, sendMsg)
+	sendErr := s.sendVia(ctx, sendInbox, sendMsg)
 	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, false)
 	if rerr != nil {
 		return Outcome{}, rerr
@@ -446,6 +455,8 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 		out.Detail = sentDetail
 	case isSendPending(sendErr):
 		out.Detail = "approved; no real Sender configured — nothing left Darbaan"
+	case errors.Is(sendErr, errNoSender):
+		out.Warn = "inbox has no configured sender (removed from config?); not sent — stays approved"
 	case backend.IsPermanent(sendErr):
 		// Permanent failure: bounce the agent with a generic reason (never the
 		// upstream body). The verdict still committed.
@@ -458,6 +469,18 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 		out.Warn = "upstream send failed (transient); stays approved for re-send"
 	}
 	return out, nil
+}
+
+// sendVia delivers sendMsg through the given inbox's sender, or returns errNoSender
+// when that inbox has no configured sender — refusing rather than silently routing
+// through the default account (C25). Recording it as a send error keeps the message
+// approved, visible (SendErr), and re-sendable once the inbox is restored.
+func (s *Service) sendVia(ctx context.Context, inbox string, sendMsg sluice.Message) error {
+	snd, ok := s.senderFor(inbox)
+	if !ok {
+		return fmt.Errorf("%w: %q", errNoSender, inbound.NormInbox(inbox))
+	}
+	return snd.Send(ctx, sendMsg)
 }
 
 // ErrNotResendable is returned by ReSend when the message is not an approved
@@ -512,7 +535,7 @@ func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
 	}
 	slog.Info("resend", "message_id", m.ID, "inbox", inbound.NormInbox(sendInbox), "identity", identity)
 
-	sendErr := s.senderFor(sendInbox).Send(ctx, sendMsg)
+	sendErr := s.sendVia(ctx, sendInbox, sendMsg)
 	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, true)
 	if rerr != nil {
 		return Outcome{}, rerr
@@ -523,6 +546,8 @@ func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
 		out.Detail = "re-sent upstream"
 	case isSendPending(sendErr):
 		out.Detail = "re-send: no real Sender configured — nothing left Darbaan"
+	case errors.Is(sendErr, errNoSender):
+		out.Warn = "inbox has no configured sender (removed from config?); not sent — stays approved"
 	case backend.IsPermanent(sendErr):
 		if bErr := s.deliverBounce(m, "upstream delivery failed permanently", false); bErr != nil {
 			out.Warn = fmt.Sprintf("re-send failed permanently AND bounce delivery failed: %v", bErr)

--- a/internal/listener/smtp.go
+++ b/internal/listener/smtp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/emersion/go-smtp"
 
 	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/provenance"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
@@ -139,6 +140,22 @@ func (s *session) Data(r io.Reader) error {
 	raw, err := io.ReadAll(r)
 	if err != nil {
 		return err
+	}
+	// Routing + ADR 0027 send-scoping key on the envelope MAIL FROM, but recipients
+	// see the header From. Reject at submit when the visible header From diverges
+	// from the routed/scoped envelope sender (C27), so a send-granted agent cannot
+	// present an identity it holds no grant on. An ambiguous From (unparseable
+	// header block, more than one From header, or not exactly one address) is
+	// rejected fail-closed; an absent From is allowed. The legitimate "send as a
+	// different identity" path is the operator's ApproveAs, not a divergent header.
+	hdrFrom, err := provenance.SubmitFromAddress(raw)
+	if err != nil {
+		slog.Warn("submission rejected: ambiguous From header", "agent", s.agent, "inbox", s.inbox, "error", err)
+		return &smtp.SMTPError{Code: 550, EnhancedCode: smtp.EnhancedCode{5, 7, 1}, Message: "message From header is malformed or ambiguous"}
+	}
+	if hdrFrom != "" && hdrFrom != provenance.NormalizeAddress(s.from) {
+		slog.Warn("submission rejected: header From differs from envelope sender", "agent", s.agent, "inbox", s.inbox)
+		return &smtp.SMTPError{Code: 550, EnhancedCode: smtp.EnhancedCode{5, 7, 1}, Message: "message From header does not match the envelope sender"}
 	}
 	if _, err := s.backend.queue.Enqueue(sluice.Submission{
 		Agent: s.agent,

--- a/internal/listener/smtp_test.go
+++ b/internal/listener/smtp_test.go
@@ -256,6 +256,45 @@ func TestSubmitQueueFailureIsTransientAndOpaque(t *testing.T) {
 	assert.NotContains(t, se.Message, "internal detail")
 }
 
+// C27: the submit face rejects a message whose header From address diverges from
+// the envelope MAIL FROM (a send-granted agent can't present an identity it holds
+// no grant on). A matching address with a display name, and an absent From, pass.
+func TestSubmitRejectsHeaderEnvelopeFromMismatch(t *testing.T) {
+	q := newSluice(t)
+	addr := startServer(t, listener.ServerConfig{
+		TLSConfig: &tls.Config{Certificates: []tls.Certificate{selfSigned(t)}},
+	}, q)
+
+	dial := func() *smtp.Client {
+		c, err := smtp.DialStartTLS(addr, &tls.Config{InsecureSkipVerify: true})
+		require.NoError(t, err)
+		require.NoError(t, c.Auth(sasl.NewPlainClient("", testUser, testPass)))
+		return c
+	}
+
+	// Header From differs from the envelope → rejected at DATA, nothing queued.
+	c := dial()
+	mismatch := "From: ceo@local\r\nTo: d@x.test\r\n\r\nbody\r\n"
+	require.Error(t, c.SendMail("agent@local", []string{"d@x.test"}, strings.NewReader(mismatch)))
+	_ = c.Close()
+
+	// Matching address with a display name → accepted (address-only comparison).
+	c = dial()
+	display := "From: Agent <agent@local>\r\nTo: d@x.test\r\n\r\nbody\r\n"
+	require.NoError(t, c.SendMail("agent@local", []string{"d@x.test"}, strings.NewReader(display)))
+	_ = c.Quit()
+
+	// Absent From → accepted (nothing to compare).
+	c = dial()
+	noFrom := "Subject: hi\r\nTo: d@x.test\r\n\r\nbody\r\n"
+	require.NoError(t, c.SendMail("agent@local", []string{"d@x.test"}, strings.NewReader(noFrom)))
+	_ = c.Quit()
+
+	metas, err := q.List()
+	require.NoError(t, err)
+	assert.Len(t, metas, 2, "only the matching-From and absent-From submissions are queued")
+}
+
 func TestPlaintextRequiresAuth(t *testing.T) {
 	q := newSluice(t)
 	addr := startServer(t, listener.ServerConfig{AllowInsecure: true}, q)

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -6,12 +6,19 @@ package provenance
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"net/mail"
 	"strings"
 
 	"github.com/emersion/go-message/textproto"
 )
+
+// NormalizeAddress is the one canonical form for an RFC 5321 address across the
+// gate — lower-cased and trimmed. From, the submit-time header/envelope check
+// (C27), and the ADR 0031 per-sender trust chokepoint all compare through it, so
+// there is a single normalizer, not two that could drift.
+func NormalizeAddress(addr string) string { return strings.ToLower(strings.TrimSpace(addr)) }
 
 // From extracts the sender address from a raw message's From header, normalized
 // to a lower-cased RFC 5321 address (e.g. "alice@example.com"), or "" when there
@@ -28,7 +35,41 @@ func From(raw []byte) string {
 	if err != nil {
 		return ""
 	}
-	return strings.ToLower(strings.TrimSpace(addr.Address))
+	return NormalizeAddress(addr.Address)
+}
+
+// SubmitFromAddress returns the normalized RFC 5321 address of a submitted
+// message's From header for the submit-time spoof check (C27), enforcing that the
+// visible From is unambiguous before it is compared to the envelope sender:
+//   - no From header            → ("", nil): allowed, nothing to compare
+//   - exactly one From, one addr → (addr, nil)
+//   - unparseable header block, more than one From header, or a From that is not
+//     exactly one address → ("", err): the caller rejects fail-closed
+//
+// Rejecting the ambiguous cases (rather than comparing only the first) closes the
+// gap where a client renders a different From than the one checked. Scope is
+// From-only by decision — Reply-To/Sender are a softer reply-path vector, out of
+// scope here.
+func SubmitFromAddress(raw []byte) (string, error) {
+	hdr, err := textproto.ReadHeader(bufio.NewReader(bytes.NewReader(raw)))
+	if err != nil {
+		return "", fmt.Errorf("unparseable header block: %w", err)
+	}
+	froms := hdr.Values("From")
+	switch {
+	case len(froms) == 0:
+		return "", nil // no From header — nothing to compare
+	case len(froms) > 1:
+		return "", fmt.Errorf("message has %d From headers", len(froms))
+	}
+	list, err := mail.ParseAddressList(froms[0])
+	if err != nil {
+		return "", fmt.Errorf("unparseable From header: %w", err)
+	}
+	if len(list) != 1 {
+		return "", fmt.Errorf("From header must be a single address, got %d", len(list))
+	}
+	return NormalizeAddress(list[0].Address), nil
 }
 
 // Namespace is the header-name prefix darbaan reserves for its own

--- a/internal/provenance/provenance_test.go
+++ b/internal/provenance/provenance_test.go
@@ -215,3 +215,30 @@ func TestFrom(t *testing.T) {
 	assert.Equal(t, "", provenance.From([]byte("Subject: no from\r\n\r\nbody")), "no From → empty")
 	assert.Equal(t, "", provenance.From([]byte("not a message")), "unparseable → empty")
 }
+
+// C27: SubmitFromAddress normalizes a single From, allows an absent From (nothing
+// to compare), and rejects every ambiguous shape fail-closed so the submit check
+// can never be bypassed by a header a client renders differently than we compare.
+func TestSubmitFromAddress(t *testing.T) {
+	ok := func(raw, want string) func(*testing.T) {
+		return func(t *testing.T) {
+			got, err := provenance.SubmitFromAddress([]byte(raw))
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		}
+	}
+	bad := func(raw string) func(*testing.T) {
+		return func(t *testing.T) {
+			_, err := provenance.SubmitFromAddress([]byte(raw))
+			require.Error(t, err)
+		}
+	}
+	t.Run("single address", ok("From: alice@example.com\r\n\r\nbody", "alice@example.com"))
+	t.Run("case+space normalized", ok("From:   Alice@Example.COM \r\n\r\nbody", "alice@example.com"))
+	t.Run("display name stripped", ok("From: Alice <alice@example.com>\r\n\r\nbody", "alice@example.com"))
+	t.Run("absent From allowed", ok("Subject: hi\r\n\r\nbody", ""))
+	t.Run("two From headers rejected", bad("From: a@x.test\r\nFrom: b@y.test\r\n\r\nbody"))
+	t.Run("two addresses rejected", bad("From: a@x.test, b@y.test\r\n\r\nbody"))
+	t.Run("unparseable From rejected", bad("From: not-an-address\r\n\r\nbody"))
+	t.Run("unparseable header block rejected", bad("this-is-not-a-header\r\n\r\nbody"))
+}


### PR DESCRIPTION
The final two findings of #232 — **C25** and **C27**. With this, #232 is complete.

`Closes #232`

> **Stacked on #243.** Base is `fix/232-unstrand-c4-c21-c26` so the diff shows only C25/C27 (C25 touches `senderFor`, which #243 also touched). Once #243 merges I'll rebase `--onto main` and retarget the base to `main`. Review the delta here; it will not merge before #243.

### C25 (LOW) — refuse a send whose inbox sender was removed
`senderFor` silently fell back to the default inbox's sender when a stamped inbox had none, so a message authored as inbox X — whose inbox was removed from config while it was held — went out through the *default* account. `newSenders` builds one sender per configured inbox, so a miss unambiguously means removed-from-config. `senderFor` is now strict (returns `ok=false` on a miss), and the approve and re-send paths route through a `sendVia` helper that refuses with `errNoSender`: the message stays approved, visible (`SendErr`), and re-sendable once the inbox is restored — never bounced, never delivered under the wrong account.

### C27 (LOW) — reject header/envelope From divergence at submit
Routing and ADR 0027 send-scoping key on the envelope MAIL FROM, but recipients see the header From, so a send-granted agent could present a header `From:` for an identity it holds no grant on — and the operator's `queue ls` shows the envelope From, so the spoof isn't visible at the decision point.

The submit face now rejects at DATA when the header From address diverges from the envelope sender. Chosen shape: **reject at submit**, not flag-for-approver. Flagging would spend the operator attention C22 just hardened, and the legitimate "send as a different identity" path already exists as the operator's **ApproveAs** (now correctly persisted post-#243). Reject adds **no new state**, so no re-send path has to honor it (the #243 lesson).

Checklist honored:
- normalized RFC 5321 address comparison through the **single** provenance normalizer (`NormalizeAddress`) — `From`, this check, and the ADR 0031 trust chokepoint all share it; no second path.
- address-only comparison — display names are free.
- ambiguous From → reject fail-closed: unparseable header block, **more than one From header**, or a From that isn't exactly one address.
- absent From → allowed (nothing to compare).
- **Scope is From-only by decision** — Reply-To / Sender are a softer reply-path vector, consciously out of scope (a decision, not an omission).

### Tests
- approve and re-send both refuse a removed-sender inbox and stay approved.
- `SubmitFromAddress`: single/normalized/display-name pass; absent allowed; multiple-From, multi-address, and unparseable-block all rejected.
- submit face rejects a header/envelope mismatch end-to-end while accepting a display-named match and an absent From.

Verified locally: `gofmt`, `go build`, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 — all clean.
