### PR TITLE
fix: validate serve config, escape admin client paths, surface dropped audit errors (#238)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -541,17 +541,28 @@ func parseMaxAge(s string) (time.Duration, error) {
 		'w': 7 * 24 * time.Hour,
 		'y': 365 * 24 * time.Hour,
 	}
+	var d time.Duration
 	if mult, ok := units[s[len(s)-1]]; ok {
 		val, err := strconv.ParseFloat(s[:len(s)-1], 64)
 		if err != nil {
 			return 0, fmt.Errorf("invalid duration %q: %w", s, err)
 		}
-		if val < 0 {
-			return 0, fmt.Errorf("invalid duration %q: must not be negative", s)
+		d = time.Duration(val * float64(mult))
+	} else {
+		parsed, err := time.ParseDuration(s)
+		if err != nil {
+			return 0, err
 		}
-		return time.Duration(val * float64(mult)), nil
+		d = parsed
 	}
-	return time.ParseDuration(s)
+	// One negativity gate over BOTH parse paths. A negative cutoff is meaningless (it
+	// selects mail "newer than a moment in the future"). The gate spans both paths
+	// deliberately: time.ParseDuration accepts "-24h" without error, so guarding only
+	// the suffix path would leave the standard-unit path open.
+	if d < 0 {
+		return 0, fmt.Errorf("invalid duration %q: must not be negative", s)
+	}
+	return d, nil
 }
 
 // buildAssessHook constructs the injection-assessment pipeline (scorer, heuristic
@@ -672,12 +683,46 @@ func imapKeywordWriter(syncers map[string]*imapsync.Syncer) listener.KeywordWrit
 	}
 }
 
