### PR TITLE
feat: wire assessment tunables, agent advisory, identity-less scoring (#233 part 3)

### DIFF
--- a/cmd/darbaan/assessment_test.go
+++ b/cmd/darbaan/assessment_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -73,6 +75,58 @@ func TestAssessmentReasonRenders(t *testing.T) {
 	assert.Contains(t, sc, "instruction_to_reader")
 
 	assert.Empty(t, assessmentReason(nil))
+}
+
+// C17: with no config file, the tunables fall back to the validated defaults.
+func TestAssessmentConfigDefaultsWhenNoFile(t *testing.T) {
+	cli := &CLI{}
+	cfg, err := cli.assessmentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, riskscore.DefaultConfig(), cfg)
+}
+
+// C17: a config file with no assessment: section also yields the defaults, so an
+// existing deployment's scoring is unchanged when the section is absent.
+func TestAssessmentConfigDefaultsWhenSectionAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("agent_username: agent\n"), 0o600))
+	cli := &CLI{Config: path}
+	cfg, err := cli.assessmentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, riskscore.DefaultConfig(), cfg)
+}
+
+// C17: an assessment: section overlays the operator's tunables onto the defaults
+// (a partial section is valid — unspecified keys keep their default).
+func TestAssessmentConfigOverlaysSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	yaml := "" +
+		"assessment:\n" +
+		"  threshold: 55\n" +
+		"  sender_baselines:\n" +
+		"    unknown: 20\n"
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+	cli := &CLI{Config: path}
+	cfg, err := cli.assessmentConfig()
+	require.NoError(t, err)
+	assert.Equal(t, 55, cfg.Threshold, "operator threshold overrides the default")
+	assert.Equal(t, 20, cfg.SenderBaselines[provenance.TrustUnknown], "operator baseline overlaid")
+	assert.Equal(t, riskscore.DefaultConfig().FactorPoints, cfg.FactorPoints, "unspecified keys keep their default")
+}
+
+// C17: an invalid assessment: section is a startup error, not silent mis-scoring.
+func TestAssessmentConfigRejectsInvalidSection(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	// low_max must be less than medium_max; this inverts them.
+	yaml := "" +
+		"assessment:\n" +
+		"  bands:\n" +
+		"    low_max: 80\n" +
+		"    medium_max: 40\n"
+	require.NoError(t, os.WriteFile(path, []byte(yaml), 0o600))
+	cli := &CLI{Config: path}
+	_, err := cli.assessmentConfig()
+	require.Error(t, err)
 }
 
 func TestBuildAssessHookDisabledIsCleanNoop(t *testing.T) {

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/kong"
+	"gopkg.in/yaml.v3"
 
 	"github.com/yaad-index/darbaan/internal/admin"
 	"github.com/yaad-index/darbaan/internal/admincfg"
@@ -202,6 +203,36 @@ func (c *CLI) configBytes() ([]byte, error) {
 		return nil, fmt.Errorf("read config %s: %w", path, err)
 	}
 	return data, nil
+}
+
+// assessmentConfig resolves the deterministic scorer's tunables (ADR 0032 §7)
+// from the optional top-level `assessment:` section of the config file, overlaid
+// onto the built-in defaults by riskscore.Parse (a partial section is valid; an
+// absent one yields the validated defaults). The `--assessment-enabled` flag is
+// the separate on/off toggle; this section only shapes the weights, bands, and
+// threshold once assessment runs.
+func (c *CLI) assessmentConfig() (riskscore.Config, error) {
+	data, err := c.configBytes()
+	if err != nil {
+		return riskscore.Config{}, err
+	}
+	if len(data) == 0 {
+		return riskscore.DefaultConfig(), nil
+	}
+	var wrapper struct {
+		Assessment yaml.Node `yaml:"assessment"`
+	}
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return riskscore.Config{}, fmt.Errorf("parse assessment config: %w", err)
+	}
+	if wrapper.Assessment.IsZero() {
+		return riskscore.DefaultConfig(), nil
+	}
+	section, err := yaml.Marshal(&wrapper.Assessment)
+	if err != nil {
+		return riskscore.Config{}, fmt.Errorf("assessment config: %w", err)
+	}
+	return riskscore.Parse(section)
 }
 
 // resolveInboxes resolves the configured inboxes (ADR 0023), or a single implicit
