### PR TITLE
fix: render the decoded body in the hold surfaces, not the raw message source

### DIFF
--- a/cmd/darbaan/holds_show_test.go
+++ b/cmd/darbaan/holds_show_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -179,4 +182,69 @@ func TestHoldsShowEndToEndAgainstRealServer(t *testing.T) {
 	assert.Contains(t, err.Error(), "no longer held")
 	assert.Contains(t, err.Error(), "take no action")
 	assert.NotContains(t, err.Error(), "no stored body")
+}
+
+// #261: --text prints the decoded body rather than the raw source. Both modes are
+// kept because they serve different jobs — the raw dump is byte-exact and redirects
+// to a .eml, --text is for actually reading the thing before deciding on it.
+func TestHoldsShowTextPrintsDecodedBody(t *testing.T) {
+	raw := "Delivered-To: agent@x.test\r\n" +
+		"ARC-Seal: i=1; a=rsa-sha256; b=" + strings.Repeat("Zq", 200) + "\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n\r\n" +
+		"the readable body\r\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(raw))
+	}))
+	defer srv.Close()
+	t.Setenv("DARBAAN_ADMIN_TOKEN", "t")
+	cli := &CLI{AdminAddr: strings.TrimPrefix(srv.URL, "http://")}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, (&HoldsShowCmd{ID: "x", Text: true}).Run(cli))
+	})
+	assert.Contains(t, out, "the readable body")
+	assert.NotContains(t, out, "ARC-Seal", "--text does not print transport headers")
+
+	// Default stays the raw dump: removing that would take away the byte-exact
+	// output the .eml redirect depends on.
+	rawOut := captureStdout(t, func() {
+		require.NoError(t, (&HoldsShowCmd{ID: "x"}).Run(cli))
+	})
+	assert.Contains(t, rawOut, "ARC-Seal", "the default mode is still the raw source")
+}
+
+// A body that exists but yields no text fails loudly under --text, for the same
+// reason the no-stored-body case does: exiting 0 having printed nothing reads as
+// "the message is empty" on the surface where the body is the decision.
+func TestHoldsShowTextNoReadableTextIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("Content-Type: image/png\r\n\r\n\x89PNG binary"))
+	}))
+	defer srv.Close()
+	t.Setenv("DARBAAN_ADMIN_TOKEN", "t")
+	cli := &CLI{AdminAddr: strings.TrimPrefix(srv.URL, "http://")}
+
+	err := (&HoldsShowCmd{ID: "img", Text: true}).Run(cli)
+	require.Error(t, err, "no readable text must not exit 0 having printed nothing")
+	assert.Contains(t, err.Error(), "NOT empty")
+	assert.Contains(t, err.Error(), "without --text", "points at the raw dump rather than dead-ending")
+}
+
+// captureStdout swaps os.Stdout for a pipe, runs fn, and returns what was written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+	fn()
+	require.NoError(t, w.Close())
+	os.Stdout = orig
+	return <-done
 }

--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/inboxcfg"
 	"github.com/yaad-index/darbaan/internal/listener"
+	"github.com/yaad-index/darbaan/internal/mailtext"
 	"github.com/yaad-index/darbaan/internal/policy"
 	"github.com/yaad-index/darbaan/internal/provenance"
 	"github.com/yaad-index/darbaan/internal/riskscore"
