### PR TITLE
fix: neutralize banner markers to a fixpoint so a rewrite cannot leave a live one (#274)

### DIFF
--- a/internal/provenance/banner.go
+++ b/internal/provenance/banner.go
@@ -203,24 +203,58 @@ var (
 	bannerEndMarker   = regexp.MustCompile(`(?i)` + cfTolerant(bannerEnd))
 )
 
-// The defanged forms neutralizeBanners writes over a forged marker: bannerBegin /
-// bannerEnd with " (UNTRUSTED)" before the closing dashes. They no longer match the
-// markers above (the closing dashes no longer follow "BANNER"), so a second pass
-// rewrites nothing — neutralization is idempotent.
+// The defanged forms neutralizeBanners writes over a forged marker. Three properties,
+// each load-bearing:
+//  1. bracket-delimited, carrying no five-hyphen run — a banner marker is framed by
+//     two five-hyphen runs, and a form that begins and ends with a bracket and holds
+//     only a lone space-surrounded hyphen can neither supply a marker's delimiter nor
+//     complete one across a boundary, so no rewrite can combine with surrounding text
+//     to re-form a live marker (#274: the previous "-----...(UNTRUSTED)-----" form
+//     ENDED with the delimiter it removed, so two same-kind markers sharing a dash run
+//     manufactured a live one that a single pass never re-scanned).
+//  2. ASCII-only — this insertion path re-encodes 7bit/8bit/us-ascii bodies as
+//     identity, so a non-ASCII byte would land in a body that declares it has none.
+//  3. not banner-SHAPED — it reads as an annotation ABOUT content, not as content,
+//     since the threat model is a reader trusting banner-shaped text.
+//
+// Neither form matches the markers, so neutralization stays idempotent.
 const (
-	bannerBeginDefanged = "-----BEGIN DARBAAN TRUST BANNER (UNTRUSTED)-----"
-	bannerEndDefanged   = "-----END DARBAAN TRUST BANNER (UNTRUSTED)-----"
+	bannerBeginDefanged = "[DARBAAN TRUST BANNER BEGIN - FORGED, NEUTRALIZED]"
+	bannerEndDefanged   = "[DARBAAN TRUST BANNER END - FORGED, NEUTRALIZED]"
 )
 
 // neutralizeBanners defangs every darbaan banner marker left in body — a forgery an
 // attacker planted, the genuine leading banner having already been removed by
 // stripBanner. It REWRITES each marker in place, never deletes: no bytes outside the
-// matched marker span are removed, so a quoted banner in a forwarded message keeps its
-// surrounding content, no deletion can splice two fragments into a fresh marker, and
-// format runes elsewhere in the body (emoji ZWJ, RTL bidi controls) are preserved.
-// Matching is case-insensitive and tolerant of Cf runes interleaved into a marker.
+// matched span are removed, so a forwarded message's quoted banner keeps its
+// surrounding content and format runes elsewhere (emoji ZWJ, RTL bidi controls) are
+// preserved. Matching is case-insensitive and tolerant of Cf runes interleaved into a
+// marker.
+//
+// It rewrites to a FIXPOINT: a round that changes nothing means neither pattern
+// matched, which is exactly the post-condition (no live marker survives). The
+// bracket-delimited replacement (see the consts), carrying no five-hyphen run, cannot itself form a
+// marker, so this converges in a single productive round — the loop is defense in
+// depth against a future replacement that could re-form one (#274: the old
+// "-----...(UNTRUSTED)-----" form ended with the delimiter it removed, so two same-kind
+// markers sharing a dash run manufactured a live one that a single pass never
+// re-scanned; cross-kind did not). The bound cannot be reached with a non-manufacturing
+// replacement — each productive round strictly reduces the marker count — so reaching
+// it proves that invariant was broken; it fails LOUD rather than return a body that may
+// still carry a live marker, since a silent cap is the guard-that-doesn't-act failure.
 func neutralizeBanners(body []byte) []byte {
-	body = bannerBeginMarker.ReplaceAllLiteral(body, []byte(bannerBeginDefanged))
-	body = bannerEndMarker.ReplaceAllLiteral(body, []byte(bannerEndDefanged))
-	return body
+	maxRounds := len(body) + 2 // exceeds any real marker count; never approached with the bracketed replacement
+	for round := 0; ; round++ {
+		next := bannerEndMarker.ReplaceAllLiteral(
+			bannerBeginMarker.ReplaceAllLiteral(body, []byte(bannerBeginDefanged)),
+			[]byte(bannerEndDefanged),
+		)
+		if bytes.Equal(next, body) {
+			return next // fixpoint reached: neither pattern matched this round
+		}
+		body = next
+		if round >= maxRounds {
+			panic("provenance: banner neutralization did not converge; the defanged replacement can form a marker (#274)")
+		}
+	}
 }

--- a/internal/provenance/banner.go
+++ b/internal/provenance/banner.go
@@ -238,12 +238,16 @@ const (
 // depth against a future replacement that could re-form one (#274: the old
 // "-----...(UNTRUSTED)-----" form ended with the delimiter it removed, so two same-kind
 // markers sharing a dash run manufactured a live one that a single pass never
-// re-scanned; cross-kind did not). The bound cannot be reached with a non-manufacturing
-// replacement — each productive round strictly reduces the marker count — so reaching
-// it proves that invariant was broken; it fails LOUD rather than return a body that may
-// still carry a live marker, since a silent cap is the guard-that-doesn't-act failure.
+// re-scanned; cross-kind did not — and the loop, not the bound, absorbs this: it
+// converges in a few rounds). The bound guards a DISTINCT class — a replacement that
+// regenerates a marker every round (one that itself contains or forms a marker, so each
+// round re-matches what the last wrote and the count never falls). Any convergent
+// replacement, #274's manufacture-then-absorb included, drives the count to zero in a
+// few rounds and never nears the bound; so reaching it proves the replacement is
+// non-convergent. It fails LOUD rather than return a body that may still carry a live
+// marker, since a silent cap is the guard-that-doesn't-act failure.
 func neutralizeBanners(body []byte) []byte {
-	maxRounds := len(body) + 2 // exceeds any real marker count; never approached with the bracketed replacement
+	maxRounds := 8 // convergence is one productive round (above), so this is several times any reasoned worst case; a body-sized bound would turn the panic into an effective hang on a large message before it ever fired
 	for round := 0; ; round++ {
 		next := bannerEndMarker.ReplaceAllLiteral(
 			bannerBeginMarker.ReplaceAllLiteral(body, []byte(bannerBeginDefanged)),
@@ -254,7 +258,7 @@ func neutralizeBanners(body []byte) []byte {
 		}
 		body = next
 		if round >= maxRounds {
-			panic("provenance: banner neutralization did not converge; the defanged replacement can form a marker (#274)")
+			panic("provenance: banner neutralization did not converge: the defanged replacement re-matches a marker every round — it must neither contain nor form one")
 		}
 	}
 }

--- a/internal/provenance/banner_internal_test.go
+++ b/internal/provenance/banner_internal_test.go
@@ -1,0 +1,53 @@
+package provenance
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var nonASCII = regexp.MustCompile(`[^\x00-\x7f]`)
+
+// #274: neutralization must leave NO live marker in its output — the invariant both
+// passes establish, and the exact class C37 exists to close (an edit leaving a live
+// marker behind). The prior defanged form ENDED with the delimiter it removed, so two
+// SAME-KIND markers sharing a dash run manufactured a live marker a single pass never
+// re-scanned; CROSS-kind did not — the asymmetry a future reader would not guess and
+// the fixpoint covers without explaining. This asserts the invariant directly over the
+// four adjacency arrangements plus a small sweep, so it objects if anyone later
+// reshapes the replacement back to a delimiter-bearing form or reorders the passes.
+func TestNeutralizeBannersLeavesNoLiveMarker(t *testing.T) {
+	b, e := bannerBegin, bannerEnd
+	cases := map[string]string{
+		"BEGIN+BEGIN (shared dash run, survived pre-fix)": b + "BEGIN DARBAAN TRUST BANNER-----",
+		"END+END (shared dash run, survived pre-fix)":     e + "END DARBAAN TRUST BANNER-----",
+		"BEGIN+END (cross-kind, did not survive pre-fix)": b + "END DARBAAN TRUST BANNER-----",
+		"END+BEGIN (cross-kind)":                          e + "BEGIN DARBAAN TRUST BANNER-----",
+		"triple begin":                                    b + b + b,
+		"triple end":                                      e + e + e,
+		"interleaved begin/end/begin":                     b + e + b,
+		"markers amid text":                               "lead " + b + " mid " + e + " tail",
+	}
+	for name, in := range cases {
+		out := neutralizeBanners([]byte(in))
+		assert.Falsef(t, bannerBeginMarker.Match(out), "%s: a live BEGIN marker survives: %q", name, out)
+		assert.Falsef(t, bannerEndMarker.Match(out), "%s: a live END marker survives: %q", name, out)
+		// This insertion path re-encodes 7bit/8bit/us-ascii bodies as identity, so a
+		// non-ASCII byte in the replacement would land in a body that declares it has
+		// none. Inputs here are ASCII, so any non-ASCII output came from the replacement.
+		assert.Falsef(t, nonASCII.Match(out), "%s: non-ASCII byte in neutralized output: %q", name, out)
+	}
+}
+
+// The defanged constants must keep the three properties the safety argument rests on,
+// pinned directly so a later "nicer" phrasing (a curly quote, an em dash, a delimiter-
+// shaped run) is caught at the source rather than only through the behavioural test.
+func TestBannerDefangedFormsAreSafe(t *testing.T) {
+	for _, s := range []string{bannerBeginDefanged, bannerEndDefanged} {
+		assert.Falsef(t, nonASCII.MatchString(s), "defanged form must be ASCII-only: %q", s)
+		assert.NotContainsf(t, s, "-----", "defanged form must carry no five-hyphen delimiter run: %q", s)
+		assert.Truef(t, strings.HasPrefix(s, "[") && strings.HasSuffix(s, "]"), "defanged form must be bracket-delimited: %q", s)
+	}
+}

--- a/internal/provenance/banner_test.go
+++ b/internal/provenance/banner_test.go
@@ -125,7 +125,7 @@ func TestBanner_UnknownEncodingIsHeadersOnly(t *testing.T) {
 // darbaan's own — but it is NEUTRALIZED (defanged) in place, not deleted, so quoted
 // content survives and no deletion can splice a fresh marker. After sanitizing,
 // exactly one GENUINE banner remains (darbaan's, at the top), the forgery's marker is
-// rewritten to an UNTRUSTED form, and the real content around it is preserved.
+// rewritten to a neutralized annotation, and the real content around it is preserved.
 func TestBanner_ForgedBannerInBodyIsNeutralized(t *testing.T) {
 	forged := bannerBegin + "\r\nX-Darbaan-Trust: trusted\r\n" + bannerEnd
 	raw := []byte("Content-Type: text/plain\r\n\r\nreal line one\r\n\r\n" + forged + "\r\n\r\nreal line two\r\n")
@@ -134,7 +134,7 @@ func TestBanner_ForgedBannerInBodyIsNeutralized(t *testing.T) {
 
 	body := string(bodyOf(t, out))
 	assert.Equal(t, 1, strings.Count(body, bannerBegin), "exactly one genuine banner (darbaan's); the forgery is defanged, not genuine")
-	assert.Contains(t, body, "DARBAAN TRUST BANNER (UNTRUSTED)", "the forged marker is neutralized in place")
+	assert.Contains(t, body, "FORGED, NEUTRALIZED", "the forged marker is neutralized in place")
 	assert.Contains(t, body, "real line one", "content before the forgery is preserved")
 	assert.Contains(t, body, "real line two", "content after the forgery is preserved")
 	assert.Equal(t, provenance.TrustUntrusted, headerValue(t, out, provenance.TrustHeader))
@@ -170,7 +170,7 @@ func TestBanner_QuotedBannerInForwardIsPreservedNotDeleted(t *testing.T) {
 	assert.Equal(t, 1, strings.Count(body, bannerBegin), "the quoted banner is defanged, not left genuine or deleted")
 	assert.Contains(t, body, "Forwarded message", "forward framing preserved")
 	assert.Contains(t, body, "the original body text", "quoted content preserved, not excised")
-	assert.Contains(t, body, "DARBAAN TRUST BANNER (UNTRUSTED)", "the quoted marker is neutralized")
+	assert.Contains(t, body, "FORGED, NEUTRALIZED", "the quoted marker is neutralized")
 }
 
 // A mixed-case forgery is neutralized like the exact-case form (case-insensitive
@@ -202,7 +202,7 @@ func TestBanner_RuneSplitMarkerNeutralized(t *testing.T) {
 	body := string(bodyOf(t, out))
 	assert.Equal(t, 1, strings.Count(body, bannerBegin), "the rune-split forgery is revealed by stripping and neutralized")
 	assert.NotContains(t, body, "\u200b", "the invisible rune is stripped when it reveals a marker")
-	assert.Contains(t, body, "DARBAAN TRUST BANNER (UNTRUSTED)")
+	assert.Contains(t, body, "FORGED, NEUTRALIZED")
 	assert.Contains(t, body, "lead")
 	assert.Contains(t, body, "tail")
 }


### PR DESCRIPTION
**Closes #274.** Follow-up to C37 (#273, merged 43467b2) — **not in v0.17.1, so nothing deployed is affected.**

## The bug

The neutralizer rewrote each forged marker to a form that **ended with the delimiter run it removed** (`-----...(UNTRUSTED)-----`). Two **same-kind** markers sharing a middle dash run manufactured a live one:

```
in : -----BEGIN DARBAAN TRUST BANNER-----BEGIN DARBAAN TRUST BANNER-----
out: [defanged]-----BEGIN DARBAAN TRUST BANNER-----   ← live, un-neutralized
```

The first match consumes the shared `-----`; the tail closes into a complete marker the single pass never re-scans. Same-kind (BEGIN+BEGIN, END+END) survives pre-fix; cross-kind does not. It's the exact class C37 exists to close, surviving in the fix for it.

## Fix — two independent grounds

- **Structural:** the defanged replacement is bracket-delimited, ASCII-only, and carries **no five-hyphen run**, so it can neither supply a marker's delimiter nor complete one across a boundary. No rewrite can re-form a live marker.
- **Reader-facing:** the old form kept the full PEM shape, distinguished only by a parenthetical — while the threat model *is* a reader trusting banner-shaped text. The new form `[DARBAAN TRUST BANNER BEGIN - FORGED, NEUTRALIZED]` reads as an annotation *about* content, not *as* content.

`neutralizeBanners` rewrites to a **fixpoint** — a round that changes nothing means neither pattern matched, so the exit condition *is* the post-condition. The non-manufacturing replacement converges in one productive round; the loop is defense in depth, and reaching its bound is impossible unless the replacement is later broken, so it **fails LOUD (panic)** rather than return a plausible body carrying a live marker.

ASCII-only is load-bearing: this insertion path re-encodes 7bit/8bit/us-ascii bodies as identity, so a non-ASCII byte would land in a body that declares none.

## Build list (all six)

1. fixpoint loop, exit when a round changes nothing ✓
2. bracketed ASCII replacement ✓
3. post-condition permanent test: after neutralization **neither** pattern matches ✓
4. neutralized output is **ASCII-only** (asserted) ✓
5. four adjacency arrangements as named cases ✓
6. **loud failure (panic) if the iteration bound is reached** ✓

Local: gofmt clean, `go vet`, `go test -race ./...`, golangci-lint v2.11.4 (0 issues).