### PR TITLE
fix: audit tail-truncation detection, inbound verdicts + attribution (#236)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -118,6 +118,7 @@ type CLI struct {
 	LogFormat string `name:"log-format" default:"text" enum:"text,json" help:"Log handler: text (human-readable) or json (structured ingest)."`
 
 	Serve      ServeCmd      `cmd:"" help:"Run the SMTP + IMAP faces and the admin API."`
+	Audit      AuditCmd      `cmd:"" help:"Inspect the tamper-evident audit log (ADR 0011)."`
 	Queue      QueueCmd      `cmd:"" help:"Inspect and decide held messages (via the running serve's admin API)."`
 	Holds      HoldsCmd      `cmd:"" help:"Inspect and decide inbound messages held for a human (ADR 0021)."`
 	Reconcile  ReconcileCmd  `cmd:"" help:"Inspect and release inboxes held by the reconcile safety cap (ADR 0026)."`
@@ -991,6 +992,38 @@ func (*VersionCmd) Run() error {
 	return nil
 }
 
+// AuditCmd groups audit-log inspection subcommands. They open the audit database
+// directly (no running serve), so they operate on the on-disk chain.
+type AuditCmd struct {
+	Verify AuditVerifyCmd `cmd:"" help:"Verify the audit log's hash chain and sequence integrity (ADR 0011). Non-zero exit on any tampering or truncation."`
+}
+
+// AuditVerifyCmd runs the audit log's integrity check (ADR 0011, C15): the
+// hash-chain links, per-entry hashes, a gap-free sequence keyed to each record,
+// and that the tail was not truncated. It exits non-zero on the first violation
+// so it is usable as a monitoring / incident-response gate.
+type AuditVerifyCmd struct{}
+
+func (*AuditVerifyCmd) Run(cli *CLI) error {
+	if cli.AuditType != "bbolt" {
+		// audit-type=null keeps no on-disk chain; there is nothing to verify.
+		fmt.Printf("audit-type=%s: no audit chain to verify\n", cli.AuditType)
+		return nil
+	}
+	// Read-only open takes bbolt's shared lock and never writes, so it cannot run
+	// while serve holds the exclusive write lock — stop serve first.
+	al, err := audit.OpenReadOnly(cli.AuditDB)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = al.Close() }()
+	if err := al.Verify(); err != nil {
+		return err // a real integrity violation: surface it and exit non-zero
+	}
+	fmt.Println("audit: chain verified OK")
+	return nil
+}
+
 // ServeCmd runs the SMTP + IMAP faces and the operator admin API.
 type ServeCmd struct{}
 
@@ -1053,6 +1086,9 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// The admin API owns the approval orchestration; it fails closed without a
 	// token (no unauthenticated admin surface).
 	svc := admin.NewService(q, inbox, sender, sgn, cli.router(), cli.ListenerDomain)
+	// Inbound hold verdicts (expose/drop) audit to the same shared log the message
+	// store writes outbound verdicts to (ADR 0011, C29).
+	svc.SetAuditLog(al)
 	adminSrv, err := admin.NewServer(cli.AdminAddr, os.Getenv("DARBAAN_ADMIN_TOKEN"), svc)
 	if err != nil {
 		return err

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -1,6 +1,7 @@
 package admin
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
@@ -14,12 +15,32 @@ import (
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
 
-// credential is one admin-API bearer credential (ADR 0029): the SHA-256 of its
-// full "Bearer <token>" header value (fixed-width, so the constant-time compare
-// can never leak token length) and the set of scopes it grants.
+// credential is one admin-API bearer credential (ADR 0029): the acting client's
+// name (for audit attribution), the SHA-256 of its full "Bearer <token>" header
+// value (fixed-width, so the constant-time compare can never leak token length),
+// and the set of scopes it grants.
 type credential struct {
+	name   string
 	hash   [32]byte
 	scopes map[string]bool
+}
+
+// actorCtxKey carries the acting operator client's name (ADR 0029) from the
+// authenticated request down to the service, so a state-changing verdict's audit
+// row can attribute who decided it (C30). Unexported: only this package sets it
+// (in scoped) and reads it (actorFrom).
+type actorCtxKey struct{}
+
+// withActor returns ctx carrying the acting client's name.
+func withActor(ctx context.Context, name string) context.Context {
+	return context.WithValue(ctx, actorCtxKey{}, name)
+}
+
+// actorFrom returns the acting client name carried on ctx, or "" when none is set
+// (a direct service call, e.g. in a test).
+func actorFrom(ctx context.Context) string {
+	name, _ := ctx.Value(actorCtxKey{}).(string)
+	return name
 }
 
 // Server is the localhost-only HTTP admin API. It is the operator's approval
@@ -51,6 +72,7 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 	}
 	s := &Server{svc: svc}
 	s.creds = append(s.creds, credential{
+		name:   "root", // the full-scope break-glass credential (ADR 0029)
 		hash:   hashBearer(token),
 		scopes: scopeSet(admincfg.AllScopes()),
 	})
@@ -94,6 +116,7 @@ func (s *Server) SetScopedClients(clients []ScopedClient) {
 			continue
 		}
 		s.creds = append(s.creds, credential{
+			name:   c.Name,
 			hash:   hashBearer(c.Token),
 			scopes: scopeSet(c.Scopes),
 		})
@@ -148,7 +171,9 @@ func (s *Server) scoped(required string, next http.HandlerFunc) http.HandlerFunc
 			writeErr(w, http.StatusForbidden, errors.New("forbidden: missing scope "+required))
 			return
 		}
-		next(w, r)
+		// Attribute the acting client on every authorized request, so a state-changing
+		// handler's audit row records who decided it (ADR 0029 / C30).
+		next(w, r.WithContext(withActor(r.Context(), cred.name)))
 	}
 }
 
