### PR TITLE
fix: compare agent credentials in constant time over fixed-width hashes (#238 C31)

### DIFF
--- a/internal/listener/auth.go
+++ b/internal/listener/auth.go
@@ -1,6 +1,10 @@
 package listener
 
-import "crypto/subtle"
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+)
 
 // Principal is an authenticated agent (ADR 0002 — the agent never holds upstream
 // credentials): its Darbaan login plus the grants that gate its access (ADR 0027).
@@ -39,6 +43,31 @@ type Auth struct {
 // dummyPassword equalizes the compare path for an unknown username.
 const dummyPassword = "x-darbaan-no-such-principal"
 
+// compareKey keys the credential comparison; it is random per process. Verify MACs
+// both the presented and the stored password to a fixed width before comparing, so
+// hmac.Equal — which, like any constant-time compare, is length-safe only for
+// equal-length inputs — never sees the raw password lengths. A keyed MAC (not a bare
+// password hash) is the right primitive here: it makes the fixed-width values
+// unpredictable, so they can't be precomputed or correlated across runs. Generated
+// once; a randomness failure is fatal, because the only fallbacks (comparing raw bytes,
+// or an unkeyed hash) would reintroduce the length oracle this closes.
+var compareKey = mustRandomKey(32)
+
+func mustRandomKey(n int) []byte {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic("listener: cannot read randomness for the auth compare key: " + err.Error())
+	}
+	return b
+}
+
+// credMAC returns the fixed-width keyed digest used for the constant-time compare.
+func credMAC(s string) []byte {
+	m := hmac.New(sha256.New, compareKey)
+	m.Write([]byte(s))
+	return m.Sum(nil)
+}
+
 // NewAuth builds an Auth over the given principals, keyed by name. Name
 // uniqueness is validated upstream (agentcfg.Validate).
 func NewAuth(principals []Principal) *Auth {
@@ -57,15 +86,35 @@ func SingleAuth(name, password string) *Auth {
 
 // Verify authenticates a presented (username, password), returning the matched
 // principal; ok is false on any miss.
+//
+// The password comparison is over fixed-width keyed MACs (credMAC), not the raw bytes.
+// A constant-time compare is length-safe only for equal-length inputs — it
+// short-circuits on a length mismatch — so comparing raw passwords would leak the
+// stored password's length, and (against the fixed-length dummy) whether the username
+// exists at all. MAC-ing both sides first makes lengths uninformative. Every outcome
+// does identical work: MAC the presented password (before the lookup), MAC the target,
+// one fixed-width compare — so the found and not-found paths are indistinguishable, and
+// both return (nil, false), which both callers map to the same ErrAuthFailed with no
+// distinguishing log. This surface is keyed by the presented username, so unlike the
+// admin credential set (ADR 0029, which scans every credential with no early exit to
+// hide which one matched) there is no set membership to conceal here — only that a miss
+// is a miss regardless of which half was wrong (ADR 0027).
+//
+// "Identical work" describes the compare path; the map lookup ahead of it is not
+// identical (a hit compares the key it found, a miss need not), leaving a small residue
+// — a key comparison plus network jitter. That residue is accepted rather than closed:
+// eliminating it would mean scanning every principal, the scan-all pattern this
+// username-keyed surface deliberately declines (there is no membership to hide).
 func (a *Auth) Verify(username, password string) (*Principal, bool) {
+	got := credMAC(password)
 	p, found := a.byName[username]
 	if !found {
-		// Compare against a fixed value so an unknown username takes a similar path
-		// to a wrong password (no username-enumeration oracle).
-		subtle.ConstantTimeCompare([]byte(password), []byte(dummyPassword))
+		// MAC the dummy and compare too, so the not-found path does the same work as a
+		// wrong password — no username-existence timing oracle.
+		_ = hmac.Equal(got, credMAC(dummyPassword))
 		return nil, false
 	}
-	if subtle.ConstantTimeCompare([]byte(password), []byte(p.Password)) != 1 {
+	if !hmac.Equal(got, credMAC(p.Password)) {
 		return nil, false
 	}
 	return &p, true

--- a/internal/listener/auth_test.go
+++ b/internal/listener/auth_test.go
@@ -1,6 +1,7 @@
 package listener_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -50,4 +51,30 @@ func TestAuthEmpty(t *testing.T) {
 	a := listener.NewAuth(nil)
 	_, ok := a.Verify("agent", "pw")
 	assert.False(t, ok)
+}
+
+// C31: the credential compare is over fixed-width keyed MACs, so the presented
+// password's length is not a branch — a right or wrong password of any length is
+// accepted/rejected on its content alone. This is a length-agnostic CORRECTNESS check,
+// not a regression guard: a raw byte compare would agree with the MAC compare on every
+// non-colliding input, so reverting the fix leaves these assertions green. The timing
+// property is not unit-assertable and is verified by review (see Verify).
+func TestAuthFixedWidthCompareIsLengthAgnostic(t *testing.T) {
+	stored := "pw" // deliberately short, so wrong passwords are both shorter and much longer
+	a := listener.NewAuth([]listener.Principal{{Name: "agent", Password: stored}})
+
+	for _, wrong := range []string{"", "x", "pw ", "PW", strings.Repeat("p", 5000)} {
+		_, ok := a.Verify("agent", wrong)
+		assert.Falsef(t, ok, "wrong password %q (len %d) must be rejected", wrong, len(wrong))
+	}
+	// The correct password authenticates regardless.
+	p, ok := a.Verify("agent", stored)
+	assert.True(t, ok)
+	assert.Equal(t, "agent", p.Name)
+
+	// Unknown username with a pathological-length password is a clean miss (no panic,
+	// same (nil,false) outcome as a wrong password).
+	np, ok := a.Verify("nobody", strings.Repeat("z", 5000))
+	assert.False(t, ok)
+	assert.Nil(t, np)
 }


### PR DESCRIPTION
**#238 PR-1 of ~6** (low-severity cleanup, security-first slice). C31 only — the item that warrants the careful 2-of-2; the rest of the correctness cluster (C33/C34/C40 + admin-addr warn + audit-log) follows as PR-2.

## The leak (C31)
Agent SMTP/IMAP login compared raw password bytes with a constant-time compare, which is length-safe only for equal-length inputs — it short-circuits on a length mismatch. So it leaked the stored password's length, and against the fixed-length dummy on the not-found path, whether the username existed at all.

## The fix
MAC both sides with **HMAC-SHA256 under a random per-process key** (`credMAC`), then compare the fixed-width MACs (`hmac.Equal`). Lengths become uninformative. A keyed MAC — not a bare password hash — is the correct primitive for a constant-time compare of variable-length secrets: it makes the fixed-width values unpredictable, and it is not password-storage hashing (an earlier bare-SHA256 draft tripped CodeQL's weak-password-hash rule; HMAC is both more correct and clears it).

## Timing-fix failure modes (the leak likes to survive next to the compare)
- **Lookup path, not just the compare:** the presented password is MAC'd *before* the map lookup, and the **not-found branch also MACs** the dummy and runs the same compare — both outcomes do identical work.
- **Unreachable by construction:** the compare is over two fixed 32-byte MACs, so the primitive's length short-circuit can never be hit — no length branch anywhere in `Verify`.
- **Non-timing channels agree:** both callers map a miss to the same `ErrAuthFailed`, no distinguishing log; `Verify` returns identical `(nil,false)`.
- **Enumerated *this* surface, not cleared by resemblance:** admin (ADR 0029) scans every credential with no early exit to hide *which* matched — a problem a username-keyed surface doesn't have, so admin's iterate-all was **not** copied. The residual map-lookup asymmetry (a hit compares the found key, a miss need not) is documented as accepted, because closing it would require the scan-all pattern this surface declines.

## Testing honesty
A pure timing fix has no meaningful failing-before — the compare is invisible to behavioural tests (a raw compare agrees with the MAC compare on all non-colliding inputs). `TestAuthFixedWidthCompareIsLengthAgnostic` is a **length-agnostic correctness** check (empty … 5000-char passwords, accept/reject, no panic), explicitly **not** a regression guard; the timing property is review-verified. The only way to *structurally* pin it (store digests at construction, so there's no plaintext to revert to) is filed as a follow-up rather than folded here. gofmt / build / -race / vet / golangci-lint v2.11.4 all green; CI incl. CodeQL green on HEAD.

## Deferred
ADR-0027 text touch-up (A12) → operator-gated ADR-hygiene pass (#237). This PR is code-only and does **not** close #238.