+// defaultInboundPollInterval mirrors the inbound-imap-poll-interval flag default;
+// resolvePollInterval falls back to it when a non-positive interval is configured.
+const defaultInboundPollInterval = 60 * time.Second
+
+// resolvePollInterval clamps a non-positive configured poll interval to the default
+// so time.NewTicker — which panics on a duration <= 0 — cannot crash serve on a
+// mis-set flag. ok is false when a clamp was applied, so the caller can warn. This
+// mirrors the telegram poll loop's floor (telegram.New).
+func resolvePollInterval(d time.Duration) (interval time.Duration, ok bool) {
+	if d <= 0 {
+		return defaultInboundPollInterval, false
+	}
+	return d, true
+}
+
+// adminAddrIsExposed reports whether addr binds the admin API to a routable
+// address — not loopback, and not the unspecified address (0.0.0.0/::), which is
+// the documented container pattern where the host narrows exposure. Used only to
+// warn at startup; a parse failure or a hostname (no literal IP) returns false, so
+// it never raises a false alarm.
+func adminAddrIsExposed(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && !ip.IsLoopback() && !ip.IsUnspecified()
+}
+
 // runSyncLoop polls one inbox's upstream on the configured interval until ctx is
 // cancelled. Sync errors are logged, never fatal — a flaky or unreachable
 // upstream must not take down serve.
 func (cli *CLI) runSyncLoop(ctx context.Context, inbox string, syncer *imapsync.Syncer, health *syncHealth) {
-	slog.Info("inbound sync loop started", "inbox", inbox, "interval", cli.InboundIMAPPollInterval.String())
-	t := time.NewTicker(cli.InboundIMAPPollInterval)
+	interval, ok := resolvePollInterval(cli.InboundIMAPPollInterval)
+	if !ok {
+		slog.Warn("inbound-imap-poll-interval must be positive; using default",
+			"configured", cli.InboundIMAPPollInterval.String(), "using", interval.String())
+	}
+	slog.Info("inbound sync loop started", "inbox", inbox, "interval", interval.String())
+	t := time.NewTicker(interval)
 	defer t.Stop()
 	runSync(ctx, inbox, syncer, health) // initial pull at startup
 	for {
@@ -1164,6 +1209,10 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// Inbound hold verdicts (expose/drop) audit to the same shared log the message
 	// store writes outbound verdicts to (ADR 0011, C29).
 	svc.SetAuditLog(al)
+	if adminAddrIsExposed(cli.AdminAddr) {
+		slog.Warn("admin-addr is bound to a non-loopback address; the admin API is token-gated but is intended to be reachable only from loopback or the container-internal network (ADR 0029)",
+			"admin_addr", cli.AdminAddr)
+	}
 	adminSrv, err := admin.NewServer(cli.AdminAddr, os.Getenv("DARBAAN_ADMIN_TOKEN"), svc)
 	if err != nil {
 		return err

--- a/cmd/darbaan/maxage_test.go
+++ b/cmd/darbaan/maxage_test.go
@@ -28,7 +28,11 @@ func TestParseMaxAge(t *testing.T) {
 		assert.Equal(t, c.want, got, c.in)
 	}
 
-	for _, bad := range []string{"abc", "1x", "yy", "-1y"} {
+	// Negatives must be rejected on BOTH parse paths. "-1y"/"-2d" exercise the d/w/y
+	// suffix path; "-24h"/"-1h30m"/"-30m"/"-500ms" exercise the time.ParseDuration
+	// path, which accepts negative durations without error — the gap a single
+	// post-parse sign gate closes (a negative cutoff selects "newer than the future").
+	for _, bad := range []string{"abc", "1x", "yy", "-1y", "-2d", "-24h", "-1h30m", "-30m", "-500ms"} {
 		_, err := parseMaxAge(bad)
 		assert.Error(t, err, bad)
 	}

--- a/cmd/darbaan/serve_helpers_test.go
+++ b/cmd/darbaan/serve_helpers_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// A non-positive poll interval is clamped to the default so time.NewTicker — which
+// panics on a duration <= 0 — cannot crash serve; a positive one passes through,
+// and ok reports whether a clamp was applied. The resolved value is always positive.
+func TestResolvePollInterval(t *testing.T) {
+	cases := []struct {
+		in     time.Duration
+		want   time.Duration
+		wantOK bool
+	}{
+		{0, defaultInboundPollInterval, false},
+		{-5 * time.Second, defaultInboundPollInterval, false},
+		{-1 * time.Nanosecond, defaultInboundPollInterval, false},
+		{30 * time.Second, 30 * time.Second, true},
+		{defaultInboundPollInterval, defaultInboundPollInterval, true},
+		{1 * time.Nanosecond, 1 * time.Nanosecond, true},
+	}
+	for _, c := range cases {
+		got, ok := resolvePollInterval(c.in)
+		assert.Equalf(t, c.want, got, "interval for %v", c.in)
+		assert.Equalf(t, c.wantOK, ok, "ok for %v", c.in)
+		assert.Truef(t, got > 0, "resolved interval must be positive (time.NewTicker) for %v", c.in)
+	}
+}
+
+// adminAddrIsExposed warns only for a routable literal IP — not loopback, and not
+// the unspecified address (0.0.0.0/::, the documented container pattern where the
+// host narrows exposure). A hostname or unparseable addr never raises a false alarm.
+func TestAdminAddrIsExposed(t *testing.T) {
+	exposed := []string{"192.168.1.5:1144", "10.0.0.2:1144", "[2001:db8::1]:1144"}
+	for _, a := range exposed {
+		assert.Truef(t, adminAddrIsExposed(a), "%s is routable and should warn", a)
+	}
+	safe := []string{
+		"127.0.0.1:1144",      // loopback v4
+		"[::1]:1144",          // loopback v6
+		"0.0.0.0:1144",        // unspecified — container pattern, host narrows exposure
+		"[::]:1144",           // unspecified v6
+		"localhost:1144",      // hostname, not a literal IP
+		"admin.internal:1144", // hostname
+		"garbage",             // no host:port
+		"",
+	}
+	for _, a := range safe {
+		assert.Falsef(t, adminAddrIsExposed(a), "%q must not warn", a)
+	}
+}
+
+// The clamp fallback must equal the flag's own default, or a mis-set interval would
+// fall back to a value the operator never documented. The flag tag is a string
+// literal that cannot reference the const, so this guards the two against drifting.
+func TestDefaultInboundPollIntervalMatchesFlag(t *testing.T) {
+	cli := parseCLI(t, []string{"version"})
+	assert.Equal(t, defaultInboundPollInterval, cli.InboundIMAPPollInterval,
+		"defaultInboundPollInterval must match the inbound-imap-poll-interval flag default")
+}

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
@@ -72,8 +73,15 @@ func (c *Client) List(ctx context.Context) ([]sluice.Meta, error) {
 }
 
 // Show returns the raw RFC 822 of a held message.
+//
+// Message ids and inbox names are caller-supplied and can carry "/", "?", "#", or
+// spaces; every one interpolated into a request path is url.PathEscape'd (here and
+// in every sibling below) so it stays a single, correctly-delimited path segment
+// rather than altering the route or spilling into a query/fragment. The server
+// matches on wildcard path segments and reads them decoded (r.PathValue), so the
+// escape round-trips.
 func (c *Client) Show(ctx context.Context, id string) ([]byte, error) {
-	resp, err := c.request(ctx, http.MethodGet, "/queue/"+id, nil)
+	resp, err := c.request(ctx, http.MethodGet, "/queue/"+url.PathEscape(id), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -92,19 +100,19 @@ func (c *Client) Show(ctx context.Context, id string) ([]byte, error) {
 
 // Approve approves a held message.
 func (c *Client) Approve(ctx context.Context, id string) (Outcome, error) {
-	return c.action(ctx, "/queue/"+id+"/approve", nil)
+	return c.action(ctx, "/queue/"+url.PathEscape(id)+"/approve", nil)
 }
 
 // ApproveAs approves a held message and sends it from the given inbox's identity
 // (ADR 0023 slice 5).
 func (c *Client) ApproveAs(ctx context.Context, id, inbox string) (Outcome, error) {
-	return c.action(ctx, "/queue/"+id+"/approve-as/"+inbox, nil)
+	return c.action(ctx, "/queue/"+url.PathEscape(id)+"/approve-as/"+url.PathEscape(inbox), nil)
 }
 
 // ReSend retries the upstream delivery of an approved message whose previous send
 // failed (C4). Only valid for a message stranded in `approved` with a send error.
 func (c *Client) ReSend(ctx context.Context, id string) (Outcome, error) {
-	return c.action(ctx, "/queue/"+id+"/resend", nil)
+	return c.action(ctx, "/queue/"+url.PathEscape(id)+"/resend", nil)
 }
 
 // Inboxes lists the configured inbox identities for the Change-sender picker
@@ -128,7 +136,7 @@ func (c *Client) Inboxes(ctx context.Context) ([]InboxIdentity, error) {
 // Reject rejects a held message with a reason.
 func (c *Client) Reject(ctx context.Context, id, reason string, retryable bool) (Outcome, error) {
 	body, _ := json.Marshal(map[string]any{"reason": reason, "retryable": retryable})
-	return c.action(ctx, "/queue/"+id+"/reject", bytes.NewReader(body))
+	return c.action(ctx, "/queue/"+url.PathEscape(id)+"/reject", bytes.NewReader(body))
 }
 
 // HeldList returns the inbound messages held for a human decision (ADR 0021).
@@ -155,7 +163,7 @@ func (c *Client) HeldList(ctx context.Context) ([]inbound.Message, error) {
 // whose body has not been fetched yet returns empty bytes and no error; a transport
 // or read fault returns a classified error (never a silent empty body).
 func (c *Client) HeldContent(ctx context.Context, id string) ([]byte, error) {
-	resp, err := c.request(ctx, http.MethodGet, "/holds/"+id+"/content", nil)
+	resp, err := c.request(ctx, http.MethodGet, "/holds/"+url.PathEscape(id)+"/content", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -192,12 +200,12 @@ func (c *Client) HeldContent(ctx context.Context, id string) ([]byte, error) {
 
 // Expose approves a held message for the agent to see (ADR 0021).
 func (c *Client) Expose(ctx context.Context, id string) (inbound.Message, error) {
-	return c.hold(ctx, "/holds/"+id+"/expose")
+	return c.hold(ctx, "/holds/"+url.PathEscape(id)+"/expose")
 }
 
 // Drop rejects a held message — it stays hidden from the agent (ADR 0021).
 func (c *Client) Drop(ctx context.Context, id string) (inbound.Message, error) {
-	return c.hold(ctx, "/holds/"+id+"/drop")
+	return c.hold(ctx, "/holds/"+url.PathEscape(id)+"/drop")
 }
 
 func (c *Client) hold(ctx context.Context, path string) (inbound.Message, error) {
@@ -269,7 +277,7 @@ func (c *Client) SyncStatus(ctx context.Context) ([]SyncStatus, error) {
 // ReleaseReconcile releases a latched inbox — confirm the large retraction and
 // resume reconciliation (ADR 0026).
 func (c *Client) ReleaseReconcile(ctx context.Context, inbox string) (ReconcileReleaseResult, error) {
-	resp, err := c.request(ctx, http.MethodPost, "/reconcile/"+inbox+"/release", nil)
+	resp, err := c.request(ctx, http.MethodPost, "/reconcile/"+url.PathEscape(inbox)+"/release", nil)
 	if err != nil {
 		return ReconcileReleaseResult{}, err
 	}

--- a/internal/admin/client_test.go
+++ b/internal/admin/client_test.go
@@ -1,0 +1,88 @@
+package admin_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// Message ids and inbox names are caller-supplied and can carry URL-significant
+// characters. The client url.PathEscape's every id/inbox segment so it stays a
+// single path segment rather than altering the route or spilling into a query or
+// fragment. This exercises the whole family of endpoints (both prefixes, both the
+// id and inbox parameters) — not one — because the escape must be applied to every
+// sibling, not most of them: an id like "msg 42?a=b&c=d#frag" round-trips to the
+// server's decoded PathValue only if it was escaped on the way out.
+func TestClientEscapesPathSegments(t *testing.T) {
+	const weirdID = "msg 42?a=b&c=d#frag"
+	const weirdInbox = "team inbox+x?y"
+
+	var gotID, gotInbox string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /queue/{id}", func(w http.ResponseWriter, r *http.Request) {
+		gotID = r.PathValue("id")
+		_, _ = w.Write([]byte("raw"))
+	})
+	mux.HandleFunc("GET /holds/{id}/content", func(w http.ResponseWriter, r *http.Request) {
+		gotID = r.PathValue("id")
+		_, _ = w.Write([]byte("body"))
+	})
+	mux.HandleFunc("POST /holds/{id}/expose", func(w http.ResponseWriter, r *http.Request) {
+		gotID = r.PathValue("id")
+		_ = json.NewEncoder(w).Encode(inbound.Message{})
+	})
+	mux.HandleFunc("POST /queue/{id}/approve-as/{inbox}", func(w http.ResponseWriter, r *http.Request) {
+		gotID, gotInbox = r.PathValue("id"), r.PathValue("inbox")
+		_ = json.NewEncoder(w).Encode(admin.Outcome{})
+	})
+	mux.HandleFunc("POST /reconcile/{inbox}/release", func(w http.ResponseWriter, r *http.Request) {
+		gotInbox = r.PathValue("inbox")
+		_ = json.NewEncoder(w).Encode(admin.ReconcileReleaseResult{})
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+	c := admin.NewClient(strings.TrimPrefix(ts.URL, "http://"), "tok")
+	ctx := context.Background()
+
+	t.Run("Show id segment", func(t *testing.T) {
+		gotID = ""
+		_, err := c.Show(ctx, weirdID)
+		require.NoError(t, err)
+		assert.Equal(t, weirdID, gotID)
+	})
+	t.Run("HeldContent id segment", func(t *testing.T) {
+		gotID = ""
+		_, err := c.HeldContent(ctx, weirdID)
+		require.NoError(t, err)
+		assert.Equal(t, weirdID, gotID)
+	})
+	t.Run("Expose id segment", func(t *testing.T) {
+		gotID = ""
+		_, err := c.Expose(ctx, weirdID)
+		require.NoError(t, err)
+		assert.Equal(t, weirdID, gotID)
+	})
+	t.Run("ApproveAs id and inbox segments", func(t *testing.T) {
+		gotID, gotInbox = "", ""
+		_, err := c.ApproveAs(ctx, weirdID, weirdInbox)
+		require.NoError(t, err)
+		assert.Equal(t, weirdID, gotID)
+		assert.Equal(t, weirdInbox, gotInbox)
+	})
+	t.Run("ReleaseReconcile inbox segment", func(t *testing.T) {
+		gotInbox = ""
+		_, err := c.ReleaseReconcile(ctx, weirdInbox)
+		require.NoError(t, err)
+		assert.Equal(t, weirdInbox, gotInbox)
+	})
+}

--- a/internal/imapsync/audit_log_test.go
+++ b/internal/imapsync/audit_log_test.go
@@ -1,0 +1,97 @@
+package imapsync_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/audit"
+	"github.com/yaad-index/darbaan/internal/imapsync"
+	"github.com/yaad-index/darbaan/internal/inbound"
+)
+
+// failingAudit fails every append, to prove a broken audit sink is surfaced
+// (logged) rather than silently swallowed, while the retraction itself still
+// commits — the audit is best-effort, but never silent.
+type failingAudit struct{}
+
+func (failingAudit) Append(audit.Record) error { return errors.New("audit sink down") }
+func (failingAudit) Verify() error             { return nil }
+func (failingAudit) Close() error              { return nil }
+
+// logHasMsg reports whether any JSON log line in buf carries the given msg.
+func logHasMsg(buf *bytes.Buffer, msg string) bool {
+	for _, ln := range bytes.Split(bytes.TrimSpace(buf.Bytes()), []byte("\n")) {
+		var m map[string]any
+		if json.Unmarshal(ln, &m) == nil && m["msg"] == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// Reconcile site: a failed retract-audit append is logged, and the retraction is
+// still committed. Before the fix the error was discarded (_ = Append(...)), so a
+// broken audit sink left a retraction with no trail and no signal.
+func TestReconcileRetractAuditFailureIsLogged(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: one\r\n\r\n1")
+	appendMsg(t, user, "From: b@x.test\r\nSubject: two\r\n\r\n2")
+	appendMsg(t, user, "From: c@x.test\r\nSubject: three\r\n\r\n3")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+
+	expungeUID(t, addr, 2) // UID 2 leaves the source
+
+	var buf bytes.Buffer
+	syncer.SetLogger(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	removed, err := syncer.Reconcile(context.Background(), imapsync.ReconcileOptions{Audit: failingAudit{}})
+	require.NoError(t, err, "a failed audit append must not fail the retraction")
+	assert.Equal(t, 1, removed, "the gone message is still retracted despite the audit failure")
+	assert.True(t, logHasMsg(&buf, "could not audit retraction"),
+		"a failed retract-audit append is logged, not silently discarded")
+}
+
+// On-demand site: FetchContent finding the upstream UID gone drops the stale
+// mapping and audits it; a failed audit append is logged, and the drop still
+// commits. The mirror of the reconcile case for the fetch-time retraction path.
+func TestFetchContentVanishedMappingAuditFailureIsLogged(t *testing.T) {
+	addr, user := startUpstream(t)
+	appendMsg(t, user, "From: a@x.test\r\nSubject: real\r\n\r\nbody")
+
+	store := newInbound(t)
+	syncer := imapsync.New(dialFor(addr), "INBOX", "agent", inbound.DefaultInbox, store, newState(t), 0)
+	syncer.SetAudit(failingAudit{})
+
+	_, err := syncer.Sync(context.Background())
+	require.NoError(t, err)
+	msgs, err := store.List("agent", inbound.DefaultInbox)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	id, upUID := msgs[0].ID, msgs[0].UpstreamUID
+
+	expungeUID(t, addr, upUID) // the message vanishes upstream; the local mapping stays
+
+	var buf bytes.Buffer
+	syncer.SetLogger(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+
+	_, ferr := syncer.FetchContent("agent", inbound.DefaultInbox, id)
+	assert.ErrorIs(t, ferr, inbound.ErrContentUnavailable)
+
+	// The stale mapping is still dropped despite the audit failure...
+	_, gerr := store.Get("agent", inbound.DefaultInbox, id)
+	assert.ErrorIs(t, gerr, inbound.ErrNotFound, "the retraction still commits")
+	// ...and the audit failure is surfaced, not swallowed.
+	assert.True(t, logHasMsg(&buf, "could not audit stale-mapping retraction"),
+		"a failed on-demand retract-audit append is logged")
+}

--- a/internal/imapsync/imapsync.go
+++ b/internal/imapsync/imapsync.go
@@ -453,14 +453,18 @@ func (s *Syncer) FetchContent(owner, inbox, id string) (inbound.Message, error) 
 			s.logger.Error("could not drop stale mapping", "id", id, "upstream_uid", m.UpstreamUID, "err", derr)
 		} else if s.audit != nil {
 			// Best-effort audit, consistent with the reconcile retraction record; a
-			// failed append must not fail the already-committed drop (ADR 0011).
-			_ = s.audit.Append(audit.Record{
+			// failed append must not fail the already-committed drop (ADR 0011). Log
+			// the failure rather than discarding it — a silently broken audit sink
+			// would otherwise leave a retraction with no trail and no signal.
+			if aerr := s.audit.Append(audit.Record{
 				Event:     "retract",
 				Agent:     owner,
 				Inbox:     inbound.NormInbox(inbox),
 				MessageID: id,
 				Detail:    fmt.Sprintf("inbox=%s upstream_uid=%d content fetch found upstream uid gone", inbound.NormInbox(inbox), m.UpstreamUID),
-			})
+			}); aerr != nil {
+				s.logger.Warn("could not audit stale-mapping retraction", "id", id, "upstream_uid", m.UpstreamUID, "err", aerr)
+			}
 		}
 		return inbound.Message{}, fmt.Errorf("imapsync: content for %s unavailable: upstream uid %d not found: %w", id, m.UpstreamUID, inbound.ErrContentUnavailable)
 	}

--- a/internal/imapsync/reconcile.go
+++ b/internal/imapsync/reconcile.go
@@ -280,14 +280,18 @@ func (s *Syncer) Reconcile(ctx context.Context, opts ReconcileOptions) (int, err
 		removed++
 		if opts.Audit != nil {
 			// Best-effort audit (the message store is the source of truth; a failed
-			// append must not fail an already-committed retraction — ADR 0011).
-			_ = opts.Audit.Append(audit.Record{
+			// append must not fail an already-committed retraction — ADR 0011). Log
+			// the failure rather than discarding it — a silently broken audit sink
+			// would otherwise leave a retraction with no trail and no signal.
+			if aerr := opts.Audit.Append(audit.Record{
 				Event:     "retract",
 				Agent:     s.owner,
 				Inbox:     inbound.NormInbox(s.inbox),
 				MessageID: m.ID,
 				Detail:    fmt.Sprintf("inbox=%s upstream_uid=%d left source", inbound.NormInbox(s.inbox), m.UpstreamUID),
-			})
+			}); aerr != nil {
+				s.logger.Warn("could not audit retraction", "id", m.ID, "upstream_uid", m.UpstreamUID, "err", aerr)
+			}
 		}
 	}
 	if len(errs) > 0 {


### PR DESCRIPTION
PR-2 of the #238 review series — a batch of low-severity correctness fixes. **Does not close #238** (later slices remain: flag fix-vs-document fork, dead-code, docs-drift, missing-tests).

## Changes

**C33 — `parseMaxAge` rejects a negative cutoff on both parse paths.** The d/w/y suffix path already guarded `val < 0`, but the fall-through `time.ParseDuration` path accepts `"-24h"` (and `"-1h30m"`, `"-30m"`, …) without error, so a negative recency cutoff slipped through silently. Refactored to a single post-parse sign gate both paths funnel through, rather than a second parallel guard — the asymmetry was the defect, so the fix removes it rather than duplicating it. A negative cutoff is meaningless (it selects mail "newer than a moment in the future").

**C34 — clamp a non-positive `inbound-imap-poll-interval` before `time.NewTicker`.** `time.NewTicker` panics on a duration `<= 0`, so `--inbound-imap-poll-interval=0` (or negative) would crash `serve`. `runSyncLoop` now clamps to the flag default and warns, mirroring the telegram poll loop's floor. Extracted as a pure `resolvePollInterval` helper for testability.

**C40 — `url.PathEscape` every caller-supplied path segment in the admin client.** Message ids and inbox names can carry `/`, `?`, `#`, or spaces; unescaped they alter the route or spill into a query/fragment. All nine id/inbox interpolations (Show, Approve, ApproveAs, ReSend, Reject, HeldContent, Expose, Drop, ReleaseReconcile) are now escaped. The server matches wildcard segments and reads them decoded (`r.PathValue`), so the escape round-trips.

**admin-addr warn.** `serve` warns when `admin-addr` binds a routable address — not loopback, and not the unspecified address (`0.0.0.0`/`::`). The admin API is token-gated but intended for loopback / container-internal use (ADR 0029). The unspecified address is deliberately exempt: it is the documented container pattern where the host narrows exposure (bind `0.0.0.0` inside, publish `127.0.0.1:PORT` outside), so warning on it would cry wolf on every correct container deploy.

**audit-log.** Both retraction audit sites (reconcile pass + on-demand `FetchContent` stale-mapping drop) now log a failed best-effort audit append instead of discarding it (`_ = Append(...)`), so a silently broken audit sink leaves a signal. The retraction still commits regardless (ADR 0011).

## Tests (failing-before / passing-after)

- `TestParseMaxAge`: negative cases on both parse paths (`-2d` suffix, `-24h`/`-1h30m`/`-30m`/`-500ms` standard-unit).
- `TestResolvePollInterval` + `TestDefaultInboundPollIntervalMatchesFlag`: clamp behavior + a guard that the fallback const matches the flag's `default:` tag (they can drift — the tag is a string literal that cannot reference the const).
- `TestAdminAddrIsExposed`: routable vs loopback/unspecified/hostname/garbage classification.
- `TestClientEscapesPathSegments`: an id/inbox carrying URL-significant characters round-trips to the correct decoded `PathValue` across the endpoint family (both prefixes, both parameters) — guards the escape being applied to every sibling, not most.
- `TestReconcileRetractAuditFailureIsLogged` + `TestFetchContentVanishedMappingAuditFailureIsLogged`: a failing audit sink is logged at both sites, and the retraction still commits.

Local: gofmt clean, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).