@@ -257,12 +282,12 @@ func (s *Server) handleHeldContent(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleExpose(w http.ResponseWriter, r *http.Request) {
-	m, err := s.svc.ExposeHeld(r.PathValue("id"))
+	m, err := s.svc.ExposeHeld(r.Context(), r.PathValue("id"))
 	s.writeHold(w, m, err)
 }
 
 func (s *Server) handleDrop(w http.ResponseWriter, r *http.Request) {
-	m, err := s.svc.DropHeld(r.PathValue("id"))
+	m, err := s.svc.DropHeld(r.Context(), r.PathValue("id"))
 	s.writeHold(w, m, err)
 }
 

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -3,12 +3,15 @@ package admin_test
 import (
 	"context"
 	"net"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/admincfg"
+	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/filter"
 	"github.com/yaad-index/darbaan/internal/inbound"
@@ -59,6 +62,43 @@ func TestAdminRoundtrip(t *testing.T) {
 
 	got, _ := q.Get(id)
 	assert.Equal(t, sluice.StatusSent, got.Status) // the chain ran in the server
+}
+
+// C30: a verdict made through a named scoped client (ADR 0029) audits that
+// client's name as the actor — the middleware carries it from the authenticated
+// request down to the store's verdict audit row, end to end.
+func TestVerdictAuditsActingClientName(t *testing.T) {
+	cap := &capturingAudit{}
+	q, err := sluice.New("bbolt", filepath.Join(t.TempDir(), "s.db"), cap)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
+	require.NoError(t, err)
+
+	svc := admin.NewService(q, newInbound(t), backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	srv, err := admin.NewServer("", "root-token", svc)
+	require.NoError(t, err)
+	srv.SetScopedClients([]admin.ScopedClient{{
+		Name:   "telegram-bot",
+		Token:  "scoped-tok",
+		Scopes: []string{admincfg.ScopeQueueRead, admincfg.ScopeQueueDecide},
+	}})
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = srv.Serve(l) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	_, err = admin.NewClient(l.Addr().String(), "scoped-tok").Approve(context.Background(), m.ID)
+	require.NoError(t, err)
+
+	var approve *audit.Record
+	for i := range cap.records {
+		if cap.records[i].Event == "approve" {
+			approve = &cap.records[i]
+		}
+	}
+	require.NotNil(t, approve, "the approve verdict was audited")
+	assert.Equal(t, "telegram-bot", approve.Actor)
 }
 
 func TestAdminUnauthorized(t *testing.T) {

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/yaad-index/darbaan/internal/approver"
+	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/backend"
 	"github.com/yaad-index/darbaan/internal/bounce"
 	"github.com/yaad-index/darbaan/internal/bounceguard"
@@ -43,6 +44,7 @@ type Service struct {
 	mailOwner  func(inbox string) string // synced-mail owner key per inbox (ADR 0027); nil until wired
 	guard      *bounceguard.Guard        // inbound bounce-spoof guard (ADR 0024; nil = off)
 	holdSpoof  bool                      // on_spoof=hold-for-human → spoofs join the held queue
+	audit      audit.AuditLog            // inbound-verdict audit sink (ADR 0011; nil = not wired, e.g. in tests)
 
 	// Reconcile controls (ADR 0026), wired by serve over its per-inbox syncers;
 	// nil when no inbox has an upstream (nothing to reconcile).
@@ -169,6 +171,12 @@ func (s *Service) senderFor(inbox string) (backend.Sender, bool) {
 	return snd, snd != nil
 }
 
+// SetAuditLog wires the tamper-evident audit sink for inbound hold verdicts
+// (ADR 0011): setHold records each expose/drop decision. serve supplies the same
+// log the message store writes to; without it (tests) inbound verdicts are not
+// audited, matching the store's own best-effort, non-fatal audit contract.
+func (s *Service) SetAuditLog(al audit.AuditLog) { s.audit = al }
+
 // SetInboundHolds wires the inbound hold-for-human queue (ADR 0021/0023): the
 // per-inbox filters that decide which synced messages are held, the per-inbox
 // mail-owner key their records live under (ADR 0027), and the bounce-spoof guard
@@ -288,23 +296,26 @@ func envelopeFromLocals(m inbound.Message) []string {
 }
 
 // ExposeHeld approves a held message for the agent to see (ADR 0021).
-func (s *Service) ExposeHeld(id string) (inbound.Message, error) {
-	return s.setHold(id, inbound.HoldApproved)
+func (s *Service) ExposeHeld(ctx context.Context, id string) (inbound.Message, error) {
+	return s.setHold(ctx, id, inbound.HoldApproved)
 }
 
 // DropHeld rejects a held message — it stays hidden from the agent (ADR 0021).
-func (s *Service) DropHeld(id string) (inbound.Message, error) {
-	return s.setHold(id, inbound.HoldRejected)
+func (s *Service) DropHeld(ctx context.Context, id string) (inbound.Message, error) {
+	return s.setHold(ctx, id, inbound.HoldRejected)
 }
 
 // setHold applies a hold decision to the message with this (store-wide unique) id,
 // resolving which inbox holds it (ADR 0023): the id is unique across the store, so
 // at most one inbox's (owner,inbox)-scoped record matches and the rest return
-// ErrNotFound. Returns ErrNotFound if no inbox holds it.
-func (s *Service) setHold(id, decision string) (inbound.Message, error) {
+// ErrNotFound. Returns ErrNotFound if no inbox holds it. On success it audits the
+// verdict (ADR 0011, C29): ADR 0011's "every verdict" covers inbound holds too, not
+// just outbound, attributed to the deciding operator client (C30).
+func (s *Service) setHold(ctx context.Context, id, decision string) (inbound.Message, error) {
 	for _, inbox := range s.inboxNames() {
 		m, err := s.inbox.SetHoldDecision(s.inboxOwner(inbox), inbox, id, decision)
 		if err == nil {
+			s.auditHold(ctx, m, decision)
 			return m, nil
 		}
 		if !errors.Is(err, inbound.ErrNotFound) {
@@ -312,6 +323,25 @@ func (s *Service) setHold(id, decision string) (inbound.Message, error) {
 		}
 	}
 	return inbound.Message{}, inbound.ErrNotFound
+}
+
+// auditHold records an inbound expose/drop verdict in the tamper-evident log
+// (ADR 0011). Best-effort and non-fatal, mirroring the message store's own audit
+// contract: the hold decision is already committed (the source of truth), so a
+// failed append is logged, never returned. A nil sink (unwired, e.g. in tests) is
+// a no-op.
+func (s *Service) auditHold(ctx context.Context, m inbound.Message, decision string) {
+	if s.audit == nil {
+		return
+	}
+	event := "drop"
+	if decision == inbound.HoldApproved {
+		event = "expose"
+	}
+	rec := audit.Record{Event: event, Inbox: m.Inbox, Actor: actorFrom(ctx), MessageID: m.ID}
+	if err := s.audit.Append(rec); err != nil {
+		slog.Warn("best-effort inbound-verdict audit append failed", "message_id", m.ID, "event", event, "err", err)
+	}
 }
 
 // Outcome is the result of an approve/reject action. Status is the committed
@@ -360,11 +390,12 @@ func (s *Service) decide(ctx context.Context, id string, human approver.Verdict,
 	if err != nil {
 		return sluice.Message{}, err
 	}
+	actor := actorFrom(ctx) // the operator client that decided (ADR 0029), audited for attribution (C30)
 	switch outcome.Disposition {
 	case approver.Approve:
-		return s.store.Approve(id, outcome.DecidedBy, outcome.Released, asInbox)
+		return s.store.Approve(id, outcome.DecidedBy, outcome.Released, asInbox, actor)
 	case approver.Reject:
-		return s.store.Reject(id, outcome.DecidedBy, outcome.Reason, outcome.Retryable)
+		return s.store.Reject(id, outcome.DecidedBy, outcome.Reason, outcome.Retryable, actor)
 	default:
 		return msg, nil // Hold — stays pending
 	}
@@ -440,7 +471,7 @@ func (s *Service) approve(ctx context.Context, id, asInbox string) (Outcome, err
 	}
 
 	sendErr := s.sendVia(ctx, sendInbox, sendMsg)
-	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, false)
+	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, false, actorFrom(ctx), identity)
 	if rerr != nil {
 		return Outcome{}, rerr
 	}
@@ -536,7 +567,7 @@ func (s *Service) ReSend(ctx context.Context, id string) (Outcome, error) {
 	slog.Info("resend", "message_id", m.ID, "inbox", inbound.NormInbox(sendInbox), "identity", identity)
 
 	sendErr := s.sendVia(ctx, sendInbox, sendMsg)
-	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, true)
+	final, rerr := s.store.RecordSendAttempt(m.ID, sendErr, true, actorFrom(ctx), identity)
 	if rerr != nil {
 		return Outcome{}, rerr
 	}

--- a/internal/admin/service_test.go
+++ b/internal/admin/service_test.go
@@ -271,7 +271,7 @@ func TestInboundHoldQueue(t *testing.T) {
 	assert.Equal(t, held.ID, list[0].ID)
 
 	// Expose decides it → off the held list, and the read face would now show it.
-	_, err = svc.ExposeHeld(held.ID)
+	_, err = svc.ExposeHeld(context.Background(), held.ID)
 	require.NoError(t, err)
 	list, err = svc.HeldList()
 	require.NoError(t, err)
@@ -280,11 +280,48 @@ func TestInboundHoldQueue(t *testing.T) {
 	// Drop also decides (stays hidden) → off the held list.
 	_, held2, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 3, UIDValidity: 1, Keywords: []string{"review"}})
 	require.NoError(t, err)
-	_, err = svc.DropHeld(held2.ID)
+	_, err = svc.DropHeld(context.Background(), held2.ID)
 	require.NoError(t, err)
 	list, err = svc.HeldList()
 	require.NoError(t, err)
 	assert.Empty(t, list)
+}
+
+// capturingAudit records appended entries for assertion (an in-memory AuditLog).
+type capturingAudit struct{ records []audit.Record }
+
+func (c *capturingAudit) Append(r audit.Record) error { c.records = append(c.records, r); return nil }
+func (c *capturingAudit) Verify() error               { return nil }
+func (c *capturingAudit) Close() error                { return nil }
+
+// C29: inbound hold verdicts (expose/drop) are audited — ADR 0011's "every
+// verdict" covers inbound holds, not just outbound.
+func TestInboundHoldVerdictsAudited(t *testing.T) {
+	q, _ := seedStore(t)
+	inbox := newInbound(t)
+	svc := admin.NewService(q, inbox, backend.StubSender{}, testSigner(t), strictRouter(), "darbaan.test")
+	cap := &capturingAudit{}
+	svc.SetAuditLog(cap)
+	flt, err := filter.Compile([]byte("rules: [{match: [{field: label, op: equals, value: review}], action: hold-for-human}]"))
+	require.NoError(t, err)
+	svc.SetInboundHolds(map[string]*filter.Filter{inbound.DefaultInbox: flt}, func(string) string { return "agent" }, nil, false)
+
+	_, exposed, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+	_, dropped, err := inbox.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 2, UIDValidity: 1, Keywords: []string{"review"}})
+	require.NoError(t, err)
+
+	em, err := svc.ExposeHeld(context.Background(), exposed.ID)
+	require.NoError(t, err)
+	_, err = svc.DropHeld(context.Background(), dropped.ID)
+	require.NoError(t, err)
+
+	require.Len(t, cap.records, 2)
+	assert.Equal(t, "expose", cap.records[0].Event)
+	assert.Equal(t, exposed.ID, cap.records[0].MessageID)
+	assert.Equal(t, em.Inbox, cap.records[0].Inbox)
+	assert.Equal(t, "drop", cap.records[1].Event)
+	assert.Equal(t, dropped.ID, cap.records[1].MessageID)
 }
 
 // HeldContent (ADR 0032 change A) returns a held message's stored body for the
@@ -313,7 +350,7 @@ func TestHeldContentRestrictedToHeld(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, raw, "a non-held id returns no content")
 
-	_, err = svc.ExposeHeld(held.ID)
+	_, err = svc.ExposeHeld(context.Background(), held.ID)
 	require.NoError(t, err)
 	raw, err = svc.HeldContent(held.ID)
 	require.NoError(t, err)
@@ -345,7 +382,7 @@ func TestInboundHoldQueueIncludesAssessment(t *testing.T) {
 	require.NotNil(t, list[0].Assessment)
 	assert.Equal(t, "flagged", list[0].Assessment.Summary, "the reason is surfaced for the operator")
 
-	_, err = svc.ExposeHeld(m.ID)
+	_, err = svc.ExposeHeld(context.Background(), m.ID)
 	require.NoError(t, err)
 	list, err = svc.HeldList()
 	require.NoError(t, err)
@@ -377,7 +414,7 @@ func TestInboundHoldQueueMultiInbox(t *testing.T) {
 	require.Len(t, list, 2) // aggregated across both inboxes
 
 	// ExposeHeld resolves the personal inbox from the id; work's hold remains.
-	_, err = svc.ExposeHeld(persHeld.ID)
+	_, err = svc.ExposeHeld(context.Background(), persHeld.ID)
 	require.NoError(t, err)
 	list, err = svc.HeldList()
 	require.NoError(t, err)
@@ -386,7 +423,7 @@ func TestInboundHoldQueueMultiInbox(t *testing.T) {
 	assert.Equal(t, "work", list[0].Inbox)
 
 	// An unknown id resolves to no inbox.
-	_, err = svc.ExposeHeld("99999")
+	_, err = svc.ExposeHeld(context.Background(), "99999")
 	require.ErrorIs(t, err, inbound.ErrNotFound)
 }
 
@@ -424,7 +461,7 @@ func TestInboundBounceGuardHold(t *testing.T) {
 	assert.Equal(t, spoof.ID, list[0].ID)
 
 	// Dropping decides it → off the held list.
-	_, err = svc.DropHeld(spoof.ID)
+	_, err = svc.DropHeld(context.Background(), spoof.ID)
 	require.NoError(t, err)
 	list, err = svc.HeldList()
 	require.NoError(t, err)

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -18,13 +18,21 @@ import (
 
 // Record is the caller-supplied content of an audit entry. Agent + Inbox are the
 // acting principal and the inbox it acted as (ADR 0027): every row answers "which
-// agent did what, as which inbox".
+// agent did what, as which inbox". Actor names the operator client that made an
+// operator decision (ADR 0029 named clients), distinct from the message's own
+// agent — it is empty for agent-originated events (e.g. enqueue).
 type Record struct {
 	Event     string `json:"event"`
 	Agent     string `json:"agent"`
 	Inbox     string `json:"inbox,omitempty"` // the inbox the action was scoped to (ADR 0023/0027)
+	Actor     string `json:"actor,omitempty"` // the operator client that decided (ADR 0029); "" for agent-originated events
 	MessageID string `json:"message_id"`
 	Detail    string `json:"detail,omitempty"` // e.g. reject reason, send-attempt result
+	// Retryable records a reject's permanence (ADR 0006): a permanent (non-retryable)
+	// reject is an operator security signal. It is a pointer so it is meaningful only
+	// where it applies — nil (omitted) for every non-reject event, rather than a bare
+	// false that would read as "permanent" on rows the flag does not describe.
+	Retryable *bool `json:"retryable,omitempty"`
 }
 
 // Entry is a persisted, hash-chained audit entry. Hash binds PrevHash and the
@@ -43,12 +51,18 @@ type Entry struct {
 type AuditLog interface {
 	// Append records one entry. For the bbolt log it links into the hash chain.
 	Append(Record) error
-	// Verify reports the first integrity violation in the log, if any.
+	// Verify reports the first integrity violation in the log, if any. It proves
+	// the entries are intact AND that none were removed from the log: the
+	// prev_hash links, the per-entry hash, a gap-free Seq run keyed to the record,
+	// and — via the store's monotonic sequence counter, which survives deletes —
+	// that the tail was not truncated. A truncate-then-append resumes at a higher
+	// counter value, so it breaks the Seq run and is no longer undetectable
+	// (ADR 0011).
 	//
-	// Integrity is NOT completeness: Verify proves the prev_hash links between
-	// the entries that ARE present are intact, but it cannot detect entries that
-	// were never written (the best-effort gap, since audit is written after the
-	// message-store commit). Detecting such gaps would be a separate
+	// Integrity is NOT completeness across stores: Verify cannot detect an entry
+	// that was never written in the first place (the best-effort gap, since audit
+	// is written after the message-store commit — a missing entry never enters
+	// this log, so there is no counter to be short). Detecting that is a separate
 	// message-store-to-audit cross-reference, not Verify's job — see the seam in
 	// the bbolt implementation. An empty or disabled log verifies clean.
 	Verify() error

--- a/internal/audit/audit_test.go
+++ b/internal/audit/audit_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
+
+	"github.com/yaad-index/darbaan/internal/seqkey"
 )
 
 func newBboltLog(t *testing.T) AuditLog {
@@ -87,5 +89,96 @@ func TestRegisteredListsBuiltins(t *testing.T) {
 
 func TestBboltRequiresPath(t *testing.T) {
 	_, err := New("bbolt", "")
+	require.Error(t, err)
+}
+
+// C15(a): deleting the last entry (a plain tail truncation) must be evident. The
+// bucket's sequence counter survives the delete, so it ends ahead of the head.
+func TestBboltDetectsTailTruncation(t *testing.T) {
+	l := newBboltLog(t)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, l.Append(Record{Event: "enqueue"}))
+	}
+	require.NoError(t, l.Verify())
+
+	bl := l.(*bboltLog)
+	require.NoError(t, bl.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		k, _ := b.Cursor().Last()
+		return b.Delete(k) // drop the tail; the sequence counter stays at 3
+	}))
+	require.Error(t, l.Verify(), "tail truncation must be detected")
+}
+
+// C15(a): the truncate-then-append attack — delete the tail, then append onto the
+// surviving head. The append resumes at the higher counter value, so the Seq run
+// gaps and the re-chained entry is no longer undetectable.
+func TestBboltDetectsTruncateThenAppend(t *testing.T) {
+	l := newBboltLog(t)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, l.Append(Record{Event: "enqueue"}))
+	}
+	bl := l.(*bboltLog)
+	require.NoError(t, bl.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		k, _ := b.Cursor().Last()
+		return b.Delete(k) // remove seq 3
+	}))
+	// A genuine later append continues from the (delete-proof) counter → seq 4,
+	// chaining hash-correctly onto seq 2. Only the Seq-run check catches it.
+	require.NoError(t, l.Append(Record{Event: "enqueue"}))
+	require.Error(t, l.Verify(), "truncate-then-append must be detected")
+}
+
+// C15: an interior deletion breaks the gap-free sequence run.
+func TestBboltDetectsInteriorGap(t *testing.T) {
+	l := newBboltLog(t)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, l.Append(Record{Event: "enqueue"}))
+	}
+	bl := l.(*bboltLog)
+	require.NoError(t, bl.db.Update(func(tx *bbolt.Tx) error {
+		return tx.Bucket(bucketName).Delete(seqkey.Encode(2)) // remove the middle entry
+	}))
+	require.Error(t, l.Verify(), "interior gap must be detected")
+}
+
+// C15: an entry moved to a key that disagrees with its own Seq is caught by the
+// key↔Seq agreement check (a record can't be silently relocated).
+func TestBboltDetectsKeySeqMismatch(t *testing.T) {
+	l := newBboltLog(t)
+	require.NoError(t, l.Append(Record{Event: "enqueue"}))
+
+	bl := l.(*bboltLog)
+	require.NoError(t, bl.db.Update(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		k, v := b.Cursor().First()
+		if err := b.Delete(k); err != nil {
+			return err
+		}
+		return b.Put(seqkey.Encode(99), v) // same entry (Seq 1) under key 99
+	}))
+	require.Error(t, l.Verify(), "key that disagrees with entry Seq must be detected")
+}
+
+// C15: the read-only opener used by `darbaan audit verify` verifies a clean chain
+// and still detects tampering, without taking the write lock.
+func TestBboltOpenReadOnlyVerifies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.db")
+	l, err := New("bbolt", path)
+	require.NoError(t, err)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, l.Append(Record{Event: "enqueue"}))
+	}
+	require.NoError(t, l.Close()) // release the write lock so a RO open can take the shared one
+
+	ro, err := OpenReadOnly(path)
+	require.NoError(t, err)
+	require.NoError(t, ro.Verify())
+	require.NoError(t, ro.Close())
+}
+
+func TestOpenReadOnlyRequiresPath(t *testing.T) {
+	_, err := OpenReadOnly("")
 	require.Error(t, err)
 }

