### PR TITLE
fix: widen admin-addr exposure warning to all-interface binds; demonstrate slash escaping (#271)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -19,6 +19,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"os"
 	"os/signal"
 	"strconv"
@@ -698,18 +699,43 @@ func resolvePollInterval(d time.Duration) (interval time.Duration, ok bool) {
 	return d, true
 }
 
-// adminAddrIsExposed reports whether addr binds the admin API to a routable
-// address — not loopback, and not the unspecified address (0.0.0.0/::), which is
-// the documented container pattern where the host narrows exposure. Used only to
-// warn at startup; a parse failure or a hostname (no literal IP) returns false, so
-// it never raises a false alarm.
+// adminAddrIsExposed reports whether addr binds the admin API beyond loopback, for
+// a startup advisory. Outcomes, kept distinct so the signal tracks the thing it
+// claims to:
+//   - a literal loopback IP (127.0.0.0/8, ::1, and their zoned / 4-in-6 forms) → not
+//     exposed (the safe default).
+//   - any other literal IP, including the unspecified address (0.0.0.0/::) and a
+//     zone-carrying literal (link-local OR global, e.g. fe80::1%eth0) → exposed
+//     (each binds an interface, or every one).
+//   - the empty host of a bare ":port" → exposed (binds every interface).
+//   - a hostname (e.g. localhost) or a malformed/unparseable addr → not exposed:
+//     names are not resolved here (a startup log line must not become a DNS
+//     dependency), and localhost is the most common safe config, so warning on it
+//     would train the operator to ignore the line.
+//
+// The empty host of a bare ":port" is caught ahead of the parse: it binds every
+// interface and must warn, but a parser reads "" as a non-address, the same as a
+// hostname. netip.ParseAddr (not net.ParseIP) does the literal parse because it
+// represents a zone-carrying literal natively — so a zoned bind is judged on its
+// address rather than routed into the hostname branch (net.ParseIP rejects zones).
+// Parsing the literal whole, with no zone string-stripping, also means there is no
+// way to manufacture an empty host from malformed input like "%eth0" and misread it
+// as the every-interface bind — that stays unparseable and silent. A zone selects an
+// interface; it does not change whether the address is loopback, and IsLoopback
+// already handles the 4-in-6 loopback (::ffff:127.0.0.1) with no Unmap.
 func adminAddrIsExposed(addr string) bool {
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
-		return false
+		return false // unparseable — never a false alarm
 	}
-	ip := net.ParseIP(host)
-	return ip != nil && !ip.IsLoopback() && !ip.IsUnspecified()
+	if host == "" {
+		return true // bare ":port" binds every interface
+	}
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return false // a hostname or malformed literal — not resolved here; never a false alarm
+	}
+	return !ip.IsLoopback() // literal IP (incl. zoned / 4-in-6): routable, unspecified, and zoned all warn; loopback does not
 }
 
 // runSyncLoop polls one inbox's upstream on the configured interval until ctx is