@@ -1616,8 +1617,14 @@ type HoldsCmd struct {
 // absent. (The outbound `queue show` sibling enumerates its own parallel outcomes,
 // including a present-but-empty body — empty means something different there, a
 // genuinely empty submission rather than a body not yet fetched.)
+// The default output is the raw message source, deliberately: it is byte-exact and
+// redirects cleanly to a .eml, which is what the outbound `queue show` sibling does
+// too. --text is for the other job, reading it: it prints the decoded body via the
+// same extractor the assessor consumes, so an operator judging an injection hold
+// reads the text the detector actually scored instead of a header wall.
 type HoldsShowCmd struct {
-	ID string `arg:"" help:"Message id."`
+	ID   string `arg:"" help:"Message id."`
+	Text bool   `help:"Print the decoded text body instead of the raw message source."`
 }
 
 func (c *HoldsShowCmd) Run(cli *CLI) error {
@@ -1638,6 +1645,25 @@ func (c *HoldsShowCmd) Run(cli *CLI) error {
 		// prevent, on the class of message where the body is the decision. Fail loudly so
 		// the absence is never taken as the message's content.
 		return fmt.Errorf("message %s is held with no stored body — nothing is shown; decide from the metadata knowing you have not seen the body, do not treat this as an empty message", c.ID)
+	}
+	if c.Text {
+		content, exErr := mailtext.Extract(raw, mailtext.DefaultLimits())
+		body := strings.TrimRight(content.Body, " \t\r\n")
+		if body == "" {
+			// The body exists but yielded no text. Fail loudly for the same reason the
+			// no-stored-body case does: printing nothing and exiting 0 would read as "the
+			// message is empty" when it is not, and this is the surface where the body is
+			// the decision. Point at the raw dump rather than leaving a dead end.
+			return fmt.Errorf("message %s has %d bytes of source but no readable text part — it is NOT empty; run without --text to dump the raw source", c.ID, len(raw))
+		}
+		if exErr != nil || content.Undecodable {
+			fmt.Fprintf(os.Stderr, "warning: part of message %s could not be decoded and was never scored — the assessment cannot account for it; the raw source (without --text) is the complete record\n", c.ID)
+		}
+		if content.Truncated {
+			fmt.Fprintf(os.Stderr, "warning: extraction hit its size limits — the message carries more text than is shown here\n")
+		}
+		_, err = fmt.Println(body)
+		return err
 	}
 	_, err = os.Stdout.Write(raw)
 	return err

--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -155,10 +155,17 @@ func holdAssessmentLine(a *inbound.Assessment) string {
 // content they had never actually seen. On an injection-assessed hold the body IS
 // the decision, so an unreadable card is not a cosmetic problem.
 //
-// Why THIS extractor. mailtext is the same one the assessor consumes, so the
-// operator reads the text the detector actually scored — rather than a separately
-// derived rendering that could quietly disagree with the verdict being judged. It
-// also flattens text/html, so an HTML-only message stays readable here.
+// Why THIS extractor. mailtext is what the assessor consumes, so the operator reads
+// the text the detector actually scored rather than a separately derived rendering
+// that could quietly disagree with the verdict being judged. It also flattens
+// text/html, so an HTML-only message stays readable here.
+//
+// That correspondence currently holds because both call sites use the package
+// defaults, NOT because anything ties them together: the screening path takes its
+// limits through an option that merely defaults to them. Today the option is
+// test-only, so there is no live divergence, but if a caller ever overrides the
+// screening limits this stops being the same view and the claim above weakens to
+// "the same extractor, possibly different bounds".
 //
 // The no-text case is always stated, never silent. Falling back to raw source would
 // reinstate the defect, and rendering nothing would read as "the message is empty" —
@@ -178,6 +185,12 @@ func fencedBody(raw []byte, budget int) string {
 		note = "\n\n(!) part of this message could not be decoded, so it was never scored — the assessment above cannot account for it; treat it as incomplete."
 	}
 
+	// This return bypasses the budget, which is safe on stated grounds rather than by
+	// accident: the string is fixed apart from a byte count, so it is bounded at a few
+	// hundred units, and the header it joins is already clamped per field. It is the
+	// same shape as the marker overflow above, so the grounds are written down rather
+	// than left for a later reader to re-derive — if this text ever grows, or the
+	// header stops being clamped, it has to come out of the budget like everything else.
 	if text == "" {
 		reason := "it has no readable text part"
 		if err != nil || c.Undecodable {
@@ -188,16 +201,31 @@ func fencedBody(raw []byte, budget int) string {
 			"Do not read the absence of text here as the message having no content.", reason, len(raw))
 	}
 
+	// Every string appended after this point has to come out of the budget, not out of
+	// the framing allowance. fenceOverhead covers the fence's own markers and the
+	// joining newlines with only a few units to spare, so an appended marker that is
+	// not subtracted here pushes the whole card past the Telegram ceiling. That is not
+	// a cosmetic overflow: the send is rejected, the hold is never marked posted, and
+	// every later poll rebuilds the identical oversized card — so the message stays
+	// held but the operator is never told it exists, on the surface whose entire
+	// purpose is telling them. Reserve the width up front instead of widening the
+	// allowance, which would only leave the next marker to rediscover this.
+	const extractionCapped = "\n[extraction limit reached — the message carries more text than was scored]"
 	budget -= utf16Len(note)
+	if c.Truncated {
+		budget -= utf16Len(extractionCapped)
+	}
 	if budget <= 0 {
 		return strings.TrimPrefix(note, "\n\n")
 	}
 	if utf16Len(text) > budget {
 		text = truncateUTF16(text, budget) + "\n[truncated]"
-	} else if c.Truncated {
-		// Not budget truncation — extraction itself hit its caps, so the message carries
-		// more text than was ever extracted. Say which kind of "there is more" this is.
-		text += "\n[extraction limit reached — the message carries more text than was scored]"
+	}
+	if c.Truncated {
+		// Not budget truncation — extraction itself hit its caps (size, part count or
+		// depth), so the message carries more text than was ever extracted, and more than
+		// was ever scored. Distinct from "[truncated]", which means it did not fit here.
+		text += extractionCapped
 	}
 	return assessor.Fence("email body", text) + note
 }

--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/yaad-index/darbaan/internal/assessor"
 	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/mailtext"
 )
 
 // pollHolds lists the inbound hold-for-human queue (ADR 0021) and posts each new
@@ -145,17 +146,60 @@ func holdAssessmentLine(a *inbound.Assessment) string {
 	return line
 }
 
-// fencedBody truncates the raw body to the UTF-16 budget (marking the cut) and
-// wraps it in an untrusted fence. A non-positive budget yields no body.
+// fencedBody renders the stored message for the operator card: the DECODED text of
+// the message, never the raw message source.
+//
+// Why extraction at all. Fencing string(raw) spent the entire budget on transport
+// headers — Received, ARC-Seal, DKIM-Signature — and truncated before a single
+// human-readable line, so the operator was asked to Expose or Drop a message whose
+// content they had never actually seen. On an injection-assessed hold the body IS
+// the decision, so an unreadable card is not a cosmetic problem.
+//
+// Why THIS extractor. mailtext is the same one the assessor consumes, so the
+// operator reads the text the detector actually scored — rather than a separately
+// derived rendering that could quietly disagree with the verdict being judged. It
+// also flattens text/html, so an HTML-only message stays readable here.
+//
+// The no-text case is always stated, never silent. Falling back to raw source would
+// reinstate the defect, and rendering nothing would read as "the message is empty" —
+// the exact misrepresentation this surface exists to prevent.
 func fencedBody(raw []byte, budget int) string {
-	if budget <= 0 {
+	if budget <= 0 || len(raw) == 0 {
 		return ""
 	}
-	text := string(raw)
+	c, err := mailtext.Extract(raw, mailtext.DefaultLimits())
+	text := strings.TrimRight(c.Body, " \t\r\n")
+
+	// Undecodable means text the message carries never reached the assessor, so the
+	// verdict cannot vouch for it. That bears directly on the decision being made and
+	// is surfaced even when readable text was recovered alongside it.
+	var note string
+	if err != nil || c.Undecodable {
+		note = "\n\n(!) part of this message could not be decoded, so it was never scored — the assessment above cannot account for it; treat it as incomplete."
+	}
+
+	if text == "" {
+		reason := "it has no readable text part"
+		if err != nil || c.Undecodable {
+			reason = "its content could not be decoded"
+		}
+		return fmt.Sprintf("(!) no message text is shown because %s — this is NOT an empty message. "+
+			"The raw source is %d bytes; dump it with `darbaan holds show <id>` (add --text for the decoded body). "+
+			"Do not read the absence of text here as the message having no content.", reason, len(raw))
+	}
+
+	budget -= utf16Len(note)
+	if budget <= 0 {
+		return strings.TrimPrefix(note, "\n\n")
+	}
 	if utf16Len(text) > budget {
 		text = truncateUTF16(text, budget) + "\n[truncated]"
+	} else if c.Truncated {
+		// Not budget truncation — extraction itself hit its caps, so the message carries
+		// more text than was ever extracted. Say which kind of "there is more" this is.
+		text += "\n[extraction limit reached — the message carries more text than was scored]"
 	}
-	return assessor.Fence("email body", text)
+	return assessor.Fence("email body", text) + note
 }
 
 func holdKeyboard(id string) models.InlineKeyboardMarkup {

--- a/internal/telegram/holds_internal_test.go
+++ b/internal/telegram/holds_internal_test.go
@@ -54,10 +54,9 @@ func TestFormatHoldNotCleared(t *testing.T) {
 // The fenced body is truncated to keep the whole notification under Telegram's
 // limit, with a clear marker.
 func TestFormatHoldTruncatesBody(t *testing.T) {
-	big := make([]byte, telegramTextLimit*2)
-	for i := range big {
-		big[i] = 'x'
-	}
+	// A REAL message: the card now renders the decoded text body, so a bare byte
+	// blob would exercise the undecodable path instead of truncation.
+	big := []byte("Content-Type: text/plain; charset=utf-8\r\n\r\n" + strings.Repeat("x", telegramTextLimit*2))
 	s := formatHold(inbound.Message{ID: "11"}, big, false)
 	assert.LessOrEqual(t, len([]rune(s)), telegramTextLimit, "stays under the Telegram limit")
 	assert.Contains(t, s, "[truncated]")
@@ -107,7 +106,8 @@ func TestPostedHoldsDedup(t *testing.T) {
 // emoji-heavy body — astral-plane chars are two units each — cannot push the hold
 // past the limit and fail every send.
 func TestFormatHoldUTF16Budget(t *testing.T) {
-	body := []byte(strings.Repeat("\U0001F600", 4000)) // 4000 runes, 8000 UTF-16 units
+	body := []byte("Content-Type: text/plain; charset=utf-8\r\n\r\n" +
+		strings.Repeat("\U0001F600", 4000)) // 4000 runes, 8000 UTF-16 units
 	s := formatHold(inbound.Message{ID: "13"}, body, false)
 	assert.LessOrEqual(t, utf16Len(s), telegramTextLimit, "stays under the Telegram UTF-16 cap")
 	assert.Contains(t, s, "[truncated]")
@@ -130,4 +130,66 @@ func TestFormatHoldFetchFailed(t *testing.T) {
 	// Distinct from a hold with no stored body (fetch succeeded, empty) — no warning.
 	ok := formatHold(m, nil, false)
 	assert.NotContains(t, ok, "could NOT be fetched")
+}
+
+// #261: the card must render the DECODED body, never the raw message source. The
+// regression this guards is not "ugly output" — a real message's transport headers
+// are large enough to consume the whole budget, so the operator was asked to decide
+// on a message whose content never appeared before the truncation point.
+func TestFormatHoldRendersDecodedBodyNotRawSource(t *testing.T) {
+	raw := []byte("Delivered-To: agent@x.test\r\n" +
+		"Received: by 2002:a17:504:8116 with SMTP id w22csp3306612njg;\r\n" +
+		"        Mon, 10 Aug 2026 18:37:18 -0700 (PDT)\r\n" +
+		"ARC-Seal: i=1; a=rsa-sha256; t=1786412238; cv=none; b=" + strings.Repeat("Zq", 400) + "\r\n" +
+		"DKIM-Signature: v=1; a=rsa-sha256; b=" + strings.Repeat("Yp", 400) + "\r\n" +
+		"Subject: a real subject\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n\r\n" +
+		"THE ACTUAL MESSAGE TEXT the operator needs to read.\r\n")
+
+	s := formatHold(inbound.Message{ID: "261", From: "a@x.test"}, raw, false)
+
+	assert.Contains(t, s, "THE ACTUAL MESSAGE TEXT", "the readable body reaches the operator")
+	assert.NotContains(t, s, "ARC-Seal", "transport headers are not shown as the body")
+	assert.NotContains(t, s, "DKIM-Signature", "signature blocks are not shown as the body")
+	assert.NotContains(t, s, "Delivered-To", "envelope headers are not shown as the body")
+	assert.Contains(t, s, "BEGIN UNTRUSTED", "message text stays fenced as inert data")
+}
+
+// An HTML-only message stays readable: mailtext flattens text/html, which the
+// previous text/plain-only extractor would have rendered as no text at all.
+func TestFormatHoldRendersHTMLOnlyBody(t *testing.T) {
+	raw := []byte("Content-Type: text/html; charset=utf-8\r\n\r\n" +
+		"<html><body><p>readable html content</p></body></html>")
+	s := formatHold(inbound.Message{ID: "262"}, raw, false)
+	assert.Contains(t, s, "readable html content")
+	assert.NotContains(t, s, "no message text is shown")
+	// Flattened, not dumped: the markup itself must not reach the card, or this
+	// passes just as well on the raw source it is meant to exclude.
+	assert.NotContains(t, s, "<p>", "html is flattened to text, not shown as markup")
+	assert.NotContains(t, s, "<body>", "html is flattened to text, not shown as markup")
+}
+
+// A message with no readable text must SAY so. Two failures are being excluded at
+// once: silently falling back to the raw source (the original defect) and rendering
+// nothing (which reads as "the message is empty" — the misrepresentation this
+// surface exists to prevent).
+func TestFormatHoldNoTextPartIsStatedNotSilent(t *testing.T) {
+	raw := []byte("Content-Type: image/png\r\nContent-Disposition: attachment; filename=x.png\r\n\r\n\x89PNG\r\n\x1a\n binary")
+	s := formatHold(inbound.Message{ID: "263"}, raw, false)
+
+	assert.Contains(t, s, "NOT an empty message", "absence of text is never presented as an empty message")
+	assert.Contains(t, s, "holds show", "the operator is pointed at the raw dump instead of a dead end")
+	assert.NotContains(t, s, "Content-Disposition", "still no raw source fallback")
+}
+
+// When part of the message could not be decoded, the card says the assessment
+// cannot account for it. The verdict is what the operator is weighing, so a
+// silently partial scoring would let them trust it further than it earned.
+func TestFormatHoldFlagsUndecodableContent(t *testing.T) {
+	raw := []byte("Content-Type: multipart/mixed; boundary=b\r\n\r\n--b\r\n" +
+		"Content-Type: text/plain\r\n\r\nvisible text\r\n--b\r\nthis part never terminates")
+	s := formatHold(inbound.Message{ID: "264"}, raw, false)
+	if strings.Contains(s, "visible text") {
+		assert.Contains(t, s, "never scored", "partial decoding is disclosed alongside whatever text was recovered")
+	}
 }

--- a/internal/telegram/holds_internal_test.go
+++ b/internal/telegram/holds_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/yaad-index/darbaan/internal/inbound"
+	"github.com/yaad-index/darbaan/internal/mailtext"
 )
 
 func TestFormatHold(t *testing.T) {
@@ -192,4 +193,52 @@ func TestFormatHoldFlagsUndecodableContent(t *testing.T) {
 	if strings.Contains(s, "visible text") {
 		assert.Contains(t, s, "never scored", "partial decoding is disclosed alongside whatever text was recovered")
 	}
+}
+
+// The extraction-limit marker must fit inside the reserved framing allowance like
+// every other appended string. It is added on the branch where the text already
+// FITS the budget, so nothing else bounds it.
+//
+// The failure it guards is not cosmetic. An oversized card is rejected by the send,
+// notifyHold returns an error, the hold is never marked posted, and the next poll
+// rebuilds the identical oversized card — so the message stays held (safe) but the
+// operator is never told it exists, on the surface whose entire purpose is telling
+// them. Deterministic per message, not a transient.
+//
+// Reachable with an ordinary body: Truncated is set when ANY extraction cap is hit,
+// including part-count and depth, so a many-part message sets it while rendering a
+// body of any size. Only the body's proximity to the budget matters.
+func TestFormatHoldExtractionMarkerStaysWithinLimit(t *testing.T) {
+	// Swept rather than spot-checked: the vulnerable window is where the extracted
+	// text lands just UNDER its budget, so a single size can miss it entirely.
+	for n := 3000; n <= 3600; n += 5 {
+		raw := manyPartMessage(n)
+		s := formatHoldForTest(t, raw)
+		assert.LessOrEqualf(t, utf16Len(s), telegramTextLimit,
+			"textLen=%d: card is %d units over the limit — an oversized card is rejected by the send, "+
+				"so the hold silently never reaches the operator", n, utf16Len(s)-telegramTextLimit)
+	}
+}
+
+// formatHoldForTest renders a hold card for a raw message.
+func formatHoldForTest(t *testing.T, raw []byte) string {
+	t.Helper()
+	return formatHold(inbound.Message{ID: "trunc", From: "a@x.test"}, raw, false)
+}
+
+// manyPartMessage builds a message that trips the extraction PART-COUNT cap while
+// its rendered text stays the given size. Size and cap-hit are independent here,
+// which is the reachability that matters: the marker branch needs a body that fits
+// the budget, and a cap hit is available at any body size.
+func manyPartMessage(textLen int) []byte {
+	var b strings.Builder
+	b.WriteString("Content-Type: multipart/mixed; boundary=bb\r\n\r\n")
+	b.WriteString("--bb\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n")
+	b.WriteString(strings.Repeat("y", textLen))
+	b.WriteString("\r\n")
+	for i := 0; i < mailtext.DefaultLimits().MaxParts+5; i++ {
+		b.WriteString("--bb\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n.\r\n")
+	}
+	b.WriteString("--bb--\r\n")
+	return []byte(b.String())
 }


### PR DESCRIPTION
Closes #261.

## The defect

The hold notification fenced `string(raw)`. A real message's transport headers — `Received`, `ARC-Seal`, `DKIM-Signature` — are large enough to consume the entire per-message budget, so the card truncated before a single readable line. Confirmed in production on v0.17.0, not only by reading the code: an operator reviewing a held message saw about sixty lines of signature blocks and no content.

That is not a cosmetic problem on this surface. A hold placed by injection assessment is precisely the case where the body *is* the decision, so an unreadable card leaves only two options, approve blind or drop blind.

## The fix

The card now renders the decoded text through `mailtext`, **the same extractor the assessor consumes**. That choice is deliberate beyond "it decodes properly": the operator reads the text the detector actually scored, rather than a separately derived rendering that could quietly disagree with the verdict they are judging. It also flattens `text/html`, so an HTML-only message stays readable — the package's other extractor, `bodyText`, returns nothing for those.

**Absence of text is always stated.** Two failures are excluded at once: falling back to raw source would reinstate the defect, and rendering nothing would read as "the message is empty", the misrepresentation this surface exists to prevent. Partial decoding is disclosed alongside whatever text was recovered, because the assessment cannot vouch for content it never saw.

## What deliberately did NOT change

The issue as I filed it claimed `holds show` was defective for the same reason. **That was wrong, and I checked before acting on it.** The outbound sibling `queue show` also writes raw to stdout: a byte-exact dump that redirects to a `.eml` is the point of the command, and replacing it would remove capability.

So the raw dump stays the default and `--text` adds the reading mode. Under `--text`, a body that yields no text is an error rather than a silent exit 0, for the same reason the no-stored-body case already is.

## Verification

Every new test was checked against the old behaviour, not merely observed to pass: reverting the extraction turns all four card tests red, and disabling `--text` turns both CLI tests red. The two pre-existing truncation tests fed non-MIME byte blobs, which exercised the raw path by construction; they now feed real messages, since the contract changed from "fence the source" to "fence the decoded text".

`gofmt`, `go vet` and the full suite under `-race` are green.

## Known limitation, stated rather than hidden

`mailtext` applies extraction caps. When they are hit the card says so explicitly and distinguishes that from budget truncation, because "there is more text than was scored" and "there is more text than fits in this message" mean different things to someone deciding.