--- a/internal/audit/bbolt.go
+++ b/internal/audit/bbolt.go
@@ -75,8 +75,10 @@ func (l *bboltLog) Append(rec Record) error {
 	})
 }
 
-// Verify walks the chain and reports the first prev_hash-link or hash mismatch.
-// It proves integrity, not completeness — see the AuditLog.Verify godoc.
+// Verify walks the chain and reports the first integrity violation: a key that
+// disagrees with its entry's Seq, a gap in the Seq run, a broken prev_hash link,
+// or a hash mismatch — then confirms the tail is whole. It proves integrity, not
+// cross-store completeness (see the AuditLog.Verify godoc).
 func (l *bboltLog) Verify() error {
 	return l.db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket(bucketName)
@@ -84,10 +86,24 @@ func (l *bboltLog) Verify() error {
 			return nil
 		}
 		prevHash := ""
-		return b.ForEach(func(_, v []byte) error {
+		var wantSeq uint64 = 1 // NextSequence issues 1 for the first entry
+		var lastSeq uint64
+		if err := b.ForEach(func(k, v []byte) error {
 			var e Entry
 			if err := json.Unmarshal(v, &e); err != nil {
 				return err
+			}
+			// The key IS the entry's Seq (seqkey-encoded): a record moved to a
+			// different slot, or a Seq edited to fake continuity, disagrees here.
+			if keySeq := seqkey.Decode(k); keySeq != e.Seq {
+				return fmt.Errorf("audit: chain broken at key %d: entry seq is %d", keySeq, e.Seq)
+			}
+			// Seq must be a gap-free run from 1. A deleted interior entry, or a
+			// truncate-then-append (which resumes at the higher, delete-proof
+			// counter value), breaks the run — the check that makes truncation
+			// evident rather than silently re-chained (ADR 0011).
+			if e.Seq != wantSeq {
+				return fmt.Errorf("audit: chain broken at seq %d: expected %d (gap or truncation)", e.Seq, wantSeq)
 			}
 			if e.PrevHash != prevHash {
 				return fmt.Errorf("audit: chain broken at seq %d: prev_hash link mismatch", e.Seq)
@@ -95,19 +111,43 @@ func (l *bboltLog) Verify() error {
 			if want := computeHash(prevHash, e); want != e.Hash {
 				return fmt.Errorf("audit: chain broken at seq %d: hash mismatch", e.Seq)
 			}
-			// Gap-detection seam (not built): completeness — that every
-			// committed message has its audit entries — cannot be checked here.
-			// Because audit is written after the message-store commit, a missing
-			// entry never appears in this log at all, so Verify walks past it.
-			// Detecting that is a separate message-store-to-audit cross-reference
-			// keyed by message id, deliberately out of scope (ADR 0011).
 			prevHash = e.Hash
+			lastSeq = e.Seq
+			wantSeq++
 			return nil
-		})
+		}); err != nil {
+			return err
+		}
+		// The bucket's sequence counter is monotonic and survives deletes, so the
+		// last surviving entry's Seq must equal it. A truncated tail (delete the
+		// last N with no re-append) leaves the counter ahead of the head — the
+		// check that makes plain tail deletion evident, not just interior edits.
+		// Completeness across the message store stays out of scope (a never-written
+		// entry never advanced this counter); see the AuditLog.Verify godoc.
+		if seq := b.Sequence(); seq != lastSeq {
+			return fmt.Errorf("audit: tail truncated: last entry seq %d but %d were issued", lastSeq, seq)
+		}
+		return nil
 	})
 }
 
 func (l *bboltLog) Close() error { return l.db.Close() }
