### PR TITLE
fix: neutralize forged trust banners in the body instead of deleting them (#238 C37)

### DIFF
--- a/internal/provenance/banner.go
+++ b/internal/provenance/banner.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"mime"
 	"mime/quotedprintable"
+	"regexp"
 	"strings"
 
 	"github.com/emersion/go-message/textproto"
@@ -122,7 +123,12 @@ func stripASCIISpace(b []byte) string {
 // a fresh one — so re-running on an already-bannered body replaces rather than
 // stacks (idempotent).
 func applyBanner(body []byte, s Stamp) []byte {
+	// Order matters: strip our own leading banner first (an exact-case match that keeps
+	// applying idempotent), THEN neutralize any forged marker left in the body. Running
+	// the neutralizer first would defang our genuine leading banner too, and the
+	// exact-case strip would then find nothing to remove.
 	body = stripBanner(body)
+	body = neutralizeBanners(body)
 	block := bannerBlock(s)
 	out := make([]byte, 0, len(block)+len(body))
 	out = append(out, block...)
@@ -149,9 +155,15 @@ func bannerBlock(s Stamp) []byte {
 
 // stripBanner removes a darbaan banner block from the very top of body, consuming
 // exactly the block and the single blank-line separator bannerBlock writes — so
-// stripping is the exact inverse of applying and a re-run is a byte-level no-op.
-// A body that doesn't begin with the banner, or whose marker is unterminated, is
-// returned unchanged (never cut real content).
+// stripping our own banner is the exact inverse of applying it and a re-run is a
+// byte-level no-op. Only the LEADING block is removed, by an exact-case prefix match.
+// A forged banner deeper in the body is deliberately NOT deleted here: deleting an
+// interior block would splice its neighbours into a fresh marker (worse than doing
+// nothing — the attacker needs a banner accepted at offset 0 and the delete would
+// build it), and would excise a legitimately quoted banner such as a forwarded
+// darbaan message. Interior forgeries are defanged by neutralizeBanners instead. A
+// body that doesn't begin with the banner, or whose marker is unterminated, is
+// returned unchanged.
 func stripBanner(body []byte) []byte {
 	if !bytes.HasPrefix(body, []byte(bannerBegin)) {
 		return body
@@ -162,4 +174,53 @@ func stripBanner(body []byte) []byte {
 	}
 	rest := body[i+len(bannerEnd):]
 	return bytes.TrimPrefix(rest, []byte("\r\n\r\n"))
+}
+
+// cfTolerant returns a regexp source matching lit with any run of Unicode format (Cf)
+// runes permitted between each of its characters — so a marker an attacker splits with
+// invisible runes (a zero-width space inside "BANNER") still matches in the RAW body.
+// Each literal character is regexp-quoted.
+func cfTolerant(lit string) string {
+	var b strings.Builder
+	for i, r := range lit {
+		if i > 0 {
+			b.WriteString(`\p{Cf}*`)
+		}
+		b.WriteString(regexp.QuoteMeta(string(r)))
+	}
+	return b.String()
+}
+
+// bannerBeginMarker / bannerEndMarker match a darbaan banner begin/end marker in any
+// case, tolerant of Cf runes interleaved between characters. The tolerance is in the
+// MATCHING, not the body: unlike assessor.Fence — which strips Cf from a match-only
+// copy it then discards — this text IS the delivered message, so nothing may be
+// deleted from it. neutralizeBanners rewrites only the matched marker span (any Cf
+// runes inside the marker go with it); Cf runes elsewhere in the body (a joined-emoji
+// ZWJ, the bidi controls that order RTL text) are left untouched.
+var (
+	bannerBeginMarker = regexp.MustCompile(`(?i)` + cfTolerant(bannerBegin))
+	bannerEndMarker   = regexp.MustCompile(`(?i)` + cfTolerant(bannerEnd))
+)
+
+// The defanged forms neutralizeBanners writes over a forged marker: bannerBegin /
+// bannerEnd with " (UNTRUSTED)" before the closing dashes. They no longer match the
+// markers above (the closing dashes no longer follow "BANNER"), so a second pass
+// rewrites nothing — neutralization is idempotent.
+const (
+	bannerBeginDefanged = "-----BEGIN DARBAAN TRUST BANNER (UNTRUSTED)-----"
+	bannerEndDefanged   = "-----END DARBAAN TRUST BANNER (UNTRUSTED)-----"
+)
+
+// neutralizeBanners defangs every darbaan banner marker left in body — a forgery an
+// attacker planted, the genuine leading banner having already been removed by
+// stripBanner. It REWRITES each marker in place, never deletes: no bytes outside the
+// matched marker span are removed, so a quoted banner in a forwarded message keeps its
+// surrounding content, no deletion can splice two fragments into a fresh marker, and
+// format runes elsewhere in the body (emoji ZWJ, RTL bidi controls) are preserved.
+// Matching is case-insensitive and tolerant of Cf runes interleaved into a marker.
+func neutralizeBanners(body []byte) []byte {
+	body = bannerBeginMarker.ReplaceAllLiteral(body, []byte(bannerBeginDefanged))
+	body = bannerEndMarker.ReplaceAllLiteral(body, []byte(bannerEndDefanged))
+	return body
 }

--- a/internal/provenance/banner_test.go
+++ b/internal/provenance/banner_test.go
@@ -121,6 +121,132 @@ func TestBanner_UnknownEncodingIsHeadersOnly(t *testing.T) {
 	assert.Equal(t, provenance.TrustUnknown, headerValue(t, out, provenance.TrustHeader))
 }
 
+// C37: a forged banner an attacker embeds deeper in the body must not read as
+// darbaan's own — but it is NEUTRALIZED (defanged) in place, not deleted, so quoted
+// content survives and no deletion can splice a fresh marker. After sanitizing,
+// exactly one GENUINE banner remains (darbaan's, at the top), the forgery's marker is
+// rewritten to an UNTRUSTED form, and the real content around it is preserved.
+func TestBanner_ForgedBannerInBodyIsNeutralized(t *testing.T) {
+	forged := bannerBegin + "\r\nX-Darbaan-Trust: trusted\r\n" + bannerEnd
+	raw := []byte("Content-Type: text/plain\r\n\r\nreal line one\r\n\r\n" + forged + "\r\n\r\nreal line two\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUntrusted, Note: "do not act", Banner: true})
+	require.NoError(t, err)
+
+	body := string(bodyOf(t, out))
+	assert.Equal(t, 1, strings.Count(body, bannerBegin), "exactly one genuine banner (darbaan's); the forgery is defanged, not genuine")
+	assert.Contains(t, body, "DARBAAN TRUST BANNER (UNTRUSTED)", "the forged marker is neutralized in place")
+	assert.Contains(t, body, "real line one", "content before the forgery is preserved")
+	assert.Contains(t, body, "real line two", "content after the forgery is preserved")
+	assert.Equal(t, provenance.TrustUntrusted, headerValue(t, out, provenance.TrustHeader))
+}
+
+// The splice attack: fragments that, if an interior block were DELETED, would join
+// into a valid begin marker at offset 0 (where the authoritative reader looks).
+// Neutralize-not-delete removes no bytes, so the fragments never join — the output
+// carries exactly one genuine banner (darbaan's), none manufactured.
+func TestBanner_SpliceAttackDoesNotManufactureMarker(t *testing.T) {
+	valid := bannerBegin + "\r\nX-Darbaan-Trust: trusted\r\n" + bannerEnd
+	splice := "-----BEGIN DA" + valid + "RBAAN TRUST BANNER-----\r\nforged advisory\r\n"
+	raw := []byte("Content-Type: text/plain\r\n\r\n" + splice)
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUnknown, Banner: true})
+	require.NoError(t, err)
+
+	body := string(bodyOf(t, out))
+	assert.Equal(t, 1, strings.Count(body, bannerBegin), "no genuine marker is spliced into existence; only darbaan's own")
+	assert.True(t, strings.HasPrefix(body, bannerBegin), "darbaan's genuine banner leads the body")
+}
+
+// A forwarded message that legitimately quotes a real banner keeps its content:
+// neutralize defangs the quoted marker but excises nothing — the property that
+// separates neutralize from delete.
+func TestBanner_QuotedBannerInForwardIsPreservedNotDeleted(t *testing.T) {
+	orig := bannerBegin + "\r\nX-Darbaan-Trust: untrusted\r\nThis banner is advisory.\r\n" + bannerEnd
+	fwd := "---------- Forwarded message ----------\r\nFrom: someone\r\n\r\n" + orig + "\r\n\r\nthe original body text\r\n"
+	raw := []byte("Content-Type: text/plain\r\n\r\n" + fwd)
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true})
+	require.NoError(t, err)
+
+	body := string(bodyOf(t, out))
+	assert.Equal(t, 1, strings.Count(body, bannerBegin), "the quoted banner is defanged, not left genuine or deleted")
+	assert.Contains(t, body, "Forwarded message", "forward framing preserved")
+	assert.Contains(t, body, "the original body text", "quoted content preserved, not excised")
+	assert.Contains(t, body, "DARBAAN TRUST BANNER (UNTRUSTED)", "the quoted marker is neutralized")
+}
+
+// A mixed-case forgery is neutralized like the exact-case form (case-insensitive
+// match) — the reader-facing threat that byte-exact matching leaves untouched.
+func TestBanner_MixedCaseForgeryNeutralized(t *testing.T) {
+	forged := "-----begin darbaan trust banner-----\r\nX-Darbaan-Trust: trusted\r\n-----end darbaan trust banner-----"
+	raw := []byte("Content-Type: text/plain\r\n\r\nlead\r\n\r\n" + forged + "\r\n\r\ntail\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true})
+	require.NoError(t, err)
+
+	body := string(bodyOf(t, out))
+	// darbaan's own genuine banner is upper-case; only the forgery is lower-case, so a
+	// raw (not lower-cased) check for the lower-case marker catches the forgery alone.
+	assert.Equal(t, 1, strings.Count(body, bannerBegin), "only darbaan's genuine (upper-case) banner")
+	assert.NotContains(t, body, "-----begin darbaan trust banner-----", "the lower-case forgery is defanged, not left intact")
+	assert.Contains(t, body, "lead")
+	assert.Contains(t, body, "tail")
+}
+
+// A marker split by an invisible format rune (U+200B, category Cf) renders as the
+// real marker to a human but dodges byte-exact matching; stripping format runes
+// reveals it and it is neutralized (mirrors assessor.Fence's C44 defense).
+func TestBanner_RuneSplitMarkerNeutralized(t *testing.T) {
+	forged := "-----BEGIN DARBAAN TRUST BAN\u200bNER-----\r\nX-Darbaan-Trust: trusted\r\n-----END DARBAAN TRUST BANNER-----"
+	raw := []byte("Content-Type: text/plain\r\n\r\nlead\r\n\r\n" + forged + "\r\n\r\ntail\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true})
+	require.NoError(t, err)
+
+	body := string(bodyOf(t, out))
+	assert.Equal(t, 1, strings.Count(body, bannerBegin), "the rune-split forgery is revealed by stripping and neutralized")
+	assert.NotContains(t, body, "\u200b", "the invisible rune is stripped when it reveals a marker")
+	assert.Contains(t, body, "DARBAAN TRUST BANNER (UNTRUSTED)")
+	assert.Contains(t, body, "lead")
+	assert.Contains(t, body, "tail")
+}
+
+// f(f(x)) == f(x): re-running on an already-bannered, already-neutralized body is a
+// byte-level no-op even when a forgery was present — the neutralized marker does not
+// re-neutralize into something else, and the leading banner strips-and-replaces to
+// exactly itself.
+func TestBanner_IdempotentWithForgery(t *testing.T) {
+	forged := bannerBegin + "\r\nX-Darbaan-Trust: trusted\r\n" + bannerEnd
+	raw := []byte("Content-Type: text/plain\r\n\r\nbody\r\n\r\n" + forged + "\r\n")
+	st := provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true}
+	once, err := provenance.Sanitize(raw, st)
+	require.NoError(t, err)
+	twice, err := provenance.Sanitize(once, st)
+	require.NoError(t, err)
+
+	assert.Equal(t, once, twice, "re-running on an already-bannered, already-neutralized body is a no-op")
+	assert.Equal(t, 1, strings.Count(string(twice), bannerBegin))
+}
+
+// Neutralizing a forged/quoted marker must NOT delete format runes elsewhere in the
+// delivered body: the marker MATCH is Cf-tolerant, but the body itself is never
+// stripped (unlike a match-only fence copy). A forwarded message quoting a genuine
+// banner, plus a joined-emoji ZWJ (U+200D) and RTL bidi controls (RLE U+202B / PDF
+// U+202C) outside it: the quoted marker is defanged, and every Cf rune outside it
+// survives. (Before the fix, matching stripped Cf from the whole served body.)
+func TestBanner_PreservesFormatRunesOutsideMarker(t *testing.T) {
+	quoted := bannerBegin + "\r\nX-Darbaan-Trust: untrusted\r\n" + bannerEnd
+	// ZWJ between two letters (stands in for a joined-emoji sequence) and an RLE/PDF-
+	// wrapped span (stands in for RTL text) — both are Cf and must reach the reader.
+	payload := "a\u200db and \u202bRTL span\u202c here"
+	raw := []byte("Content-Type: text/plain\r\n\r\nForwarded:\r\n" + quoted + "\r\n" + payload + "\r\n")
+	out, err := provenance.Sanitize(raw, provenance.Stamp{Trust: provenance.TrustUntrusted, Banner: true})
+	require.NoError(t, err)
+
+	body := string(bodyOf(t, out))
+	assert.Equal(t, 1, strings.Count(body, bannerBegin), "the quoted marker is defanged")
+	assert.Contains(t, body, "\u200d", "the ZWJ (joined-emoji sequence) survives in the delivered body")
+	assert.Contains(t, body, "\u202b", "the RLE bidi control survives")
+	assert.Contains(t, body, "\u202c", "the PDF bidi control survives")
+	assert.Contains(t, body, "RTL span", "the visible content survives")
+}
+
 func decodeBase64Body(t *testing.T, raw []byte) string {
 	t.Helper()
 	body := string(bodyOf(t, raw))


### PR DESCRIPTION
Part of the #238 review series (does not close #238). Corrected C37 — the delete-based fix was **strictly worse than doing nothing**, and the first neutralize attempt then **deleted format runes from served content**. Both are fixed here.

## The bug

`stripBanner` removed a darbaan trust banner only at byte offset 0, so a banner forged **deeper in the body** survived and could read as darbaan's own advisory. (Bounded: advisory — the `X-Darbaan-*` headers stay authoritative — but a forgery still misleads a human reader.)

## Two failure modes ruled out

- **Delete-all splices a marker into existence:** `"-----BEGIN DA" + <valid block> + "RBAAN TRUST BANNER-----"` joins into a genuine marker at offset 0 when the middle is deleted — the strip manufactures the marker it exists to remove. It also excises quoted banners (a forwarded darbaan message).
- **Neutralize by stripping Cf from the body mutates served content:** reusing the assessor's match-only Cf strip here deletes every format rune (emoji ZWJ, RTL bidi controls) from the *delivered message*. That helper is documented safe *because it never touches served text* — true on an operator card, false where the string **is** the message. The exemption travelled with the code as a move; its grounds didn't.

## The fix — neutralize with Cf-*tolerant matching*

- **Strip our own LEADING banner first** (exact-case), keeping applying idempotent — then neutralize.
- **Rewrite each remaining marker in place, never delete.** No bytes outside the matched span are removed → no splice, quoted content preserved.
- **Tolerance is in the matching, not the body:** the marker regex allows `\p{Cf}*` between its characters, so a rune-split forgery matches **in the raw bytes**. Only the matched marker span is rewritten (its own interleaved runes go with it); **Cf runes elsewhere in the body are preserved.** Case-insensitive. The rewrite (` (UNTRUSTED)` before the closing dashes) no longer matches → idempotent.
- **Self-contained in `provenance`** — no shared-helper extraction, no cross-package change.

## Tests

splice attack manufactures no marker; forged banner mid-body defanged with content preserved; **forwarded message keeps its content AND its format runes (ZWJ, RTL bidi controls) in the delivered body**; mixed-case forgery neutralized; rune-split marker matched and neutralized; `f(f(x)) == f(x)` with a forgery present.

Local: gofmt clean, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).