@@ -1182,7 +1213,14 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// startup instead of lurking behind the flag and surprising the operator on
 	// flip. The hook is only installed on the syncers when enabled; disabled leaves
 	// FetchContent byte-identical to before (no Screen call, no Assessment written).
-	assessHook, err := cli.buildAssessHook(inboxes, provResolver, riskscore.DefaultConfig())
+	// The scorer's weights/bands/threshold come from the operator's `assessment:`
+	// config section (ADR 0032 §7), overlaid on the defaults — a bad overlay fails
+	// startup here rather than silently scoring wrong.
+	assessCfg, err := cli.assessmentConfig()
+	if err != nil {
+		return fmt.Errorf("assessment config: %w", err)
+	}
+	assessHook, err := cli.buildAssessHook(inboxes, provResolver, assessCfg)
 	if err != nil {
 		return err
 	}
@@ -1270,8 +1308,15 @@ func (*ServeCmd) Run(cli *CLI) error {
 		Addr:          cli.IMAPAddr,
 		TLSConfig:     tlsConfig,
 		AllowInsecure: cli.ListenerAllowInsecure,
-		ServeStamp: func(inbox string, raw []byte) ([]byte, error) {
-			return provenance.Sanitize(raw, provResolver(inbox, provenance.From(raw)))
+		ServeStamp: func(inbox string, raw []byte, risk, riskFactors string) ([]byte, error) {
+			// Merge the caller-resolved advisory (ADR 0032 §6) into the same
+			// strip-then-stamp pass as the trust verdict, so the namespace strip
+			// clears any inbound X-Darbaan-Risk look-alike before the system value
+			// is stamped. Empty advisory strings leave the headers unset.
+			st := provResolver(inbox, provenance.From(raw))
+			st.Risk = risk
+			st.RiskFactors = riskFactors
+			return provenance.Sanitize(raw, st)
 		},
 	}, auth, inbox, imapContentFetch(syncers, inbox), imapKeywordWriter(syncers), filters, guard, holdSpoof, pw.mailOwner, syncNow)
 	if err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -118,6 +118,43 @@ approval-light: [manual]
 assessment-enabled: false
 assessment-timeout: 5s
 
+# Once assessment is enabled, an OPTIONAL `assessment:` section tunes the
+# deterministic scorer's weights, bands, and human-surface threshold (ADR 0032
+# §7). Every key is overlaid onto the built-in defaults, so a partial section is
+# valid — unspecified keys keep their default — and omitting the section entirely
+# leaves the defaults unchanged. A composed score at or above `threshold` is held
+# for a human. An invalid section (e.g. band cutoffs out of order) fails startup
+# rather than scoring wrong. Below are the defaults, shown for reference:
+#
+# assessment:
+#   # Baseline points by the trust the gate stamped on the source (ADR 0030/0031),
+#   # never a re-read of From. The "unknown" floor is required.
+#   sender_baselines:
+#     trusted: 0
+#     untrusted: 40
+#     unknown: 30
+#   # Point adjustment by the mailbox's recipient position; an unlisted position
+#   # adds nothing. An identity-less inbox (no address to match) adds nothing.
+#   recipient_adjust:
+#     to: 0
+#     cc: 5
+#     bcc: 10
+#   # Per-factor contribution when a content factor is flagged; the table is
+#   # authoritative, so a flagged factor with no entry adds nothing.
+#   factor_points:
+#     instruction_to_reader: 40
+#     secrets_request: 40
+#     hidden_directives: 30
+#     attachment_directives: 30
+#   # Labeled-band cutoffs over the 0-100 score: below low_max is low, below
+#   # medium_max is medium, at or above medium_max is high.
+#   bands:
+#     low_max: 33
+#     medium_max: 66
+#   # Human-surface cutoff: a composed score >= threshold is held. Lower it for a
+#   # more conservative posture.
+#   threshold: 70
+
 # --- Multi-inbox + multi-agent (optional; ADR 0023 / ADR 0027) ---------------
 # The flat fields above define ONE inbox and ONE implicit agent. To front several
 # inboxes and/or several agent principals, add `inboxes:` and `agents:` lists.