+
+// OpenReadOnly opens an existing bbolt audit log read-only for offline integrity
+// verification (the `darbaan audit verify` command). It never writes and takes
+// bbolt's shared lock, so it cannot run while a serve process holds the exclusive
+// write lock — stop serve first, or it fails fast on the lock timeout. A missing
+// bucket / empty database verifies clean.
+func OpenReadOnly(path string) (AuditLog, error) {
+	if path == "" {
+		return nil, fmt.Errorf("audit: bbolt requires a database path (audit-db)")
+	}
+	db, err := bbolt.Open(path, 0o600, &bbolt.Options{Timeout: time.Second, ReadOnly: true})
+	if err != nil {
+		return nil, fmt.Errorf("audit: open db read-only: %w", err)
+	}
+	return &bboltLog{db: db}, nil
+}
 
 // computeHash is the deterministic chain hash: sha256(prevHash || payload),
 // where payload is the entry without its own Hash field.

--- a/internal/seqkey/seqkey.go
+++ b/internal/seqkey/seqkey.go
@@ -12,3 +12,13 @@ func Encode(seq uint64) []byte {
 	binary.BigEndian.PutUint64(b, seq)
 	return b
 }
+
+// Decode reads back a key written by Encode. A key that is not exactly 8 bytes
+// decodes to 0, which callers that pair keys with a stored sequence treat as a
+// mismatch (the audit Verify uses it to assert key↔Seq agreement).
+func Decode(key []byte) uint64 {
+	if len(key) != 8 {
+		return 0
+	}
+	return binary.BigEndian.Uint64(key)
+}

