### PR TITLE
fix: bound X-GM-LABELS writes to mailbox validity and honor ctx in sync (#235 part 2)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -725,6 +725,49 @@ func runSync(ctx context.Context, inbox string, s *imapsync.Syncer, health *sync
 // after the first call.
 const DefaultSyncOnStatusInterval = time.Minute
 
+// OnDemandSyncTimeout bounds one STATUS-triggered on-demand pull (ADR 0028). The
+// trigger runs synchronously on the agent's own session goroutine, so an upstream
+// that accepts the connection and then answers nothing would otherwise block that
+// agent's STATUS indefinitely — and, because the coordinator clears its
+// single-flight flag only when the pull returns, would wedge on-demand sync for the
+// inbox for the process lifetime (every later trigger then reads as an in-flight
+// debounce skip and reports success while doing nothing). A bounded context lets
+// Sync's cancellation close the client and unblock a hung command (see Syncer.Sync),
+// which clears the flag so the next STATUS recovers.
+//
+// The bound exists to turn "forever" into "eventually", NOT to enforce
+// responsiveness, so it is deliberately generous. Sync advances the cursor only on a
+// clean pull (pull's error path returns before state.Save), so a cancellation
+// mid-pull discards that attempt's progress; a first sync against a new or reset
+// mailbox is a full re-sync from zero, exactly when a STATUS pull is slowest, and too
+// tight a deadline would cancel it partway every time and restart from the same place
+// — a livelock that reads as a slow upstream. Five minutes is far above the default
+// poll interval and go-imap's ~30s dial, so a healthy pull never truncates; a
+// genuinely stalled upstream is surfaced by the background sync loop's health
+// tracking, not here.
+const OnDemandSyncTimeout = 5 * time.Minute
+
+// onDemandSyncNow runs one STATUS-triggered on-demand pull bounded by timeout. The
+// deadline is what gives Sync's cancellation hook something to fire on: the STATUS
+// handler runs this synchronously on the agent's session goroutine with no context
+// of its own, so without a bound a hung upstream would block that agent and wedge
+// the inbox's single-flight flag. A pull cut off by its own deadline is a normal
+// outcome here, not a fault — ctx.Err() is the authoritative signal (a command-phase
+// cancellation surfaces as the client's closed-connection error, NOT
+// context.DeadlineExceeded), so classify on it and swallow with a debug trace rather
+// than let the STATUS handler log a failure (which would read like the pre-field
+// deferral warning). A genuine pull error, deadline not reached, is returned.
+func onDemandSyncNow(od *imapsync.OnDemandSync, inbox string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	_, _, terr := od.Trigger(ctx, inbox)
+	if terr != nil && ctx.Err() != nil {
+		slog.Debug("on-demand sync deferred: pull exceeded its budget", "inbox", inbox)
+		return nil
+	}
+	return terr
+}
+
 // newOnDemandSync builds the STATUS-triggered on-demand sync coordinator
 // (ADR 0028): it registers each inbox that opted in (sync_on_status) AND has an
 // upstream syncer, with its debounce window (sync_on_status_interval, or the
@@ -1246,8 +1289,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// background loop, on the connection's goroutine.
 	onDemand := newOnDemandSync(inboxes, syncers)
 	syncNow := func(inbox string) error {
-		_, _, terr := onDemand.Trigger(context.Background(), inbox)
-		return terr
+		return onDemandSyncNow(onDemand, inbox, OnDemandSyncTimeout)
 	}
 
 	// Wire the reconcile safety-cap controls onto the admin surface (ADR 0026):

--- a/cmd/darbaan/ondemand_timeout_test.go
+++ b/cmd/darbaan/ondemand_timeout_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// startHungIMAP runs a raw IMAP server that completes the connect + LOGIN handshake
+// but never answers a SELECT: the "accepted then silent" upstream whose command
+// phase go-imap's connect timeout does not cover. It is the production hazard the
+// on-demand bound exists for. Closed at test end via the returned stop func.
+func startHungIMAP(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	done := make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		br := bufio.NewReader(conn)
+		_, _ = io.WriteString(conn, "* OK [CAPABILITY IMAP4rev1 AUTH=PLAIN] hung ready\r\n")
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			fields := strings.SplitN(strings.TrimRight(line, "\r\n"), " ", 3)
+			if len(fields) < 2 {
+				continue
+			}
+			tag, cmd := fields[0], strings.ToUpper(fields[1])
+			if cmd == "SELECT" {
+				<-done // park, answering nothing, until the test tears down
+				return
+			}
+			switch cmd {
+			case "CAPABILITY":
+				_, _ = io.WriteString(conn, "* CAPABILITY IMAP4rev1 AUTH=PLAIN\r\n"+tag+" OK done\r\n")
+			default: // LOGIN, NOOP, …
+				_, _ = fmt.Fprintf(conn, "%s OK %s done\r\n", tag, cmd)
+			}
+		}
+	}()
+	return ln.Addr().String(), func() { close(done); _ = ln.Close() }
+}
+
+func hungDial(addr string) imapsync.DialFunc {
+	return func() (*imapclient.Client, error) {
+		c, err := imapclient.DialInsecure(addr, nil)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.Login("u", "p").Wait(); err != nil {
+			_ = c.Close()
+			return nil, err
+		}
+		return c, nil
+	}
+}
+
+func onDemandFixture(t *testing.T, dial imapsync.DialFunc) *imapsync.OnDemandSync {
+	t.Helper()
+	store, err := inbound.New("bbolt", filepath.Join(t.TempDir(), "inbound.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+	state, err := imapsync.NewStateStore(filepath.Join(t.TempDir(), "sync.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = state.Close() })
+	syncer := imapsync.New(dial, "INBOX", "agent", inbound.DefaultInbox, store, state, 0)
+	od := imapsync.NewOnDemandSync()
+	od.Register("work", syncer, 0) // no debounce
+	return od
+}
+
+// onDemandSyncNow must bound a STATUS pull against an upstream that accepts login and
+// then hangs on SELECT: it returns within the deadline rather than blocking the
+// caller forever. This is the wiring the finding was about — it fails (hits the
+// watchdog) if the bound is removed, so a green result proves the deadline is applied
+// at this call site, not merely that Sync would honour some other context. A deadline
+// reached mid-command is a deferral, so the returned error is nil even though the
+// command-phase cancellation surfaces internally as a closed-connection error, not
+// context.DeadlineExceeded — the ctx.Err() classification catches that case.
+func TestOnDemandSyncNowBoundsHungUpstream(t *testing.T) {
+	addr, stop := startHungIMAP(t)
+	defer stop()
+	od := onDemandFixture(t, hungDial(addr))
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { done <- onDemandSyncNow(od, "work", 300*time.Millisecond) }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err, "a deadline reached mid-pull is a deferral, swallowed, not a failure")
+		assert.Less(t, time.Since(start), 3*time.Second, "the pull was bounded by its deadline, not left hanging")
+	case <-time.After(5 * time.Second):
+		t.Fatal("onDemandSyncNow did not return: the deadline was not applied at this call site")
+	}
+}
+
+// A genuine pull error, with the deadline NOT reached, is returned rather than
+// swallowed — the deferral classification keys on ctx.Err(), so it must not hide a
+// real failure that happened well within budget.
+func TestOnDemandSyncNowReturnsRealError(t *testing.T) {
+	od := onDemandFixture(t, func() (*imapclient.Client, error) {
+		return nil, fmt.Errorf("dial refused")
+	})
+	err := onDemandSyncNow(od, "work", 5*time.Second)
+	require.Error(t, err, "a non-deadline failure is surfaced, not swallowed as a deferral")
+	assert.Contains(t, err.Error(), "connect")
+}

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -125,10 +125,19 @@ func Dialer(addr, username, password string) DialFunc {
 // re-syncs from scratch. The upstream is read-only (no flag/delete write-back,
 // v1). Returns the count stored this run.
 func (s *Syncer) Sync(ctx context.Context) (int, error) {
-	c, err := s.dial()
+	c, err := s.dialContext(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("imapsync: connect: %w", err)
+		return 0, err
 	}
+	// go-imap bounds only the CONNECT phase (its dialer's fixed timeout), not the
+	// post-connect commands: a server that accepts the socket and then never answers
+	// a SELECT/FETCH would block .Wait() indefinitely. Bind the command phase to ctx
+	// by closing the client on cancellation — closing the connection makes any
+	// in-flight .Wait() return, a genuine unblock of the blocked call rather than a
+	// pre-entry ctx check the hung call never reaches. stop() cancels the hook if
+	// Sync returns first (the common, uncancelled path).
+	stop := context.AfterFunc(ctx, func() { _ = c.Close() })
+	defer stop()
 	defer func() { _ = c.Logout().Wait(); _ = c.Close() }()
 
 	sel, err := c.Select(s.mailbox, nil).Wait()
@@ -167,6 +176,43 @@ func (s *Syncer) Sync(ctx context.Context) (int, error) {
 	// watermark (the cursor), and the current UIDVALIDITY.
 	s.logger.Info("inbound sync cycle", "stored", stored, "watermark_uid", highest, "uidvalidity", sel.UIDValidity)
 	return stored, nil
+}
+
+// dialContext runs the injected dial and honors ctx during the CONNECT phase. The
+// DialFunc is a blocking network round-trip with no ctx of its own (go-imap bounds
+// it only by the dialer's fixed timeout), so a cancellation mid-connect would
+// otherwise wait out that whole timeout. dialContext returns promptly on
+// cancellation instead; if the dial then completes anyway, its client is closed so
+// the connection does not leak. It preserves the "imapsync: connect" error wrap of
+// the original inline dial.
+func (s *Syncer) dialContext(ctx context.Context) (*imapclient.Client, error) {
+	type result struct {
+		c   *imapclient.Client
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		c, err := s.dial()
+		ch <- result{c: c, err: err}
+	}()
+	select {
+	case <-ctx.Done():
+		// Drain the in-flight dial so its client (if it lands after cancellation) is
+		// closed rather than leaked. This drain goroutine outlives the call until the
+		// dial returns; it is bounded by the DialFunc's own connect timeout (go-imap's
+		// dialer defaults to ~30s), the weakest of the bounds here but a real one.
+		go func() {
+			if r := <-ch; r.c != nil {
+				_ = r.c.Close()
+			}
+		}()
+		return nil, fmt.Errorf("imapsync: connect: %w", ctx.Err())
+	case r := <-ch:
+		if r.err != nil {
+			return nil, fmt.Errorf("imapsync: connect: %w", r.err)
+		}
+		return r.c, nil
+	}
 }
 
 // pull fetches new messages and stores them, returning the count stored and the

--- a/internal/imapsync/sync_ctx_test.go
+++ b/internal/imapsync/sync_ctx_test.go
@@ -1,0 +1,163 @@
+package imapsync_test
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// startHangingUpstream runs a raw IMAP server that completes the connect + LOGIN
+// handshake normally but never answers the named command (e.g. "SELECT"): it holds
+// the socket open and says nothing, the "accepted then silent" upstream go-imap's
+// connect timeout does not cover. It closes `reached` the instant it receives the
+// named command — the deterministic point at which that command is in flight — so a
+// test can cancel exactly then, guaranteeing it exercises the command-phase unblock
+// rather than (by a timing race) the connect-cancellation path. The `release`
+// channel, closed by the caller, unblocks the parked handler at test end.
+func startHangingUpstream(t *testing.T, hangOn string) (addr string, reached, release chan struct{}) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	reached = make(chan struct{})
+	release = make(chan struct{})
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		br := bufio.NewReader(conn)
+		// Advertise capabilities in the greeting so go-imap logs in without a separate
+		// pre-login CAPABILITY round-trip; no LOGINDISABLED, so plain LOGIN is allowed.
+		_, _ = io.WriteString(conn, "* OK [CAPABILITY IMAP4rev1 AUTH=PLAIN] fake ready\r\n")
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			fields := strings.SplitN(line, " ", 3)
+			if len(fields) < 2 {
+				continue
+			}
+			tag, cmd := fields[0], strings.ToUpper(fields[1])
+			if cmd == strings.ToUpper(hangOn) {
+				close(reached) // the withheld command is now in flight
+				<-release      // park here, answering nothing, until the test releases us
+				return
+			}
+			switch cmd {
+			case "CAPABILITY":
+				_, _ = io.WriteString(conn, "* CAPABILITY IMAP4rev1 AUTH=PLAIN\r\n")
+				_, _ = io.WriteString(conn, tag+" OK CAPABILITY completed\r\n")
+			case "LOGOUT":
+				_, _ = io.WriteString(conn, "* BYE\r\n"+tag+" OK LOGOUT completed\r\n")
+				return
+			default: // LOGIN, NOOP, … — anything but the parked command
+				_, _ = fmt.Fprintf(conn, "%s OK %s completed\r\n", tag, cmd)
+			}
+		}
+	}()
+	t.Cleanup(func() { _ = ln.Close() })
+	return ln.Addr().String(), reached, release
+}
+
+// C32: Sync honors ctx when the upstream accepts the connection and then never
+// answers the SELECT — the command phase go-imap does not bound. With ctx cancelled
+// shortly after entry, Sync must unblock the in-flight SELECT and return promptly,
+// not hang on it. The upstream stays connected the whole time, so a pass here cannot
+// be an artifact of an already-closed connection or a ctx cancelled before entry.
+func TestSyncHonorsContextOnHungUpstream(t *testing.T) {
+	addr, reached, release := startHangingUpstream(t, "SELECT")
+	defer close(release)
+
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, newInbound(t), newState(t), 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// Cancel exactly when the SELECT is in flight (the server signals `reached`), so
+	// the test provably exercises the command-phase unblock, not the connect path.
+	go func() { <-reached; cancel() }()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { _, err := syncer.Sync(ctx); done <- err }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a cancelled sync against a hung upstream returns an error")
+		assert.Less(t, time.Since(start), 2*time.Second, "sync unblocked the hung SELECT instead of hanging")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Sync did not return after ctx cancellation against a hung upstream")
+	}
+}
+
+// C32 (on-demand entry point): OnDemandSync.Trigger runs Sync with the caller's
+// context, so a bounded context from the STATUS wiring (OnDemandSyncTimeout in
+// cmd/darbaan) bounds a hung on-demand pull too — the interactive path an agent
+// reaches. Against an upstream that accepts login then never answers SELECT, a
+// Trigger whose context is cancelled while the command is in flight must return
+// promptly rather than block the session goroutine and wedge the coordinator's
+// single-flight flag for the process lifetime.
+func TestOnDemandTriggerHonorsContextOnHungUpstream(t *testing.T) {
+	addr, reached, release := startHangingUpstream(t, "SELECT")
+	defer close(release)
+
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, newInbound(t), newState(t), 0)
+	od := imapsync.NewOnDemandSync()
+	od.Register("work", syncer, 0) // no debounce, so the trigger runs the pull
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { <-reached; cancel() }()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { _, _, err := od.Trigger(ctx, "work"); done <- err }()
+
+	select {
+	case err := <-done:
+		require.Error(t, err, "a cancelled on-demand trigger against a hung upstream returns an error")
+		assert.Less(t, time.Since(start), 2*time.Second, "the on-demand pull unblocked instead of wedging")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Trigger did not return after ctx cancellation against a hung upstream")
+	}
+}
+
+// C32 (connect phase): Sync honors ctx while the dial itself is blocked (a
+// black-hole connect), abandoning it promptly on cancellation rather than waiting
+// out the dialer's fixed timeout.
+func TestSyncHonorsContextWhileConnecting(t *testing.T) {
+	blocked := make(chan struct{})
+	t.Cleanup(func() { close(blocked) })
+	dial := func() (*imapclient.Client, error) {
+		<-blocked // the dial never completes until test cleanup
+		return nil, fmt.Errorf("unreachable")
+	}
+	syncer := imapsync.New(dial, "INBOX", "agent", inbound.DefaultInbox, newInbound(t), newState(t), 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() { time.Sleep(50 * time.Millisecond); cancel() }()
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() { _, err := syncer.Sync(ctx); done <- err }()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled, "a cancelled connect surfaces the cancellation")
+		assert.Less(t, time.Since(start), 2*time.Second, "sync abandoned the blocked connect promptly")
+	case <-time.After(5 * time.Second):
+		t.Fatal("Sync did not abandon a blocked connect on ctx cancellation")
+	}
+}