--- a/internal/listener/imap.go
+++ b/internal/listener/imap.go
@@ -39,13 +39,18 @@ type IMAPServerConfig struct {
 	// It closes the legacy gap — pre-ADR blobs serve with their real trust, and
 	// served trust stays fresh on a config change — and is idempotent, so it's a
 	// safe belt-and-suspenders on every fetch. nil disables it (serve as stored).
+	// The advisory (risk band/score + factors) is stamped in the same pass, so the
+	// namespace strip that precedes it makes the advisory headers spoof-proof too.
 	ServeStamp ServeStamp
 }
 
 // ServeStamp sanitizes+stamps a raw message for the given (serving) inbox,
 // returning the served bytes (ADR 0030). It reads only the inbox key it is
-// given, never the message.
-type ServeStamp func(inbox string, raw []byte) ([]byte, error)
+// given and the caller-resolved advisory strings, never the message. risk and
+// riskFactors carry the agent-facing assessment advisory (ADR 0032 §6): empty
+// strings stamp no advisory header, and any inbound look-alike is stripped by
+// the same sanitize pass before the system value is stamped.
+type ServeStamp func(inbox string, raw []byte, risk, riskFactors string) ([]byte, error)
 
 // ContentFetch resolves a message's full content (Raw) on demand: for a present
 // record from its blob, for a pending record by fetching the body from upstream
@@ -586,7 +591,12 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 				// un-sanitized — real stored blobs are sanitized at write, so this is
 				// a near-dead edge.
 				if s.serveStamp != nil {
-					if stamped, serr := s.serveStamp(s.selectedInbox, raw); serr == nil {
+					// The agent-facing advisory (ADR 0032 §6) is resolved from the freshly
+					// fetched record's persisted assessment and stamped in the same
+					// sanitize pass, so the namespace strip clears any inbound X-Darbaan-Risk
+					// look-alike before the system value lands.
+					risk, riskFactors := riskAdvisory(full.Assessment)
+					if stamped, serr := s.serveStamp(s.selectedInbox, raw, risk, riskFactors); serr == nil {
 						raw = stamped
 					} else {
 						raw = nil
@@ -604,6 +614,21 @@ func (s *imapSession) rawResolver(m inbound.Message) rawFunc {
 		}
 		return raw, err
 	}
+}
+
+// riskAdvisory renders the agent-facing injection-assessment advisory (ADR 0032
+// §6) for a served message from its persisted assessment: the composed band and
+// score, and the flagged factors. Every field is system-defined and carries no
+// message bytes. It returns empty strings — so no advisory header is stamped —
+// when there is no composed score to surface: an unassessed message, or a
+// fail-safe not-cleared hold that never earned a band.
+func riskAdvisory(a *inbound.Assessment) (risk, factors string) {
+	if a == nil || a.NotCleared || a.Band == "" {
+		return "", ""
+	}
+	risk = fmt.Sprintf("%s; score=%d", a.Band, a.Score)
+	factors = strings.Join(a.Factors, ", ")
+	return risk, factors
 }
 
 func (s *imapSession) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, _ *imap.StoreOptions) error {

--- a/internal/listener/imap_test.go
+++ b/internal/listener/imap_test.go
@@ -1004,8 +1004,8 @@ func TestIMAPServeStampReStampsFresh(t *testing.T) {
 	store := seedInbound(t) // present bounce at seq 1, stored trust=unknown (default resolver)
 
 	// Serve-path resolves TRUSTED for the inbox: it must override the stored value.
-	ss := func(_ string, raw []byte) ([]byte, error) {
-		return provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustTrusted})
+	ss := func(_ string, raw []byte, risk, riskFactors string) ([]byte, error) {
+		return provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustTrusted, Risk: risk, RiskFactors: riskFactors})
 	}
 
 	c, err := imapclient.DialInsecure(startIMAPServeStamp(t, store, ss), nil)