--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -198,8 +198,8 @@ func (s *bboltStore) Get(id string) (Message, error) {
 	return s.withRaw(rec)
 }
 
-func (s *bboltStore) Approve(id, decidedBy string, released []byte, asInbox string) (Message, error) {
-	return s.transitionFromPending(id, "approve", decidedBy, func(m *Message) {
+func (s *bboltStore) Approve(id, decidedBy string, released []byte, asInbox, actor string) (Message, error) {
+	return s.transitionFromPending(id, "approve", decidedBy, actor, nil, func(m *Message) {
 		m.Status = StatusApproved
 		m.DecidedBy = decidedBy
 		// An amended body (ADR 0004) is recorded inline; it is nil in v1 (no
@@ -214,17 +214,26 @@ func (s *bboltStore) Approve(id, decidedBy string, released []byte, asInbox stri
 	})
 }
 
-func (s *bboltStore) Reject(id, decidedBy, reason string, retryable bool) (Message, error) {
-	return s.transitionFromPending(id, "reject", reason, func(m *Message) {
+func (s *bboltStore) Reject(id, decidedBy, reason string, retryable bool, actor string) (Message, error) {
+	out, err := s.transitionFromPending(id, "reject", reason, actor, &retryable, func(m *Message) {
 		m.Status = StatusRejected
 		m.DecidedBy = decidedBy
 		m.Reason = reason
 		m.Retryable = retryable
 	})
+	if err == nil && !retryable {
+		// A permanent (5xx) reject is an operator security signal (ADR 0006, C28):
+		// surface it loudly, distinct from the routine transient reject.
+		slog.Warn("outbound message permanently rejected", "message_id", id, "agent", out.Agent, "inbox", out.Inbox, "actor", actor)
+	}
+	return out, err
 }
 
-func (s *bboltStore) RecordSendAttempt(id string, sendErr error, resend bool) (Message, error) {
+func (s *bboltStore) RecordSendAttempt(id string, sendErr error, resend bool, actor, asIdentity string) (Message, error) {
 	detail := "sent"
+	if asIdentity != "" {
+		detail = "sent as " + asIdentity // ApproveAs identity, audited (C16)
+	}
 	var out Message
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		rec, key, err := loadStored(tx, id)
@@ -257,6 +266,9 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error, resend bool) (M
 	}
 	if sendErr != nil {
 		detail = sendErr.Error()
+		if asIdentity != "" {
+			detail += " (as " + asIdentity + ")"
+		}
 	}
 	// A re-send is a distinct, operator-triggered delivery — audit it under its own
 	// event so it is not indistinguishable from the first send in the durable log.
@@ -264,7 +276,7 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error, resend bool) (M
 	if resend {
 		event = "resend_attempt"
 	}
-	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, Inbox: out.Inbox, MessageID: id, Detail: detail})
+	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, Inbox: out.Inbox, Actor: actor, MessageID: id, Detail: detail})
 	return out, nil
 }
 
@@ -272,7 +284,7 @@ func (s *bboltStore) RecordSendAttempt(id string, sendErr error, resend bool) (M
 // writes a best-effort audit entry. It errors if the message is not pending, so
 // a verdict can never be applied twice. The returned message includes the raw
 // body (the approve/reject callers send it / attach it to a bounce).
-func (s *bboltStore) transitionFromPending(id, event, detail string, mutate func(*Message)) (Message, error) {
+func (s *bboltStore) transitionFromPending(id, event, detail, actor string, retryable *bool, mutate func(*Message)) (Message, error) {
 	var rec stored
 	err := s.db.Update(func(tx *bbolt.Tx) error {
 		r, key, err := loadStored(tx, id)
@@ -293,7 +305,7 @@ func (s *bboltStore) transitionFromPending(id, event, detail string, mutate func
 	if err != nil {
 		return Message{}, err
 	}
-	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, Inbox: out.Inbox, MessageID: id, Detail: detail})
+	s.writeAudit(audit.Record{Event: event, Agent: out.Agent, Inbox: out.Inbox, Actor: actor, MessageID: id, Detail: detail, Retryable: retryable})
 	return out, nil
 }
 

--- a/internal/sluice/sluice.go
+++ b/internal/sluice/sluice.go
@@ -123,18 +123,24 @@ type MessageStore interface {
 	// Get returns the full message (including the raw body), or ErrNotFound.
 	Get(id string) (Message, error)
 	// Approve marks a pending message approved, recording the deciding approver,
-	// (when edited) the released body, and (when an ApproveAs chose one) the
-	// asInbox whose identity to send from — decision metadata only; the stored
-	// body is unchanged. It does not send. ErrNotPending if not pending.
-	Approve(id, decidedBy string, released []byte, asInbox string) (Message, error)
-	// Reject marks a pending message rejected with a reason and retryable flag.
-	Reject(id, decidedBy, reason string, retryable bool) (Message, error)
+	// (when edited) the released body, (when an ApproveAs chose one) the asInbox
+	// whose identity to send from — decision metadata only; the stored body is
+	// unchanged — and actor, the operator client that decided (ADR 0029),
+	// audited for attribution. It does not send. ErrNotPending if not pending.
+	Approve(id, decidedBy string, released []byte, asInbox, actor string) (Message, error)
+	// Reject marks a pending message rejected with a reason and retryable flag,
+	// auditing the deciding operator client (actor, ADR 0029) and the reject's
+	// permanence (a permanent reject is a security signal, ADR 0006).
+	Reject(id, decidedBy, reason string, retryable bool, actor string) (Message, error)
 	// RecordSendAttempt records the result of attempting to release an approved
 	// message to the upstream Sender. resend marks an operator-triggered re-send
-	// (a distinct audit event from the first delivery). It refuses any record
-	// against a non-approved message, and against an already-sent message admits
-	// only an idempotent success — never a failure stamp onto a sent record.
-	RecordSendAttempt(id string, sendErr error, resend bool) (Message, error)
+	// (a distinct audit event from the first delivery); actor is the deciding
+	// operator client and asIdentity the ApproveAs send identity ("" when sent
+	// as-stamped), both audited so the trail shows who sent as which identity. It
+	// refuses any record against a non-approved message, and against an
+	// already-sent message admits only an idempotent success — never a failure
+	// stamp onto a sent record.
+	RecordSendAttempt(id string, sendErr error, resend bool, actor, asIdentity string) (Message, error)
 	// Close releases the underlying resources.
 	Close() error
 }

--- a/internal/sluice/sluice_test.go
+++ b/internal/sluice/sluice_test.go
@@ -101,7 +101,7 @@ func TestApproveTransitionsAndAudits(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	approved, err := q.Approve(m.ID, "manual", nil, "")
+	approved, err := q.Approve(m.ID, "manual", nil, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusApproved, approved.Status)
 	assert.Equal(t, "manual", approved.DecidedBy)
@@ -115,7 +115,7 @@ func TestApproveStoresEditedBody(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	approved, err := q.Approve(m.ID, "manual", []byte("edited"), "")
+	approved, err := q.Approve(m.ID, "manual", []byte("edited"), "", "")
 	require.NoError(t, err)
 	assert.Equal(t, []byte("edited"), approved.Released)
 }
@@ -125,7 +125,7 @@ func TestRejectRecordsReason(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	rejected, err := q.Reject(m.ID, "manual", "looks like exfiltration", false)
+	rejected, err := q.Reject(m.ID, "manual", "looks like exfiltration", false, "")
 	require.NoError(t, err)
 	assert.Equal(t, sluice.StatusRejected, rejected.Status)
 	assert.Equal(t, "looks like exfiltration", rejected.Reason)
@@ -137,12 +137,12 @@ func TestDoubleDecisionRejected(t *testing.T) {
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
 
-	_, err = q.Approve(m.ID, "manual", nil, "")
+	_, err = q.Approve(m.ID, "manual", nil, "", "")
 	require.NoError(t, err)
 
-	_, err = q.Approve(m.ID, "manual", nil, "")
+	_, err = q.Approve(m.ID, "manual", nil, "", "")
 	require.ErrorIs(t, err, sluice.ErrNotPending)
-	_, err = q.Reject(m.ID, "manual", "too late", false)
+	_, err = q.Reject(m.ID, "manual", "too late", false, "")
 	require.ErrorIs(t, err, sluice.ErrNotPending)
 }
 
@@ -150,10 +150,10 @@ func TestRecordSendAttemptStoresError(t *testing.T) {
 	q, al := newStore(t)
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("orig")})
 	require.NoError(t, err)
-	_, err = q.Approve(m.ID, "manual", nil, "")
+	_, err = q.Approve(m.ID, "manual", nil, "", "")
 	require.NoError(t, err)
 
-	out, err := q.RecordSendAttempt(m.ID, errors.New("upstream send pending"), false)
+	out, err := q.RecordSendAttempt(m.ID, errors.New("upstream send pending"), false, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, "upstream send pending", out.SendErr)
 	require.NoError(t, al.Verify())
@@ -168,30 +168,30 @@ func TestRecordSendAttemptRejectsNonApproved(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pending → refused.
-	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"), false)
+	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"), false, "", "")
 	require.ErrorIs(t, err, sluice.ErrNotApproved)
 
 	// Rejected → refused.
-	_, err = q.Reject(m.ID, "manual", "no", false)
+	_, err = q.Reject(m.ID, "manual", "no", false, "")
 	require.NoError(t, err)
-	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"), false)
+	_, err = q.RecordSendAttempt(m.ID, errors.New("boom"), false, "", "")
 	require.ErrorIs(t, err, sluice.ErrNotApproved)
 
 	// Approved → allowed; and idempotent once sent.
 	m2, err := q.Enqueue(sluice.Submission{Agent: "agent", Raw: []byte("two")})
 	require.NoError(t, err)
-	_, err = q.Approve(m2.ID, "manual", nil, "")
+	_, err = q.Approve(m2.ID, "manual", nil, "", "")
 	require.NoError(t, err)
-	sent, err := q.RecordSendAttempt(m2.ID, nil, false)
+	sent, err := q.RecordSendAttempt(m2.ID, nil, false, "", "")
 	require.NoError(t, err)
 	require.Equal(t, sluice.StatusSent, sent.Status)
-	_, err = q.RecordSendAttempt(m2.ID, nil, false) // idempotent on an already-sent message
+	_, err = q.RecordSendAttempt(m2.ID, nil, false, "", "") // idempotent on an already-sent message
 	require.NoError(t, err)
 
 	// A failure recorded against an already-sent message is refused — a losing
 	// concurrent second attempt can never turn a delivered message into
 	// sent-with-error (review note).
-	_, err = q.RecordSendAttempt(m2.ID, errors.New("late failure"), true)
+	_, err = q.RecordSendAttempt(m2.ID, errors.New("late failure"), true, "", "")
 	require.ErrorIs(t, err, sluice.ErrNotApproved)
 	after, err := q.Get(m2.ID)
 	require.NoError(t, err)
@@ -205,9 +205,9 @@ func TestListSurfacesInboxAndSendErr(t *testing.T) {
 	q, _ := newStore(t)
 	m, err := q.Enqueue(sluice.Submission{Agent: "agent", Inbox: "work", From: "f", Raw: []byte("Subject: s\r\n\r\nb")})
 	require.NoError(t, err)
-	_, err = q.Approve(m.ID, "manual", nil, "")
+	_, err = q.Approve(m.ID, "manual", nil, "", "")
 	require.NoError(t, err)
-	_, err = q.RecordSendAttempt(m.ID, errors.New("451 temporary failure"), false)
+	_, err = q.RecordSendAttempt(m.ID, errors.New("451 temporary failure"), false, "", "")
 	require.NoError(t, err)
 
 	metas, err := q.List()
@@ -254,23 +254,23 @@ func TestTransitionsSucceedWhenAuditFails(t *testing.T) {
 
 	t.Run("approve", func(t *testing.T) {
 		q, id := seedFailing(t)
-		out, err := q.Approve(id, "manual", nil, "")
+		out, err := q.Approve(id, "manual", nil, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, sluice.StatusApproved, out.Status)
 	})
 
 	t.Run("reject", func(t *testing.T) {
 		q, id := seedFailing(t)
-		out, err := q.Reject(id, "manual", "no", false)
+		out, err := q.Reject(id, "manual", "no", false, "")
 		require.NoError(t, err)
 		assert.Equal(t, sluice.StatusRejected, out.Status)
 	})
 
 	t.Run("record send attempt", func(t *testing.T) {
 		q, id := seedFailing(t)
-		_, err := q.Approve(id, "manual", nil, "")
+		_, err := q.Approve(id, "manual", nil, "", "")
 		require.NoError(t, err)
-		out, err := q.RecordSendAttempt(id, errors.New("upstream send pending"), false)
+		out, err := q.RecordSendAttempt(id, errors.New("upstream send pending"), false, "", "")
 		require.NoError(t, err)
 		assert.Equal(t, "upstream send pending", out.SendErr)
 	})
@@ -303,4 +303,58 @@ func TestEnqueueAuditRecordsAgentAndInbox(t *testing.T) {
 	assert.Equal(t, "enqueue", cap.records[0].Event)
 	assert.Equal(t, "agent-a", cap.records[0].Agent)
 	assert.Equal(t, "work", cap.records[0].Inbox)
+	assert.Empty(t, cap.records[0].Actor, "enqueue is agent-originated: no operator actor")
+}
+
+// C30/C16: an approve + send audits the deciding operator client (Actor) and, for
+// an ApproveAs, the send identity in the send-attempt Detail.
+func TestApproveSendAuditRecordsActorAndIdentity(t *testing.T) {
+	cap := &capturingAudit{}
+	q, err := sluice.New("bbolt", filepath.Join(t.TempDir(), "s.db"), cap)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent-a", Inbox: "work", Raw: []byte("Subject: x\r\n\r\nb")})
+	require.NoError(t, err)
+	_, err = q.Approve(m.ID, "manual", nil, "work", "ops-alice")
+	require.NoError(t, err)
+	_, err = q.RecordSendAttempt(m.ID, nil, false, "ops-alice", "work@example.test")
+	require.NoError(t, err)
+
+	byEvent := map[string]audit.Record{}
+	for _, r := range cap.records {
+		byEvent[r.Event] = r
+	}
+	require.Contains(t, byEvent, "approve")
+	assert.Equal(t, "ops-alice", byEvent["approve"].Actor)
+	require.Contains(t, byEvent, "send_attempt")
+	assert.Equal(t, "ops-alice", byEvent["send_attempt"].Actor)
+	assert.Equal(t, "sent as work@example.test", byEvent["send_attempt"].Detail)
+}
+
+// C28: a reject audits its permanence via the Retryable flag — set on reject rows,
+// nil on rows the flag does not describe.
+func TestRejectAuditRecordsRetryableFlag(t *testing.T) {
+	cap := &capturingAudit{}
+	q, err := sluice.New("bbolt", filepath.Join(t.TempDir(), "s.db"), cap)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = q.Close() })
+
+	m, err := q.Enqueue(sluice.Submission{Agent: "agent-a", Raw: []byte("Subject: x\r\n\r\nb")})
+	require.NoError(t, err)
+	_, err = q.Reject(m.ID, "manual", "exfiltration", false, "ops-bob")
+	require.NoError(t, err)
+
+	var reject *audit.Record
+	for i := range cap.records {
+		if cap.records[i].Event == "reject" {
+			reject = &cap.records[i]
+		}
+	}
+	require.NotNil(t, reject)
+	assert.Equal(t, "ops-bob", reject.Actor)
+	require.NotNil(t, reject.Retryable, "reject records the permanence flag")
+	assert.False(t, *reject.Retryable, "a permanent reject records retryable=false")
+	// The enqueue row is not a reject: the flag does not apply and stays nil.
+	assert.Nil(t, cap.records[0].Retryable)
 }

--- a/internal/sluice/tiering_internal_test.go
+++ b/internal/sluice/tiering_internal_test.go
@@ -120,7 +120,7 @@ func TestLegacyInlineRecordFallback(t *testing.T) {
 	assert.Equal(t, len(legacy.Raw), metas[0].Size)
 
 	// A legacy message still transitions, and the verdict reads back its raw.
-	approved, err := q.Approve("1", "op", nil, "")
+	approved, err := q.Approve("1", "op", nil, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, StatusApproved, approved.Status)
 	assert.Equal(t, legacy.Raw, approved.Raw)


### PR DESCRIPTION
Closes #236. Audit-integrity hardening from the review backlog — ADR 0011 promises "every verdict, tamper-evident", but tail truncation was undetectable, inbound verdicts were unaudited, and operator/identity attribution was dropped.

## Findings addressed

**C15 (MEDIUM) — tail-truncation undetectable + `Verify` never invoked.** `AuditLog.Verify` now asserts, per entry, that the key equals the entry's own `Seq` (key↔Seq agreement) and that `Seq` is a gap-free run from 1; after the walk it checks the last entry's `Seq` against the bucket's sequence counter, which is monotonic and survives deletes. A plain tail deletion leaves the counter ahead of the head; a truncate-then-append resumes at the higher counter value and gaps the run — both are now caught. Adds `darbaan audit verify`, which opens the log read-only and exits non-zero on any violation (usable as an incident-response / monitoring gate).

**C16 (MEDIUM) — ApproveAs identity unrecorded.** The chosen send identity is threaded into the send-attempt audit `Detail` (`sent as <identity>`, and `… (as <identity>)` on failure), so the trail reconstructs that a message was sent as a different sender than stored.

**C29 (LOW) — inbound verdicts unaudited.** `admin.Service` gains the audit log (the same one the message store writes to); `setHold` appends an `expose`/`drop` record. Best-effort and non-fatal, matching the store's own audit contract; a nil sink (tests) is a no-op.

**C30 (LOW) — acting client name discarded.** The credential now carries the ADR 0029 client name; the `scoped` middleware attaches it to the request context, and it flows to the new `audit.Record.Actor` field on every state-changing verdict (approve/reject/send/resend/expose/drop). Verdicts now attribute who decided, not just the approver name.

**C28 (LOW) — permanent rejects indistinguishable.** A reject's permanence is recorded in `audit.Record.Retryable` (a pointer — set on reject rows, nil elsewhere), and a permanent reject logs a WARN.

## Cross-package touch

The `sluice.MessageStore` interface gains an `actor` argument on `Approve`/`Reject` and `actor, asIdentity` on `RecordSendAttempt` (the store is the single writer of outbound verdict audit rows, so attribution belongs there). Callers are `admin.Service` only; the churn elsewhere is mechanical test-call updates.

## Testing

`go test -race ./...`, `go vet ./...`, golangci-lint v2 — all clean. New tests cover tail truncation, truncate-then-append, interior gap, key↔Seq mismatch, read-only verify (audit); ApproveAs identity + actor in the send audit and the reject Retryable flag (sluice); inbound expose/drop auditing (service); and end-to-end that a named scoped client is recorded as the verdict actor (http). CLI smoke-tested (`audit verify` on null / missing / populated logs).

This is a `fix:` so it accrues to the release-please batch (#242).