--- a/internal/imapsync/xgmlabels.go
+++ b/internal/imapsync/xgmlabels.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -38,7 +39,7 @@ func RawGmailLabelStore(addr, username, password, mailbox string) LabelStoreFunc
 // newLabelStore is the dialer-injected core of RawGmailLabelStore (production
 // uses a TLS dialer; tests inject a plaintext one).
 func newLabelStore(dial func() (net.Conn, error), username, password, mailbox string) LabelStoreFunc {
-	return func(uid, _ uint32, add, remove []string) error {
+	return func(uid, uidValidity uint32, add, remove []string) error {
 		if len(add) == 0 && len(remove) == 0 {
 			return nil
 		}
@@ -58,8 +59,35 @@ func newLabelStore(dial func() (net.Conn, error), username, password, mailbox st
 		if !hasCap(caps, "X-GM-EXT-1") {
 			return ErrNotXGM
 		}
-		if err := rc.do("a3", fmt.Sprintf("SELECT %s", imapQuote(mailbox))); err != nil {
+		// Confirm the mailbox UID space is KNOWN and still matches the one the message
+		// was recorded under BEFORE issuing any UID STORE. A UIDVALIDITY change means the
+		// mailbox was reset and the stored UID now addresses a different message (or
+		// none), so a STORE against it would label the wrong mail. SELECT's UIDVALIDITY
+		// rides an untagged "* OK [UIDVALIDITY n]" response code, which rc.do discards —
+		// so collect the untagged lines and read it (selectUIDValidity).
+		//
+		// Refuse when the validity is UNKNOWN on EITHER side (0), not only on a mismatch:
+		// selectUIDValidity yields 0 for a missing/unparseable code, and a record
+		// predating the persisted UIDValidity field carries 0 (WriteKeywords passes it
+		// through with no zero check), so a bare "got != uidValidity" would read 0 != 0
+		// as a match and STORE against a UID space it never confirmed — the exact hole
+		// this guard exists to close. Unknown-on-either-side is therefore a refusal,
+		// matching the #253 reconcile skip for zero-validity records. A confirmed
+		// mismatch is the mailbox-reset refusal, mirroring the plain-keyword path's guard
+		// (WriteKeywords in imapsync.go) at the same point (post-SELECT, pre-STORE). (The
+		// plain-keyword path has the same both-zero shape; tracked as a follow-up.) Label
+		// writes are best-effort and retried (reconcileKeywords), so a refusal defers the
+		// write, it does not lose it.
+		selLines, err := rc.collect("a3", fmt.Sprintf("SELECT %s", imapQuote(mailbox)))
+		if err != nil {
 			return err
+		}
+		got := selectUIDValidity(selLines)
+		if got == 0 || uidValidity == 0 {
+			return fmt.Errorf("imapsync: xgm label write for uid %d: unconfirmed mailbox validity (server %d, record %d)", uid, got, uidValidity)
+		}
+		if got != uidValidity {
+			return fmt.Errorf("imapsync: xgm label write for uid %d: mailbox reset (uidvalidity %d != %d)", uid, got, uidValidity)
 		}
 		if len(add) > 0 {
 			if err := rc.do("a4", fmt.Sprintf("UID STORE %d +X-GM-LABELS (%s)", uid, labelList(add))); err != nil {
@@ -127,6 +155,35 @@ func (rc *rawConn) collect(tag, cmd string) ([]string, error) {
 		}
 		untagged = append(untagged, line)
 	}
+}
+
+// selectUIDValidity extracts the mailbox UIDVALIDITY from a SELECT response's
+// untagged lines. RFC 3501 requires an untagged "* OK [UIDVALIDITY n]" response
+// code on a successful SELECT; this scans for that code and parses n. It returns
+// 0 when no parseable code is present — 0 is never a valid UIDVALIDITY, so the
+// caller treats it as "unknown" and refuses rather than writing against an
+// unconfirmed UID space. The bracket match is case-insensitive (response codes
+// are), and ToUpper preserves ASCII byte offsets so the index into the original
+// line stays aligned.
+func selectUIDValidity(lines []string) uint32 {
+	const marker = "[UIDVALIDITY "
+	for _, l := range lines {
+		i := strings.Index(strings.ToUpper(l), marker)
+		if i < 0 {
+			continue
+		}
+		rest := l[i+len(marker):]
+		j := strings.IndexByte(rest, ']')
+		if j < 0 {
+			continue
+		}
+		n, err := strconv.ParseUint(strings.TrimSpace(rest[:j]), 10, 32)
+		if err != nil {
+			continue
+		}
+		return uint32(n)
+	}
+	return 0
 }
 
 func hasCap(lines []string, want string) bool {

--- a/internal/imapsync/xgmlabels_internal_test.go
+++ b/internal/imapsync/xgmlabels_internal_test.go
@@ -1,13 +1,19 @@
 package imapsync
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
+	"io"
 	"net"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapserver"
 	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,6 +45,155 @@ func TestLabelStoreNotGmail(t *testing.T) {
 	)
 	err = ls(1, 1, []string{"useless"}, nil)
 	require.ErrorIs(t, err, ErrNotXGM)
+}
+
+// fakeXGM is a scripted raw IMAP server for the X-GM-LABELS write path: it
+// advertises X-GM-EXT-1, answers SELECT with a configurable UIDVALIDITY, and
+// records every command line it receives so a test can assert whether a UID STORE
+// was ever dispatched. It speaks only the handful of commands newLabelStore issues.
+type fakeXGM struct {
+	ln          net.Listener
+	uidValidity uint32
+	mu          sync.Mutex
+	cmds        []string
+}
+
+func newFakeXGM(t *testing.T, uidValidity uint32) *fakeXGM {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	f := &fakeXGM{ln: ln, uidValidity: uidValidity}
+	go f.serve()
+	t.Cleanup(func() { _ = ln.Close() })
+	return f
+}
+
+func (f *fakeXGM) addr() string { return f.ln.Addr().String() }
+
+func (f *fakeXGM) record(cmd string) {
+	f.mu.Lock()
+	f.cmds = append(f.cmds, cmd)
+	f.mu.Unlock()
+}
+
+// sawUIDStore reports whether any recorded command was a UID STORE — the side
+// effect a stale-validity write must never reach.
+func (f *fakeXGM) sawUIDStore() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.cmds {
+		if strings.Contains(strings.ToUpper(c), "UID STORE") {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *fakeXGM) serve() {
+	conn, err := f.ln.Accept()
+	if err != nil {
+		return
+	}
+	defer func() { _ = conn.Close() }()
+	br := bufio.NewReader(conn)
+	_, _ = io.WriteString(conn, "* OK fakeXGM ready\r\n")
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		f.record(line)
+		fields := strings.SplitN(line, " ", 3)
+		if len(fields) < 2 {
+			continue
+		}
+		tag, cmd := fields[0], strings.ToUpper(fields[1])
+		switch cmd {
+		case "CAPABILITY":
+			_, _ = io.WriteString(conn, "* CAPABILITY IMAP4rev1 X-GM-EXT-1\r\n")
+			_, _ = io.WriteString(conn, tag+" OK CAPABILITY completed\r\n")
+		case "SELECT":
+			if f.uidValidity != 0 { // 0 → answer SELECT with NO UIDVALIDITY response code
+				_, _ = fmt.Fprintf(conn, "* OK [UIDVALIDITY %d] UIDs valid\r\n", f.uidValidity)
+			}
+			_, _ = io.WriteString(conn, tag+" OK [READ-WRITE] SELECT completed\r\n")
+		case "LOGOUT":
+			_, _ = io.WriteString(conn, "* BYE\r\n"+tag+" OK LOGOUT completed\r\n")
+			return
+		default: // LOGIN, UID STORE, …
+			_, _ = io.WriteString(conn, tag+" OK completed\r\n")
+		}
+	}
+}
+
+// C9: the label writer refuses when the mailbox UIDVALIDITY no longer matches the
+// one the message was recorded under, and it refuses BEFORE issuing any UID STORE —
+// the same guard the plain-keyword path applies (WriteKeywords), at the same point
+// (post-SELECT, pre-STORE). A stale UID must never reach a STORE against a reset
+// mailbox, where it would label a different message. The assertion that no UID STORE
+// reached the server is what would fail if the check were moved even one step later.
+func TestLabelStoreRefusesStaleValidityBeforeStore(t *testing.T) {
+	f := newFakeXGM(t, 4000) // the upstream mailbox is now at validity 4000
+	ls := newLabelStore(
+		func() (net.Conn, error) { return net.Dial("tcp", f.addr()) },
+		"u", "p", "INBOX",
+	)
+	// The message was recorded under validity 3000 — the mailbox has since reset.
+	err := ls(42, 3000, []string{"Important"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mailbox reset")
+	assert.False(t, f.sawUIDStore(), "a stale-validity label write must not reach a UID STORE")
+}
+
+// C9 (match): when the mailbox UIDVALIDITY matches the recorded one, the label
+// write proceeds and the UID STORE is issued.
+func TestLabelStoreIssuesStoreOnMatchingValidity(t *testing.T) {
+	f := newFakeXGM(t, 4000)
+	ls := newLabelStore(
+		func() (net.Conn, error) { return net.Dial("tcp", f.addr()) },
+		"u", "p", "INBOX",
+	)
+	require.NoError(t, ls(42, 4000, []string{"Important"}, nil))
+	assert.True(t, f.sawUIDStore(), "a matching-validity label write issues the UID STORE")
+}
+
+// C9 (unknown validity, both sides zero — the fail-open the guard must close): when
+// the SELECT response carries no parseable UIDVALIDITY code (got 0) AND the record's
+// stored validity is also 0 (a record predating the persisted field), the writer must
+// refuse rather than read 0 == 0 as a match and STORE against an unconfirmed UID space.
+func TestLabelStoreRefusesUnknownValidityBeforeStore(t *testing.T) {
+	f := newFakeXGM(t, 0) // SELECT answers without a UIDVALIDITY response code
+	ls := newLabelStore(
+		func() (net.Conn, error) { return net.Dial("tcp", f.addr()) },
+		"u", "p", "INBOX",
+	)
+	err := ls(42, 0, []string{"Important"}, nil) // record validity also unknown (0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unconfirmed mailbox validity")
+	assert.False(t, f.sawUIDStore(), "an unconfirmed-validity label write must not reach a UID STORE")
+}
+
+// C9 (one side unknown): a known server validity but a zero recorded validity also
+// refuses — the record's UID space cannot be confirmed against the mailbox, so it must
+// not reach a UID STORE.
+func TestLabelStoreRefusesZeroRecordValidity(t *testing.T) {
+	f := newFakeXGM(t, 4000)
+	ls := newLabelStore(
+		func() (net.Conn, error) { return net.Dial("tcp", f.addr()) },
+		"u", "p", "INBOX",
+	)
+	err := ls(42, 0, []string{"Important"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unconfirmed mailbox validity")
+	assert.False(t, f.sawUIDStore(), "a zero recorded validity must not reach a UID STORE")
+}
+
+func TestSelectUIDValidity(t *testing.T) {
+	assert.Equal(t, uint32(4000), selectUIDValidity([]string{"* OK [UIDVALIDITY 4000] UIDs valid"}))
+	assert.Equal(t, uint32(1), selectUIDValidity([]string{"* 3 EXISTS", "* OK [uidvalidity 1] lower-case code"}))
+	assert.Zero(t, selectUIDValidity([]string{"* 3 EXISTS", "* OK no validity code here"}), "absent code reads as 0 (fails the equality guard safe)")
+	assert.Zero(t, selectUIDValidity([]string{"* OK [UIDVALIDITY notanumber] bad"}), "unparseable code reads as 0")
 }
 
 func TestImapQuote(t *testing.T) {


### PR DESCRIPTION
Part 2 (final) of #235 sync-engine correctness — the upstream round-trip half. Part 1 (#253) covered the reconcile/sync race and superseded-validity cleanup; this covers C9 and C32. Built on current main (post-#253).

## C9 — X-GM-LABELS write ignored mailbox validity
`newLabelStore` (internal/imapsync/xgmlabels.go) is handed the message's `uidValidity` at the call site (`WriteKeywords`), but the closure discarded it and issued `UID STORE` after a `SELECT` via `rc.do` (which throws away SELECT's untagged data). After a `UIDVALIDITY` reset the stored UID addresses a different message, so a label could be written to the wrong mail.

Root-cause fix — make the existing parameter load-bearing: `SELECT` via `rc.collect`, read the `* OK [UIDVALIDITY n]` code (`selectUIDValidity`), refuse **before** any `UID STORE`, mirroring the plain-keyword guard in `WriteKeywords`. Refuse when validity is unknown (`0`) on **either** side, not only on a mismatch: `selectUIDValidity` yields `0` for a missing/unparseable code and a record predating the persisted field carries `0` (WriteKeywords forwards it unchecked), so a bare `got != uidValidity` would read `0 != 0` as a match and STORE against an unconfirmed UID space. Unknown-either-side is a refusal, matching the #253 zero-validity skip. Pure equality/known check — no newer-vs-superseded inference, so #255 is unaffected. Plain-keyword path shares the same both-zero shape → **#257**.

## C32 — Sync took a context it never used
`Syncer.Sync(ctx)` never consulted `ctx`; go-imap bounds only the connect phase, so an upstream that accepts the socket then never answers a `SELECT`/`FETCH` blocks `.Wait()` indefinitely.
- `dialContext` honors `ctx` across the connect phase; `context.AfterFunc` closes the client on cancellation to **genuinely unblock** an in-flight command.
- **On-demand entry point (the interactive one).** `OnDemandSync.Trigger` threads `ctx` into `Sync`, but its production caller (`cmd/darbaan` STATUS handler) passed `context.Background()` — no deadline, so the hook could never fire there, and since the coordinator clears its single-flight flag only when the pull returns, a permanent block would **silently disable on-demand sync** for that inbox for the process lifetime. Bound it at the wiring site (`OnDemandSyncTimeout`): a deliberately generous deadline that turns "forever" into "eventually" without truncating a legitimate full re-sync (the cursor advances only on a clean pull, so too-tight a bound would livelock). A deadline reached mid-pull is swallowed as a **deferral** (not logged as a failure — `ctx.Err()` is the authoritative signal, since a command-phase cancellation surfaces as the client's closed-connection error, not `context.DeadlineExceeded`). The background poll already carries a cancellable context, so both entry points are now genuinely bounded.

### Cross-package touch: cmd/darbaan/main.go
The C32 fix requires the STATUS wiring to supply a bounded context (the `internal/imapsync` mechanism is inert without one — a cancellation bound is a property of the mechanism *and* the supplied context together). `OnDemandSyncTimeout` const + the `syncNow` closure now derive a timeout context and classify a deadline as a deferral. No behavior change on any other path.

## Tests (all failing-before / passing-after, under `-race`)
- **C9**: scripted X-GM server — stale-validity and unknown-validity (both-zero) writes refuse with **no `UID STORE` reaching the wire**; matching validity issues it; `selectUIDValidity` unit cases.
- **C32**: a hung-upstream server that completes login then never answers `SELECT`, **signalling from its park point** so cancellation provably lands while the command is in flight (not the connect path) — asserts both `Sync` and `OnDemandSync.Trigger` return in <2s rather than hanging; plus a blocked-connect case (`context.Canceled`).

## Gates
`gofmt -l` clean · `go vet ./...` clean · `golangci-lint` v2.11.4 0 issues · full suite green, `-race` on internal/imapsync (incl. determinism ×10).

Closes #235