@@ -1026,4 +1026,55 @@ func TestIMAPServeStampReStampsFresh(t *testing.T) {
 	assert.NotContains(t, body, "X-Darbaan-Trust: unknown", "stored value overridden on serve")
 	assert.Equal(t, 1, strings.Count(body, "X-Darbaan-Trust:"), "exactly one trust header, not stacked")
 	assert.Contains(t, body, "refused-marker", "body preserved")
+}
+
+// C23: a below-threshold (agent-handled) message is served with the agent-facing
+// risk advisory (ADR 0032 §6) as system-authored X-Darbaan-* headers, stamped in
+// the same sanitize pass so an inbound look-alike is stripped before the real
+// value lands.
+func TestIMAPServeStampAdvisoryHeaders(t *testing.T) {
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	_, m, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Subject: "hello", UpstreamUID: 1, UIDValidity: 1,
+		Envelope: &inbound.Envelope{Subject: "hello"},
+	})
+	require.NoError(t, err)
+	// The raw carries an attacker-planted advisory header that must not survive.
+	_, err = store.SetContentAssessed("agent", inbound.DefaultInbox, m.ID,
+		[]byte("Subject: hello\r\nX-Darbaan-Risk: high; score=99\r\n\r\nbody-keep"),
+		&inbound.Assessment{
+			Disposition: inbound.AssessmentAgentHandled,
+			Band:        "low", Score: 12,
+			Factors: []string{"secrets_request"},
+		})
+	require.NoError(t, err)
+
+	// Serve-path stamp mirrors production: the trust verdict and the advisory are
+	// stamped together, after the namespace strip.
+	ss := func(_ string, raw []byte, risk, riskFactors string) ([]byte, error) {
+		return provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUnknown, Risk: risk, RiskFactors: riskFactors})
+	}
+
+	c, err := imapclient.DialInsecure(startIMAPServeStamp(t, store, ss), nil)
+	require.NoError(t, err)
+	defer func() { _ = c.Close() }()
+	require.NoError(t, c.Login("agent", "pw").Wait())
+	_, err = c.Select("INBOX", nil).Wait()
+	require.NoError(t, err)
+
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	}).Collect()
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	body := string(msgs[0].FindBodySection(&imap.FetchItemBodySection{}))
+	assert.Contains(t, body, "X-Darbaan-Risk: low; score=12", "advisory band+score is stamped from the assessment")
+	assert.Contains(t, body, "X-Darbaan-Risk-Factors: secrets_request", "advisory factors are stamped")
+	assert.NotContains(t, body, "score=99", "inbound advisory look-alike is stripped before the system value lands")
+	assert.Equal(t, 1, strings.Count(body, "X-Darbaan-Risk:"), "exactly one advisory header, not stacked")
+	assert.Contains(t, body, "body-keep", "body preserved")
 }

--- a/internal/provenance/provenance.go
+++ b/internal/provenance/provenance.go
@@ -90,6 +90,16 @@ const (
 	TrustUnknown   = "unknown"
 )
 
+// RiskHeader and RiskFactorsHeader carry the agent-facing injection-assessment
+// advisory (ADR 0032 §6): the composed risk band/score and the flagged factors
+// for a served message. Like the trust headers they are system-authored and live
+// in the reserved namespace, so the Layer-1 strip removes any inbound look-alike
+// before darbaan stamps its own — an attacker can never pre-forge them.
+const (
+	RiskHeader        = "X-Darbaan-Risk"
+	RiskFactorsHeader = "X-Darbaan-Risk-Factors"
+)
+
 var namespaceLower = strings.ToLower(Namespace)
 
 // Stamp is the provenance darbaan writes onto a message (ADR 0030): the trust
