### PR TITLE
fix: store agent credential digests at construction (#266)

### DIFF
--- a/internal/listener/auth.go
+++ b/internal/listener/auth.go
@@ -37,20 +37,36 @@ func (p *Principal) CanSend(inbox string) bool {
 // the username or the password was wrong — no username-enumeration oracle
 // (ADR 0027). v1 ran a single credential; this generalizes it to a map of agents.
 type Auth struct {
-	byName map[string]Principal
+	byName map[string]storedPrincipal
+}
+
+// storedPrincipal is the internal record NewAuth keeps for each agent: the non-secret
+// grants plus the fixed-width MAC of the credential (pwMAC). The plaintext password is
+// hashed at construction and never retained, so Verify has no plaintext in scope to
+// compare against — a regression to a raw byte compare would have to visibly re-add
+// plaintext credential storage, which is reviewable, rather than being invisible to
+// every behavioural test (#266, C31 follow-up). A side benefit is that agent passwords
+// are not held in memory past startup.
+type storedPrincipal struct {
+	name         string
+	defaultInbox string
+	reads        map[string]bool
+	sends        map[string]bool
+	pwMAC        []byte
 }
 
 // dummyPassword equalizes the compare path for an unknown username.
 const dummyPassword = "x-darbaan-no-such-principal"
 
-// compareKey keys the credential comparison; it is random per process. Verify MACs
-// both the presented and the stored password to a fixed width before comparing, so
-// hmac.Equal — which, like any constant-time compare, is length-safe only for
-// equal-length inputs — never sees the raw password lengths. A keyed MAC (not a bare
-// password hash) is the right primitive here: it makes the fixed-width values
-// unpredictable, so they can't be precomputed or correlated across runs. Generated
-// once; a randomness failure is fatal, because the only fallbacks (comparing raw bytes,
-// or an unkeyed hash) would reintroduce the length oracle this closes.
+// compareKey keys the credential comparison; it is random per process. The presented
+// password is MAC'd in Verify and each stored credential is MAC'd once at construction
+// (NewAuth); the two fixed-width digests are compared, so hmac.Equal — which, like any
+// constant-time compare, is length-safe only for equal-length inputs — never sees the
+// raw password lengths. A keyed MAC (not a bare password hash) is the right primitive
+// here: it makes the fixed-width values unpredictable, so an attacker can't precompute
+// or correlate them across runs. Generated once; a randomness failure is fatal, because
+// the only fallbacks (comparing raw bytes, or an unkeyed hash) would reintroduce the
+// length oracle this closes.
 var compareKey = mustRandomKey(32)
 
 func mustRandomKey(n int) []byte {
@@ -68,12 +84,27 @@ func credMAC(s string) []byte {
 	return m.Sum(nil)
 }
 
+// dummyMAC is the fixed-width digest the not-found path compares against. Like the
+// stored credential digests it is precomputed (at package init), so an unknown username
+// does exactly the same work as a wrong password — MAC the presented password, one
+// fixed-width compare against an already-computed target — with no extra hashing on
+// either path for an attacker to time against.
+var dummyMAC = credMAC(dummyPassword)
+
 // NewAuth builds an Auth over the given principals, keyed by name. Name
 // uniqueness is validated upstream (agentcfg.Validate).
 func NewAuth(principals []Principal) *Auth {
-	byName := make(map[string]Principal, len(principals))
+	byName := make(map[string]storedPrincipal, len(principals))
 	for _, p := range principals {
-		byName[p.Name] = p
+		// Hash the credential here and keep only the digest; the plaintext p.Password
+		// is not stored (#266).
+		byName[p.Name] = storedPrincipal{
+			name:         p.Name,
+			defaultInbox: p.DefaultInbox,
+			reads:        p.Reads,
+			sends:        p.Sends,
+			pwMAC:        credMAC(p.Password),
+		}
 	}
 	return &Auth{byName: byName}
 }
@@ -91,14 +122,16 @@ func SingleAuth(name, password string) *Auth {
 // A constant-time compare is length-safe only for equal-length inputs — it
 // short-circuits on a length mismatch — so comparing raw passwords would leak the
 // stored password's length, and (against the fixed-length dummy) whether the username
-// exists at all. MAC-ing both sides first makes lengths uninformative. Every outcome
-// does identical work: MAC the presented password (before the lookup), MAC the target,
-// one fixed-width compare — so the found and not-found paths are indistinguishable, and
-// both return (nil, false), which both callers map to the same ErrAuthFailed with no
-// distinguishing log. This surface is keyed by the presented username, so unlike the
-// admin credential set (ADR 0029, which scans every credential with no early exit to
-// hide which one matched) there is no set membership to conceal here — only that a miss
-// is a miss regardless of which half was wrong (ADR 0027).
+// exists at all. MAC-ing both sides makes lengths uninformative. The stored credential's
+// MAC is computed once at construction (NewAuth) and only the presented password is
+// MAC'd here. Every outcome does identical work: MAC the presented password (before the
+// lookup), one fixed-width compare against a precomputed target MAC — the stored digest
+// for a hit, dummyMAC for a miss — so the found and not-found paths are
+// indistinguishable, and both return (nil, false), which both callers map to the same
+// ErrAuthFailed with no distinguishing log. This surface is keyed by the presented
+// username, so unlike the admin credential set (ADR 0029, which scans every credential
+// with no early exit to hide which one matched) there is no set membership to conceal
+// here — only that a miss is a miss regardless of which half was wrong (ADR 0027).
 //
 // "Identical work" describes the compare path; the map lookup ahead of it is not
 // identical (a hit compares the key it found, a miss need not), leaving a small residue
@@ -107,15 +140,22 @@ func SingleAuth(name, password string) *Auth {
 // username-keyed surface deliberately declines (there is no membership to hide).
 func (a *Auth) Verify(username, password string) (*Principal, bool) {
 	got := credMAC(password)
-	p, found := a.byName[username]
+	sp, found := a.byName[username]
 	if !found {
-		// MAC the dummy and compare too, so the not-found path does the same work as a
-		// wrong password — no username-existence timing oracle.
-		_ = hmac.Equal(got, credMAC(dummyPassword))
+		// Compare against the precomputed dummy so the not-found path does the same work
+		// as a wrong password — no username-existence timing oracle.
+		_ = hmac.Equal(got, dummyMAC)
 		return nil, false
 	}
-	if !hmac.Equal(got, credMAC(p.Password)) {
+	if !hmac.Equal(got, sp.pwMAC) {
 		return nil, false
 	}
-	return &p, true
+	// Rebuild the principal for the caller from the non-secret fields; the plaintext
+	// password was discarded at construction and no caller reads Principal.Password.
+	return &Principal{
+		Name:         sp.name,
+		DefaultInbox: sp.defaultInbox,
+		Reads:        sp.reads,
+		Sends:        sp.sends,
+	}, true
 }

--- a/internal/listener/auth_test.go
+++ b/internal/listener/auth_test.go
@@ -46,6 +46,24 @@ func TestAuthPerAgent(t *testing.T) {
 	assert.False(t, ok, "agent-a's password must not authenticate agent-b")
 }
 
+// #266: the credential digest is computed at construction and the plaintext is
+// discarded, so the authenticated Principal handed back to callers carries no
+// password. This is the observable half of the structural pin — Verify has no plaintext
+// in scope to compare against, so a regression to plaintext storage would have to
+// visibly re-add it (and re-populate this field) rather than slip past every
+// behavioural test the way a raw-byte-compare revert does. The non-secret grants are
+// still propagated, so the reconstruction is checked too.
+func TestAuthReturnedPrincipalCarriesNoPlaintext(t *testing.T) {
+	a := listener.NewAuth([]listener.Principal{
+		{Name: "agent", Password: "s3cret", DefaultInbox: "in"},
+	})
+	p, ok := a.Verify("agent", "s3cret")
+	assert.True(t, ok)
+	assert.Equal(t, "agent", p.Name)
+	assert.Equal(t, "in", p.DefaultInbox, "non-secret grants are still propagated")
+	assert.Empty(t, p.Password, "the authenticated principal must not carry the plaintext credential")
+}
+
 // An empty Auth authenticates no one (no panic on the miss path).
 func TestAuthEmpty(t *testing.T) {
 	a := listener.NewAuth(nil)


### PR DESCRIPTION
## Why

The C31 constant-time agent-auth fix compares fixed-width keyed MACs of the presented and stored passwords. That property is **invisible to any behavioural test** — a raw byte compare agrees with the MAC compare on every non-colliding input, so a revert to a raw compare leaves every assertion green and can only be caught by review.

## What

Pin the property structurally so a regression is reviewable rather than silent:

- `NewAuth` MACs each credential **at construction** and stores only the digest in an internal `storedPrincipal`; the plaintext is discarded.
- `Verify` MACs only the presented password and compares it against the precomputed digest. There is then **no plaintext in scope** to revert a raw compare to — a future regression would have to visibly re-add plaintext credential storage.
- The not-found path compares against a **precomputed dummy MAC** (previously MAC'd per call), so found and not-found still do identical work — the username-existence timing symmetry is preserved now that the stored side is precomputed.
- Side benefit: agent passwords are no longer retained in memory past startup.

The authenticated `Principal` handed back to callers is rebuilt from the non-secret grants only — verified that no caller reads `Principal.Password` (`internal/listener/smtp.go`, `imap.go` use only `Name`/`Reads`/`Sends`).

## Test

`TestAuthReturnedPrincipalCarriesNoPlaintext` pins the observable half — the returned principal carries no plaintext and the non-secret grants still propagate. The timing property itself remains review-verified (unit-invisible), as documented on `Verify`.

## Scope

`internal/listener/auth.go` (+ test). No exported-shape change: `NewAuth`/`SingleAuth` still take plaintext and hash on the way in.

Sequenced after #262 per the queue; independent of it (different package), so it can land in either order.

Closes #266