### PR TITLE
fix: reconcile no longer retracts a concurrently-synced message + cleans superseded-validity orphans (#235 part 1)

### DIFF
--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -188,12 +188,20 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 	//   - C8: a record under a SUPERSEDED UIDVALIDITY is orphaned — its UID is
 	//     meaningless in the current UID space and forward sync only ever adds, never
 	//     cleans — so reconcile owns its cleanup and treats it as a candidate,
-	//     counted under the same cap/latch as any other retraction.
+	//     counted under the same cap/latch as any other retraction. A record with an
+	//     UNKNOWN validity (zero) is NOT such an orphan: the persisted field is
+	//     omitempty with no backfill, so a record predating it deserializes to zero.
+	//     Zero is absence of information, not evidence of a superseded UID space, so
+	//     it is left untouched rather than retracted by inference (reclaiming those
+	//     records would need an explicit validity backfill, a separate decision).
 	var gone []inbound.Message
 	syncedCount := 0
 	for _, m := range msgs {
 		if m.UpstreamUID == 0 {
 			continue // locally-generated — never retracted
+		}
+		if m.UIDValidity == 0 {
+			continue // unknown validity (predates the field) — never retract by inference
 		}
 		if m.UIDValidity != uidValidity {
 			syncedCount++ // C8: superseded-validity orphan is a candidate

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -117,20 +117,20 @@ type ReconcileOptions struct {
 //  3. Candidate selection. A record is a retraction candidate only if it carries an
 //     upstream UID (UpstreamUID != 0 — locally-generated bounces are never
 //     reconciled), subject to three validity/horizon exclusions:
-//       - CURSOR HORIZON (C7): a current-validity record is judged against the
-//         upstream present-set (candidate iff its UID is absent) ONLY when its UID is
-//         at or below the sync cursor captured before the snapshot; a UID above the
-//         cursor may have been stored by a concurrent Sync after the snapshot, so it
-//         is too fresh to judge and is deferred to the next pass.
-//       - UNKNOWN VALIDITY: a record with UIDVALIDITY zero predates the persisted
-//         field (omitempty, no backfill), so zero is absence of information, not a
-//         superseded UID space — it is skipped, never retracted by inference.
-//       - SUPERSEDED VALIDITY (C8): a PENDING record under a superseded UIDVALIDITY
-//         is an orphan — headers-only, its UID meaningless in the current space, can
-//         never serve content — and reconcile reclaims it (forward sync only ever
-//         adds, never cleans). A PRESENT record under a superseded validity keeps a
-//         cached, served, readable body, so it is skipped — deleting it would be a
-//         hard loss, left for a deliberate reclaim decision (#255).
+//     - CURSOR HORIZON (C7): a current-validity record is judged against the
+//     upstream present-set (candidate iff its UID is absent) ONLY when its UID is
+//     at or below the sync cursor captured before the snapshot; a UID above the
+//     cursor may have been stored by a concurrent Sync after the snapshot, so it
+//     is too fresh to judge and is deferred to the next pass.
+//     - UNKNOWN VALIDITY: a record with UIDVALIDITY zero predates the persisted
+//     field (omitempty, no backfill), so zero is absence of information, not a
+//     superseded UID space — it is skipped, never retracted by inference.
+//     - SUPERSEDED VALIDITY (C8): a PENDING record under a superseded UIDVALIDITY
+//     is an orphan — headers-only, its UID meaningless in the current space, can
+//     never serve content — and reconcile reclaims it (forward sync only ever
+//     adds, never cleans). A PRESENT record under a superseded validity keeps a
+//     cached, served, readable body, so it is skipped — deleting it would be a
+//     hard loss, left for a deliberate reclaim decision (#255).
 //  4. Retract each candidate (RemoveSynced) and append a retract audit record.
 //     Per-message failures are collected and the pass continues (best-effort), so
 //     one stuck record never blocks the rest; the next cycle retries the failures.

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -114,11 +114,23 @@ type ReconcileOptions struct {
 //     forward-sync cursor's, the whole UID space changed (a mailbox reset, a full
 //     re-sync per ADR 0019) — NOT a signal that every message was deleted. Skip
 //     presence-deletion this cycle and let the forward sync own the re-sync.
-//  3. Synced-only set-diff: a record is a retraction candidate only if it carries
-//     an upstream UID (UpstreamUID != 0 — locally-generated bounces are never
-//     reconciled), matches the current UIDVALIDITY (records under a superseded
-//     validity are the forward re-sync's concern), and its UID is absent from the
-//     upstream present-set.
+//  3. Candidate selection. A record is a retraction candidate only if it carries an
+//     upstream UID (UpstreamUID != 0 — locally-generated bounces are never
+//     reconciled), subject to three validity/horizon exclusions:
+//       - CURSOR HORIZON (C7): a current-validity record is judged against the
+//         upstream present-set (candidate iff its UID is absent) ONLY when its UID is
+//         at or below the sync cursor captured before the snapshot; a UID above the
+//         cursor may have been stored by a concurrent Sync after the snapshot, so it
+//         is too fresh to judge and is deferred to the next pass.
+//       - UNKNOWN VALIDITY: a record with UIDVALIDITY zero predates the persisted
+//         field (omitempty, no backfill), so zero is absence of information, not a
+//         superseded UID space — it is skipped, never retracted by inference.
+//       - SUPERSEDED VALIDITY (C8): a PENDING record under a superseded UIDVALIDITY
+//         is an orphan — headers-only, its UID meaningless in the current space, can
+//         never serve content — and reconcile reclaims it (forward sync only ever
+//         adds, never cleans). A PRESENT record under a superseded validity keeps a
+//         cached, served, readable body, so it is skipped — deleting it would be a
+//         hard loss, left for a deliberate reclaim decision (#255).
 //  4. Retract each candidate (RemoveSynced) and append a retract audit record.
 //     Per-message failures are collected and the pass continues (best-effort), so
 //     one stuck record never blocks the rest; the next cycle retries the failures.
@@ -185,15 +197,16 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 	//     stored by a Sync running concurrently with (after) our upstream snapshot,
 	//     so it is too fresh to judge — leave it for the next pass rather than risk
 	//     retracting a legitimate new message the snapshot merely predates;
-	//   - C8: a record under a SUPERSEDED UIDVALIDITY is orphaned — its UID is
+	//   - C8: a PENDING record under a SUPERSEDED UIDVALIDITY is orphaned — its UID is
 	//     meaningless in the current UID space and forward sync only ever adds, never
-	//     cleans — so reconcile owns its cleanup and treats it as a candidate,
-	//     counted under the same cap/latch as any other retraction. A record with an
-	//     UNKNOWN validity (zero) is NOT such an orphan: the persisted field is
-	//     omitempty with no backfill, so a record predating it deserializes to zero.
-	//     Zero is absence of information, not evidence of a superseded UID space, so
-	//     it is left untouched rather than retracted by inference (reclaiming those
-	//     records would need an explicit validity backfill, a separate decision).
+	//     cleans — so reconcile owns its cleanup and treats it as a candidate, counted
+	//     under the same cap/latch as any other retraction. A PRESENT record under a
+	//     superseded validity is NOT reclaimed: its body is already cached and served
+	//     as a readable message, so deleting it is a hard loss (left for #255). A
+	//     record with an UNKNOWN validity (zero) is likewise not an orphan: the
+	//     persisted field is omitempty with no backfill, so a record predating it
+	//     deserializes to zero — absence of information, not a superseded UID space —
+	//     and is left untouched rather than retracted by inference.
 	var gone []inbound.Message
 	syncedCount := 0
 	for _, m := range msgs {
@@ -204,7 +217,20 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 			continue // unknown validity (predates the field) — never retract by inference
 		}
 		if m.UIDValidity != uidValidity {
-			syncedCount++ // C8: superseded-validity orphan is a candidate
+			// Superseded-validity orphan. Cleanup claims ONLY a pending (headers-only)
+			// record: its UID is meaningless in the current UID space, so a content fetch
+			// can only ever fail — retracting it loses nothing. A PRESENT record under a
+			// superseded validity already has a cached body and is served as a fully
+			// readable message today (the read face reports its own constant UIDVALIDITY
+			// and never fetches upstream), so deleting it is a hard loss of that blob —
+			// the exact silent loss this pass exists to prevent. Leave it untouched for a
+			// deliberate reclaim decision (#255), never delete by inference. A present
+			// orphan is also NOT set-diffed below: its UID lives in a different space, so
+			// comparing it to the current present-set would be meaningless.
+			if !m.Pending {
+				continue
+			}
+			syncedCount++ // C8: pending superseded-validity orphan is a candidate
 			gone = append(gone, m)
 			continue
 		}

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -140,18 +140,30 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 		return 0, ErrReconcileHeld
 	}
 
+	// Load the sync cursor BEFORE snapshotting the upstream (C7). Sync and reconcile
+	// overlap by design (both fire at startup; a STATUS-triggered sync adds more), so
+	// a message can arrive upstream and be stored by a concurrent Sync AFTER our
+	// present-set snapshot below but BEFORE we list the store. Such a message is
+	// absent from the snapshot yet present locally — and retracting it would be
+	// silent permanent loss, since the sync cursor has already advanced past its UID
+	// and it is never re-pulled. Capturing the cursor here, before the snapshot,
+	// bounds retraction to UIDs at or below it; anything above is too fresh to judge
+	// against this snapshot and is left for the next pass.
+	loaded, err := s.state.Load(s.stateKey())
+	if err != nil {
+		return 0, fmt.Errorf("imapsync: reconcile: load state: %w", err)
+	}
+	cursorUID := loaded.LastUID
+
 	// Guard 1: authoritative present-set (read-only). Failure ⇒ skip (fail-safe).
 	uidValidity, upUIDs, err := s.ListUpstreamUIDs()
 	if err != nil {
 		return 0, fmt.Errorf("imapsync: reconcile: %w", err)
 	}
 
-	loaded, err := s.state.Load(s.stateKey())
-	if err != nil {
-		return 0, fmt.Errorf("imapsync: reconcile: load state: %w", err)
-	}
-	// Guard 2: UIDVALIDITY-skip. A mismatch (mailbox reset, or no forward sync yet)
-	// means the UID space changed, not that everything was deleted.
+	// Guard 2: UIDVALIDITY-skip. A mismatch between the cursor's validity and the
+	// upstream's means the UID space changed (mailbox reset) or forward sync has not
+	// run yet — the current-validity set-diff below would be meaningless, so skip.
 	if loaded.UIDValidity != uidValidity {
 		return 0, nil
 	}
@@ -165,14 +177,31 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 	if err != nil {
 		return 0, fmt.Errorf("imapsync: reconcile: list store: %w", err)
 	}
-	// Guard 3: synced-only set-diff. Skip locally-generated records (no upstream
-	// UID) and records under a superseded UIDVALIDITY; a candidate is a synced
-	// record whose UID is no longer present upstream.
+	// Guard 3: synced-only set-diff. A candidate is a synced record whose UID is no
+	// longer present upstream, with two exclusions and one addition:
+	//   - a locally-generated record (no upstream UID, e.g. a bounce) is never
+	//     retracted;
+	//   - C7: a record whose UID is ABOVE the pre-snapshot cursor may have been
+	//     stored by a Sync running concurrently with (after) our upstream snapshot,
+	//     so it is too fresh to judge — leave it for the next pass rather than risk
+	//     retracting a legitimate new message the snapshot merely predates;
+	//   - C8: a record under a SUPERSEDED UIDVALIDITY is orphaned — its UID is
+	//     meaningless in the current UID space and forward sync only ever adds, never
+	//     cleans — so reconcile owns its cleanup and treats it as a candidate,
+	//     counted under the same cap/latch as any other retraction.
 	var gone []inbound.Message
 	syncedCount := 0
 	for _, m := range msgs {
-		if m.UpstreamUID == 0 || m.UIDValidity != uidValidity {
+		if m.UpstreamUID == 0 {
+			continue // locally-generated — never retracted
+		}
+		if m.UIDValidity != uidValidity {
+			syncedCount++ // C8: superseded-validity orphan is a candidate
+			gone = append(gone, m)
 			continue
+		}
+		if m.UpstreamUID > cursorUID {
+			continue // C7: too fresh to judge against this snapshot
 		}
 		syncedCount++
 		if !present[m.UpstreamUID] {

--- a/internal/imapsync/reconcile_race_test.go
+++ b/internal/imapsync/reconcile_race_test.go
@@ -1,0 +1,141 @@
+package imapsync_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// listHookStore wraps an InboundStore and runs a one-shot hook the first time
+// List is called, delegating every other method to the embedded store. Reconcile
+// calls store.List exactly once per pass, AFTER it has loaded the sync cursor and
+// snapshotted the upstream — so the hook injects a real interleaving at that
+// window: a concurrent Sync that stores a fresh message and advances the cursor
+// while the reconcile pass is mid-flight.
+type listHookStore struct {
+	inbound.InboundStore
+	once sync.Once
+	hook func()
+}
+
+func (s *listHookStore) List(owner, inbox string) ([]inbound.Message, error) {
+	s.once.Do(s.hook)
+	return s.InboundStore.List(owner, inbox)
+}
+
+// C7: a message that arrives upstream and is stored by a concurrent Sync AFTER
+// reconcile's upstream snapshot but BEFORE it lists the store must NOT be
+// retracted — its UID is above the cursor reconcile captured before the snapshot,
+// so it is too fresh to judge and is left for the next pass. Retracting it would
+// be silent permanent loss (the cursor has advanced past its UID, so it is never
+// re-pulled). A genuinely-absent message is still retracted in the same pass, so
+// the fix narrows retraction to positively-confirmed removals rather than
+// disabling it.
+func TestReconcileSparesMessageStoredByConcurrentSync(t *testing.T) {
+	addr, syncer, store, state := syncN(t, 3) // store {1,2,3}, cursor LastUID=3
+	expungeUID(t, addr, 2)                    // UID 2 genuinely leaves upstream
+
+	loaded, err := state.Load("INBOX")
+	require.NoError(t, err)
+	validity := loaded.UIDValidity
+
+	// The interleaving: while reconcile is mid-pass (cursor already captured at 3,
+	// upstream snapshot already taken as {1,3}), a concurrent Sync stores UID 4 and
+	// advances the cursor to 4. UID 4 is absent from the snapshot and beyond the
+	// pre-snapshot cursor.
+	hooked := &listHookStore{InboundStore: store, hook: func() {
+		_, _, aerr := store.AddSyncedPending(inbound.Delivery{
+			Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 4, UIDValidity: validity,
+		})
+		require.NoError(t, aerr)
+		require.NoError(t, state.Save("INBOX", imapsync.State{UIDValidity: validity, LastUID: 4}))
+	}}
+	raceSyncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, hooked, state, 0)
+
+	removed, err := raceSyncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "only the genuinely-absent UID 2 is retracted")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	uids := uidSet(msgs)
+	assert.Contains(t, uids, uint32(4), "the concurrently-stored fresh message survives the race")
+	assert.Contains(t, uids, uint32(1))
+	assert.Contains(t, uids, uint32(3))
+	assert.NotContains(t, uids, uint32(2), "the genuinely-removed message is still retracted")
+	_ = syncer
+}
+
+// C8: a record left under a SUPERSEDED UIDVALIDITY (the mailbox was reset and
+// forward sync has since advanced to the new validity) is orphaned — forward sync
+// only ever adds, and the plain set-diff skips other-validity records. Reconcile
+// now owns the cleanup: the orphan is retracted, while every current-validity
+// record still present upstream is untouched (no over-deletion masquerading as
+// orphan reclaim).
+func TestReconcileCleansSupersededValidityOrphans(t *testing.T) {
+	_, syncer, store, state := syncN(t, 3) // {1,2,3} @ current validity, all present upstream
+
+	loaded, err := state.Load("INBOX")
+	require.NoError(t, err)
+	staleValidity := loaded.UIDValidity + 1000 // a distinct, superseded validity
+
+	// An orphan from before a UIDVALIDITY reset: its UID is meaningless in the
+	// current UID space.
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 99, UIDValidity: staleValidity,
+	})
+	require.NoError(t, err)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "only the superseded-validity orphan is retracted")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	uids := uidSet(msgs)
+	assert.Len(t, msgs, 3, "the three current-validity records survive")
+	assert.Contains(t, uids, uint32(1))
+	assert.Contains(t, uids, uint32(2))
+	assert.Contains(t, uids, uint32(3))
+	assert.NotContains(t, uids, uint32(99), "the orphan is gone")
+}
+
+// C8 (idempotency): re-running reconcile after the orphan is already cleaned
+// retracts nothing and leaves the store unchanged — a retry can never compound
+// the loss.
+func TestReconcileOrphanCleanupIdempotent(t *testing.T) {
+	_, syncer, store, state := syncN(t, 2)
+
+	loaded, err := state.Load("INBOX")
+	require.NoError(t, err)
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 77, UIDValidity: loaded.UIDValidity + 1000,
+	})
+	require.NoError(t, err)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed)
+
+	removed2, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, removed2, "a second pass finds nothing to retract")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	assert.Len(t, msgs, 2, "the current-validity records are untouched across retries")
+}
+
+func uidSet(msgs []inbound.Message) map[uint32]bool {
+	out := make(map[uint32]bool, len(msgs))
+	for _, m := range msgs {
+		out[m.UpstreamUID] = true
+	}
+	return out
+}