@@ -100,6 +110,14 @@ type Stamp struct {
 	Trust  string // one of the Trust* values; "" leaves X-Darbaan-Trust unset
 	Note   string // optional directive; "" leaves X-Darbaan-Note unset
 	Banner bool   // also emit a fenced top-of-body banner (top-level text/plain only)
+
+	// Risk and RiskFactors carry the agent-facing assessment advisory (ADR 0032
+	// §6), resolved by the caller from the message's persisted assessment (never
+	// from message content). An empty field leaves its header unset — so an
+	// unassessed message, or one whose assessment carries no composed score,
+	// gets no advisory header.
+	Risk        string // composed band/score, e.g. "low; score=12"; "" leaves X-Darbaan-Risk unset
+	RiskFactors string // flagged factor list; "" leaves X-Darbaan-Risk-Factors unset
 }
 
 // Strip removes every X-Darbaan-* header from a raw RFC 822 message without
@@ -147,6 +165,12 @@ func rewrite(raw []byte, s Stamp) ([]byte, error) {
 	}
 	if s.Note != "" {
 		hdr.Set(NoteHeader, headerSafe(s.Note))
+	}
+	if s.Risk != "" {
+		hdr.Set(RiskHeader, headerSafe(s.Risk))
+	}
+	if s.RiskFactors != "" {
+		hdr.Set(RiskFactorsHeader, headerSafe(s.RiskFactors))
 	}
 	body, err := io.ReadAll(br)
 	if err != nil {

--- a/internal/provenance/provenance_test.go
+++ b/internal/provenance/provenance_test.go
@@ -185,6 +185,29 @@ func TestSanitize_StampsNote(t *testing.T) {
 	assert.NotContains(t, headerKeys(t, none), provenance.NoteHeader, "no note configured → no note header")
 }
 
+// C23: the assessment advisory (risk band/score + factors) is stamped alongside
+// the trust, and any inbound look-alike in the reserved namespace is stripped
+// first — so a sender can never pre-forge its own advisory. An empty advisory
+// leaves the headers off.
+func TestSanitize_StampsRiskAdvisory(t *testing.T) {
+	// The inbound message plants a forged advisory that must not survive.
+	raw := []byte("Subject: hi\r\nX-Darbaan-Risk: high; score=99\r\nX-Darbaan-Risk-Factors: nothing\r\n\r\nbody")
+
+	out, err := provenance.Sanitize(raw, provenance.Stamp{
+		Trust: provenance.TrustUnknown, Risk: "low; score=12", RiskFactors: "secrets_request, instruction_to_reader",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "low; score=12", headerValue(t, out, provenance.RiskHeader), "system advisory replaces the forged one")
+	assert.Equal(t, "secrets_request, instruction_to_reader", headerValue(t, out, provenance.RiskFactorsHeader))
+	assert.NotContains(t, string(out), "score=99", "forged inbound advisory stripped")
+
+	none, err := provenance.Sanitize([]byte("Subject: hi\r\n\r\nbody"), provenance.Stamp{Trust: provenance.TrustTrusted})
+	require.NoError(t, err)
+	keys := headerKeys(t, none)
+	assert.NotContains(t, keys, provenance.RiskHeader, "no advisory configured → no risk header")
+	assert.NotContains(t, keys, provenance.RiskFactorsHeader, "no advisory configured → no factors header")
+}
+
 // The note is header-sanitized at stamp time: CR/LF/control chars are dropped so
 // a value can never inject a second header. Exactly one X-Darbaan-Note results.
 func TestSanitize_NoteHeaderInjectionStripped(t *testing.T) {

--- a/internal/riskscore/score.go
+++ b/internal/riskscore/score.go
@@ -47,6 +47,13 @@ const (
 	RecipientTo  Recipient = "to"
 	RecipientCc  Recipient = "cc"
 	RecipientBcc Recipient = "bcc"
+	// RecipientUnknown is the position for a message whose recipient cannot be
+	// resolved because the mailbox's own address is unknown (an identity-less
+	// deployment). It carries no configured adjustment — an unlisted position adds
+	// nothing (C36) — so a config gap does not tax every message the Bcc penalty.
+	// It is distinct from Bcc, which is the cautious position for a KNOWN self that
+	// is genuinely absent from To/Cc (real bulk/hidden delivery).
+	RecipientUnknown Recipient = ""
 )
 
 // Band is the labeled interval a score falls in (ADR 0032 §1). Bands are a

--- a/internal/screener/screener.go
+++ b/internal/screener/screener.go
@@ -114,19 +114,26 @@ func (s *Screener) Screen(ctx context.Context, raw []byte, trust string, recipie
 }
 
 // ResolveRecipient returns the position the mailbox self held on a message with
-// the given To and Cc recipient addresses. To wins over Cc. A mailbox found in
+// the given To and Cc recipient addresses. To wins over Cc. A KNOWN self found in
 // neither — delivered via Bcc, an alias, or a list — is treated as the most
 // cautious position, Bcc, since bulk/hidden delivery is a mild risk signal
 // (ADR 0032 §3) and an unresolved position should never earn the safest score.
+//
+// An EMPTY self (an identity-less deployment: the inbox has no configured send
+// identity to match against To/Cc) is a configuration gap, not a delivery signal.
+// Its position cannot be resolved, so it earns RecipientUnknown — no adjustment —
+// rather than the Bcc penalty, which would otherwise add +10 to every message the
+// deployment ever assesses (C36).
 func ResolveRecipient(self string, to, cc []string) riskscore.Recipient {
 	self = normalizeAddr(self)
-	if self != "" {
-		if containsAddr(to, self) {
-			return riskscore.RecipientTo
-		}
-		if containsAddr(cc, self) {
-			return riskscore.RecipientCc
-		}
+	if self == "" {
+		return riskscore.RecipientUnknown
+	}
+	if containsAddr(to, self) {
+		return riskscore.RecipientTo
+	}
+	if containsAddr(cc, self) {
+		return riskscore.RecipientCc
 	}
 	return riskscore.RecipientBcc
 }

--- a/internal/screener/screener_test.go
+++ b/internal/screener/screener_test.go
@@ -201,7 +201,21 @@ func TestResolveRecipient(t *testing.T) {
 
 	assert.Equal(t, riskscore.RecipientTo, ResolveRecipient("me@example.com", to, cc), "case-insensitive To match")
 	assert.Equal(t, riskscore.RecipientCc, ResolveRecipient("cc@example.com", to, cc))
-	assert.Equal(t, riskscore.RecipientBcc, ResolveRecipient("hidden@example.com", to, cc), "not in To/Cc → cautious Bcc")
-	assert.Equal(t, riskscore.RecipientBcc, ResolveRecipient("", to, cc), "empty self → cautious Bcc")
+	assert.Equal(t, riskscore.RecipientBcc, ResolveRecipient("hidden@example.com", to, cc), "known self not in To/Cc → cautious Bcc")
+	// C36: an empty self (identity-less deployment) is a config gap, not hidden
+	// delivery — it earns no adjustment (RecipientUnknown), not the Bcc penalty.
+	assert.Equal(t, riskscore.RecipientUnknown, ResolveRecipient("", to, cc), "empty self → no adjustment, not Bcc")
 	assert.Equal(t, riskscore.RecipientTo, ResolveRecipient(" me@example.com ", to, cc), "trimmed")
+}
+
+// C36: RecipientUnknown carries no configured adjustment (an unlisted position
+// adds nothing), so an identity-less deployment is not taxed the Bcc penalty on
+// every message.
+func TestResolveRecipientUnknownHasNoAdjustment(t *testing.T) {
+	s, err := riskscore.New(riskscore.DefaultConfig())
+	require.NoError(t, err)
+	unknown := s.CheapScore(provenance.TrustTrusted, riskscore.RecipientUnknown)
+	bcc := s.CheapScore(provenance.TrustTrusted, riskscore.RecipientBcc)
+	assert.Equal(t, 0, unknown.Recipient, "unknown position adds nothing")
+	assert.Equal(t, 10, bcc.Recipient, "Bcc still carries its +10")
 }


### PR DESCRIPTION
Part 3 of 3 for #233 (injection-assessment hardening — the final cut). Theme: **wire the two ADR 0032 surfaces that were built but never reached production, and fix a scoring skew on identity-less deployments.** Best-effort/defense-in-depth — the human send-gate and sender baseline remain the real backstops. ADR 0032 is live in prod, so each behaviour change is called out.

## Findings addressed

**C17 (MEDIUM) — operator tunables were unwired; `riskscore.Parse` was dead code.** Serve hardcoded `riskscore.DefaultConfig()`, so the YAML overlay built for exactly this (ADR 0032 §7) had zero production callers. Serve now parses an optional top-level `assessment:` section via `riskscore.Parse`, overlaid on the defaults — a partial section is valid (unspecified keys keep their default), and an absent section keeps the defaults, so an existing deployment's scoring is unchanged. **Behaviour note:** a bad overlay (e.g. band cutoffs out of order) now fails startup rather than lurking; the section is documented with the default values in `config.example.yaml`.

**C23 (MEDIUM) — the agent-facing advisory (ADR 0032 §6) was unimplemented.** The persisted assessment was never surfaced to the agent. A served, assessed message now carries system-authored `X-Darbaan-Risk` (band; score) and `X-Darbaan-Risk-Factors` headers, resolved from the persisted assessment and stamped in the **same sanitize pass** as the trust verdict — so the Layer-1 namespace strip clears any inbound `X-Darbaan-Risk` look-alike before the system value lands (spoof-proof, the same floor the trust header rides on). No advisory is stamped for an unassessed message or a not-cleared fail-safe hold that carries no composed score.

**C36 (LOW) — an empty send-identity skewed every score.** `ResolveRecipient("")` returned `RecipientBcc`, adding +10 to every message on an identity-less deployment. An unresolvable self is a configuration gap, not hidden delivery, so it now earns a new `RecipientUnknown` position — no adjustment (an unlisted position adds nothing). Bcc stays the cautious position for a KNOWN self genuinely absent from To/Cc. **Behaviour note:** a net *reduction* in score for identity-less deployments (the safe direction for over-hold on a live feature).

## Cross-package touch

The advisory (C23) threads through three packages by design, each staying in its lane: `internal/provenance` gains the two advisory fields on `Stamp` (stamped in the existing strip-then-stamp chokepoint, no new namespace-handling path); `internal/listener` resolves the advisory strings from the fetched record's assessment and passes them to the serve-path stamp; `cmd/darbaan` merges them into the trust stamp. `internal/riskscore` gains the `RecipientUnknown` sentinel for C36; `internal/screener` returns it for an empty self.

## Tests

`assessment:` section overlay + absent-section-keeps-defaults + invalid-section-fails-startup; advisory headers stamped from the assessment with an inbound look-alike stripped before the system value lands; `RecipientUnknown` carries no adjustment while Bcc keeps its +10.

`go test -race ./...`, `go vet`, golangci-lint v2 — all green. `feat:` → accrues to release-please #242.

Closes #233.

## Upgrade note (for the batched release)

C36 removes the uniform +10 that an identity-less deployment previously added to every message. A deployment that lowered `threshold` to compensate for that constant penalty will hold slightly *less* after upgrading. The C17 `assessment:` section shipped in this same PR is the re-tune knob — such deployments can lower `threshold` (or set a per-position `recipient_adjust`) to restore their prior posture. Worth a line in the release notes.