@@ -1210,7 +1236,7 @@ func (*ServeCmd) Run(cli *CLI) error {
 	// store writes outbound verdicts to (ADR 0011, C29).
 	svc.SetAuditLog(al)
 	if adminAddrIsExposed(cli.AdminAddr) {
-		slog.Warn("admin-addr is bound to a non-loopback address; the admin API is token-gated but is intended to be reachable only from loopback or the container-internal network (ADR 0029)",
+		slog.Warn("admin-addr binds the admin API beyond loopback (a routable address, or every interface via 0.0.0.0/:: or a bare :port). It is token-gated but is intended to be reachable only from loopback or a container-internal network (ADR 0029). If this is a container that publishes the port as 127.0.0.1:PORT on the host, this is expected — confirm the host narrows it; otherwise bind a loopback address.",
 			"admin_addr", cli.AdminAddr)
 	}
 	adminSrv, err := admin.NewServer(cli.AdminAddr, os.Getenv("DARBAAN_ADMIN_TOKEN"), svc)

--- a/cmd/darbaan/serve_helpers_test.go
+++ b/cmd/darbaan/serve_helpers_test.go
@@ -31,23 +31,37 @@ func TestResolvePollInterval(t *testing.T) {
 	}
 }
 
-// adminAddrIsExposed warns only for a routable literal IP — not loopback, and not
-// the unspecified address (0.0.0.0/::, the documented container pattern where the
-// host narrows exposure). A hostname or unparseable addr never raises a false alarm.
+// adminAddrIsExposed warns on any literal IP that is not loopback — routable, the
+// every-interface binds (unspecified 0.0.0.0/:: and the empty host of a bare
+// ":port"), and a zone-carrying literal (link-local OR global). A literal loopback
+// IP (incl. zoned and 4-in-6 forms), a hostname (not resolved here), and a
+// malformed/unparseable addr stay silent. Routable examples use documentation ranges
+// (RFC 5737 / 3849), not real infrastructure addresses.
 func TestAdminAddrIsExposed(t *testing.T) {
-	exposed := []string{"192.168.1.5:1144", "10.0.0.2:1144", "[2001:db8::1]:1144"}
+	exposed := []string{
+		"192.0.2.10:1144",         // TEST-NET-1 routable v4
+		"198.51.100.5:1144",       // TEST-NET-2 routable v4
+		"[2001:db8::1]:1144",      // documentation range v6
+		"0.0.0.0:1144",            // unspecified v4 — every interface
+		"[::]:1144",               // unspecified v6 — every interface
+		":1144",                   // bare port, empty host — every interface
+		"[fe80::1%eth0]:1144",     // zoned link-local literal — binds an interface
+		"[2001:db8::1%eth0]:1144", // zoned GLOBAL literal — reachable, still a literal bind
+	}
 	for _, a := range exposed {
-		assert.Truef(t, adminAddrIsExposed(a), "%s is routable and should warn", a)
+		assert.Truef(t, adminAddrIsExposed(a), "%q binds beyond loopback and should warn", a)
 	}
 	safe := []string{
-		"127.0.0.1:1144",      // loopback v4
-		"[::1]:1144",          // loopback v6
-		"0.0.0.0:1144",        // unspecified — container pattern, host narrows exposure
-		"[::]:1144",           // unspecified v6
-		"localhost:1144",      // hostname, not a literal IP
-		"admin.internal:1144", // hostname
-		"garbage",             // no host:port
-		"",
+		"127.0.0.1:1144",          // loopback v4
+		"127.0.0.5:1144",          // 127.0.0.0/8 is all loopback, not just .1
+		"[::1]:1144",              // loopback v6
+		"[::1%lo0]:1144",          // zoned loopback — the zone is stripped/parsed, loopback preserved
+		"[::ffff:127.0.0.1]:1144", // 4-in-6 loopback — IsLoopback handles it with no Unmap
+		"localhost:1144",          // hostname, not a literal IP — most common safe config
+		"admin.internal:1144",     // hostname
+		"[%eth0]:1144",            // malformed zone (no address) — unparseable, must NOT read as every-interface
+		"garbage",                 // no host:port
+		"",                        // unparseable
 	}
 	for _, a := range safe {
 		assert.Falsef(t, adminAddrIsExposed(a), "%q must not warn", a)

--- a/internal/admin/client_test.go
+++ b/internal/admin/client_test.go
@@ -20,11 +20,17 @@ import (
 // single path segment rather than altering the route or spilling into a query or
 // fragment. This exercises the whole family of endpoints (both prefixes, both the
 // id and inbox parameters) — not one — because the escape must be applied to every
-// sibling, not most of them: an id like "msg 42?a=b&c=d#frag" round-trips to the
+// sibling, not most of them: an id like "msg/42?a=b&c=d#frag" round-trips to the
 // server's decoded PathValue only if it was escaped on the way out.
+//
+// The sample includes "/" deliberately: it is the one character whose mishandling
+// changes routing rather than a parameter value (an unescaped slash splits into an
+// extra path segment and lands on a different route or none). Escaped to %2F it
+// stays within one wildcard segment and the mux decodes it back, so the round-trip
+// demonstrates the strongest case rather than asserting it.
 func TestClientEscapesPathSegments(t *testing.T) {
-	const weirdID = "msg 42?a=b&c=d#frag"
-	const weirdInbox = "team inbox+x?y"
+	const weirdID = "msg/42?a=b&c=d#frag"
+	const weirdInbox = "team/inbox+x?y"
 
 	var gotID, gotInbox string
 	mux := http.NewServeMux()


### PR DESCRIPTION
Follow-up to the #269 review — **closes #271**. Two observations raised in that review, carried forward as a fresh PR (#269 merged before they could fold in). Updated after review to close the zoned-literal residue.

## Obs 1 — the exposure warning was silent on the broadest binds

PR-2's `admin-addr` startup advisory warned on a single routable IP but stayed silent on `0.0.0.0`/`::` (every interface), a bare `:port`, **and a zone-carrying literal** (link-local *or* global, e.g. `fe80::1%eth0` / `2001:db8::1%eth0`). The container rationale that justified exempting the unspecified address was scoped to containers but applied unconditionally — the same binary runs directly on a host, where binding an interface is exactly what an operator would want flagged. A silent broadest-exposure case reads as clearance — the same shape as a guard that quietly stopped guarding.

`adminAddrIsExposed` now warns on any literal IP that is not loopback (routable, unspecified, zone-carrying) plus the empty host of a bare `:port`; it stays silent for a loopback literal (incl. zoned and 4-in-6 forms), a hostname, and a malformed/unparseable addr.

The literal parse uses **`netip.ParseAddr`** rather than `net.ParseIP`: it represents a zone-carrying literal natively, so a zoned bind is judged on its address rather than routed into the hostname branch (`net.ParseIP` rejects zones). Because the whole literal is parsed — no zone string-stripping — there is **no way to manufacture an empty host** from malformed input like `%eth0` and misread it as the every-interface bind; that stays unparseable and silent (an ordering hazard the string-strip alternative would have required a guard against — the parser version makes it inexpressible). `IsLoopback` handles the 4-in-6 loopback (`::ffff:127.0.0.1`) with no `Unmap`, verified equivalent to `net.ParseIP` across the full case list.

## Obs 2 — the escape test now demonstrates the slash case

The round-trip test's sample id/inbox now include `/` — the one character whose mishandling changes routing rather than a parameter value. Escaped to `%2F` it stays within one wildcard segment and the mux decodes it back (verified: `PathValue` returns the exact original), so the test demonstrates the escape comment's strongest claim instead of asserting it.

## Tests

Exposure classification: routable (documentation ranges, RFC 5737 / 3849), unspecified, bare `:port`, **zoned link-local**, **zoned global**, a `127.0.0.0/8` non-`.1` loopback, **zoned loopback**, **4-in-6 loopback**, a **malformed zone**, hostnames, and unparseable input. Escape round-trip carries `/` through the whole endpoint family (both prefixes, both parameters).

Local: gofmt clean, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).