--- a/internal/imapsync/reconcile_race_test.go
+++ b/internal/imapsync/reconcile_race_test.go
@@ -132,6 +132,34 @@ func TestReconcileOrphanCleanupIdempotent(t *testing.T) {
 	assert.Len(t, msgs, 2, "the current-validity records are untouched across retries")
 }
 
+// C8 (unknown validity): a record with UIDValidity == 0 is NOT a superseded-validity
+// orphan — the persisted field is omitempty with no backfill, so a record predating it
+// deserializes to zero. Zero is absence of information, not evidence of a reset UID
+// space, so reconcile must leave it untouched rather than retract it by inference
+// (which would be the exact silent permanent loss this pass exists to prevent).
+func TestReconcileSparesUnknownValidityRecords(t *testing.T) {
+	_, syncer, store, _ := syncN(t, 3) // {1,2,3} @ current validity, all present upstream
+
+	// A record from before UIDValidity was persisted: the field is absent on the wire
+	// and deserializes to zero.
+	_, _, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 42, UIDValidity: 0,
+	})
+	require.NoError(t, err)
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Zero(t, removed, "a zero-validity record is never retracted by inference")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	uids := uidSet(msgs)
+	assert.Contains(t, uids, uint32(42), "the unknown-validity record survives the pass")
+	assert.Contains(t, uids, uint32(1))
+	assert.Contains(t, uids, uint32(2))
+	assert.Contains(t, uids, uint32(3))
+}
+
 func uidSet(msgs []inbound.Message) map[uint32]bool {
 	out := make(map[uint32]bool, len(msgs))
 	for _, m := range msgs {

--- a/internal/imapsync/reconcile_race_test.go
+++ b/internal/imapsync/reconcile_race_test.go
@@ -160,6 +160,52 @@ func TestReconcileSparesUnknownValidityRecords(t *testing.T) {
 	assert.Contains(t, uids, uint32(3))
 }
 
+// C8 (present orphan): a record under a SUPERSEDED UIDVALIDITY whose body is already
+// cached (Pending == false) is a fully readable message today — the read face serves
+// its own constant UIDVALIDITY and never filters on the upstream one, and content
+// resolution returns the cached body without consulting validity. Retracting it is a
+// hard delete of the record, dedup entry, and content blob. So cleanup must claim ONLY
+// a pending orphan (headers-only, can never serve content); a present orphan is left
+// untouched for a deliberate reclaim decision. This asserts selectivity in one pass: a
+// pending orphan is retracted while a present orphan under the same superseded validity
+// survives alongside the current-validity records.
+func TestReconcileSparesPresentSupersededValidityOrphan(t *testing.T) {
+	_, syncer, store, state := syncN(t, 3) // {1,2,3} @ current validity, all present upstream
+
+	loaded, err := state.Load("INBOX")
+	require.NoError(t, err)
+	staleValidity := loaded.UIDValidity + 1000
+
+	// A pending orphan under the superseded validity — headers-only, reclaimable.
+	_, _, err = store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 88, UIDValidity: staleValidity,
+	})
+	require.NoError(t, err)
+
+	// A PRESENT orphan under the same superseded validity — its body is cached, so it is
+	// a readable message that must not be deleted by inference.
+	_, present, err := store.AddSyncedPending(inbound.Delivery{
+		Owner: "agent", Inbox: inbound.DefaultInbox, UpstreamUID: 99, UIDValidity: staleValidity,
+	})
+	require.NoError(t, err)
+	filled, err := store.SetContent("agent", inbound.DefaultInbox, present.ID, []byte("From: x@example.test\r\n\r\ncached body\r\n"))
+	require.NoError(t, err)
+	require.False(t, filled.Pending, "the present orphan has a cached body")
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, removed, "only the pending orphan is retracted; the present one is spared")
+
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	uids := uidSet(msgs)
+	assert.Contains(t, uids, uint32(99), "the present superseded-validity orphan survives (readable body)")
+	assert.NotContains(t, uids, uint32(88), "the pending superseded-validity orphan is reclaimed")
+	assert.Contains(t, uids, uint32(1))
+	assert.Contains(t, uids, uint32(2))
+	assert.Contains(t, uids, uint32(3))
+}
+
 func uidSet(msgs []inbound.Message) map[uint32]bool {
 	out := make(map[uint32]bool, len(msgs))
 	for _, m := range msgs {


### PR DESCRIPTION
Part 1 of 2 for #235 (sync-engine correctness). Theme: **two ownership gaps in the reconcile/sync loop that can silently lose a legitimate message.** Reconcile and sync overlap by design (both fire at startup; a STATUS-triggered sync adds more), so both are reachable in normal operation. Both rewrite the same guard-3 loop in `reconcile.go` and interact, so they ship together.

## Findings addressed

**C7 (MEDIUM) — reconcile/sync race could permanently retract a fresh message.** Reconcile snapshotted the upstream present-set, then listed the store. A message that arrived upstream *after* the snapshot and was stored by a concurrent `Sync` *before* the store list was absent from the snapshot → retracted — and since the sync cursor had already advanced past its UID, it was never re-pulled. Silent permanent local loss. **Fix:** load the sync cursor BEFORE snapshotting the upstream, and exclude any record whose UID is above that cursor from retraction (too fresh to judge against this snapshot — left for the next pass). Retraction still fires for a record positively confirmed absent upstream, so the gate is narrowed, not disabled.

**C8 (MEDIUM) — superseded-UIDVALIDITY records were orphaned forever.** After a UIDVALIDITY reset, `FetchContent`'s reset branch deferred cleanup to reconcile, reconcile's set-diff skipped other-validity records, and `Sync` only ever adds — so each deferred to another that never did it. Old-validity records lingered forever, listable but serving empty bodies alongside new-validity duplicates. **Fix:** reconcile now owns the cleanup — a same-inbox record under a superseded UIDVALIDITY is a retraction candidate, counted under the same safety cap/latch as any other retraction. **Behaviour note:** a large post-reset orphan set latches the inbox for operator review (release once) rather than auto-purging — the same anomaly backstop that already guards mass removals. A current-validity record still present upstream is never touched.

## Tests

Real interleaving, failing-before/passing-after (verified: the C7 test fails with the cursor-horizon exclusion reverted, passes with it):
- a store decorator fires a concurrent `Sync` (stores a fresh UID, advances the cursor) at the reconcile guard's store-list boundary, and asserts the fresh message survives while a genuinely-absent message is still retracted in the same pass;
- superseded-validity orphan cleanup retracts only the orphan and leaves current-validity records intact (no over-deletion masquerading as orphan reclaim);
- the cleanup is idempotent under retry (a second pass retracts nothing).

`go test -race ./...`, `go vet`, golangci-lint v2 — all green. `fix:` → accrues to release-please #242.

Part 1 of 2 (closes part of #235). Part 2 covers C9 (X-GM-LABELS honors UIDVALIDITY) + C32 (bounded sync context).

## Review fold-in (8729191)

Addresses the C8 review point: the orphan branch retracted **any** record whose validity differed from upstream's, including `UIDValidity == 0`. Zero is absence of information (the persisted field is `omitempty` with no backfill, so a record predating it deserializes to zero), not evidence of a superseded UID space — so it was reachable and would be silently retracted below the latch, the exact silent-loss mode this PR closes. Fix: skip zero-validity records entirely before the mismatch branch (never retract by inference); reclaiming them would need an explicit validity backfill, a separate decision. Added a failing-before/passing-after test asserting a zero-validity record survives a pass.

## Review fold-in (187d620)

Addresses the second-round blocker (both reviewers): the C8 orphan branch retracted **every** superseded-validity record, but "inert, serves empty body" only holds for a **pending** one. A present (body-cached) record under a superseded validity is a fully readable message today — the read face serves its own constant UIDVALIDITY and never filters on the upstream one, and content resolution returns the cached body without consulting validity — so `RemoveSynced` hard-deleting it (record + dedup entry + content blob) is the exact silent loss this PR closes, reached through cleanup instead of the diff. With eager-at-ingest assessment every synced record is stored present, so a post-reset set is exactly present orphans, and a recency-bounded re-pull need not restore them. The safety cap does **not** backstop this (orphans inflate numerator and denominator both).

**Fix:** qualify the orphan branch on `m.Pending` — a pending orphan is reclaimed, a present one is skipped outright (out of both the candidate set and the synced count, so it can never inflate the cap denominator). Rewrote the exported guard-3 doc comment to state all three exclusions (cursor horizon, unknown validity, pending-only orphan reclaim) rather than patching the inverted clause. Added a selectivity test: a pending orphan is retracted while a present orphan under the same superseded validity survives (failing-before/passing-after — without the guard the present orphan's blob is destroyed). Present-orphan residual folded into #255 alongside the zero-validity class (same underlying decision).