### PR TITLE
fix: anchor hold-card truncation caveat ahead of the gloss clauses (#282)

### DIFF
--- a/internal/listener/auth.go
+++ b/internal/listener/auth.go
@@ -12,7 +12,11 @@ import (
 // inboxes it may read / send as. A principal with nil Reads/Sends is unrestricted
 // — the single-agent / back-compat case, where the one agent sees every inbox.
 type Principal struct {
-	Name         string
+	Name string
+	// Password is input-only: NewAuth/SingleAuth read it to compute the stored
+	// credential MAC and it is never populated on a Principal returned by Verify (#266).
+	// A verified principal's Password is always empty — empty by design, not a
+	// misconfiguration.
 	Password     string
 	DefaultInbox string
 	Reads        map[string]bool
@@ -41,12 +45,14 @@ type Auth struct {
 }
 
 // storedPrincipal is the internal record NewAuth keeps for each agent: the non-secret
-// grants plus the fixed-width MAC of the credential (pwMAC). The plaintext password is
-// hashed at construction and never retained, so Verify has no plaintext in scope to
-// compare against — a regression to a raw byte compare would have to visibly re-add
-// plaintext credential storage, which is reviewable, rather than being invisible to
-// every behavioural test (#266, C31 follow-up). A side benefit is that agent passwords
-// are not held in memory past startup.
+// grants plus the fixed-width MAC of the credential (pwMAC). It holds no plaintext
+// password, so Verify has none in scope to compare against — a regression to a raw byte
+// compare would have to visibly re-add plaintext credential storage, which is reviewable
+// rather than invisible to every behavioural test (#266, C31 follow-up). This narrows
+// where the plaintext lives; it does not remove it — the caller's Principal slice still
+// carries the password (and it arrives via the environment, which the process retains
+// for its lifetime regardless), so this is a smaller-surface claim, not "the password is
+// gone from memory".
 type storedPrincipal struct {
 	name         string
 	defaultInbox string

--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -137,24 +137,33 @@ func holdAssessmentLine(a *inbound.Assessment) string {
 		}
 		return "could not be assessed (held fail-safe)"
 	}
-	// Band + score in operator terms; the factor identifiers ("secrets_request")
-	// named the rule that fired without saying what it means, so they are replaced by
-	// a fixed gloss (glossFactors). The rest of the stored summary is dropped — it only
-	// restated those same identifiers — EXCEPT its truncation caveat, which is not a
-	// restatement but a statement of how far the score can be trusted (it was computed
-	// on partial content). That caveat is preserved here rather than left to the
-	// fenced-body section, because the degraded cards (fetch-failed, no readable body)
-	// return before that section, so this line is the only place it survives on those
-	// paths — which are exactly the cards where the operator cannot read the body to
-	// judge for themselves (#262, review). Recognised by the assessor's exported
-	// constant, not by matching the prose, so a reword of the note is a compile-time
-	// change here rather than a silent loss.
+	// Band + score in operator terms, then the trust caveat (if any), then the factor
+	// glosses. Two things drive the content and the order:
+	//   - The factor identifiers ("secrets_request") named the rule that fired without
+	//     saying what it means, so they are replaced by a fixed gloss (glossFactors); the
+	//     rest of the stored summary is dropped, it only restated those identifiers.
+	//   - EXCEPT the summary's truncation caveat, which is not a restatement but a
+	//     statement of how far the score can be trusted (it was computed on partial
+	//     content). It is kept here rather than left to the fenced-body section, because
+	//     the degraded cards (fetch-failed, no readable body) return before that section,
+	//     so this line is the only place it survives on those paths — exactly the cards
+	//     where the operator cannot read the body to judge for themselves (#262, review).
+	// The caveat goes AHEAD of the gloss clauses so that if this line is ever clamped
+	// (clampField, 300 runes) the enumerable factor detail is truncated first and the
+	// trust qualifier stays anchored: a shortened factor list is degraded information, a
+	// dropped "scored on partial content" is misleading — the precise failure this change
+	// exists to fix, which must not be re-armed by later prose growth (review).
+	//
+	// The caveat is recognised by the assessor's exported constant, which makes a reword
+	// of the note a compile-time change for THIS renderer. It does NOT protect records
+	// already on disk: those keep the old wording and would silently stop matching after
+	// a reword — the residue a structured flag removes (#280).
 	line := fmt.Sprintf("%s risk (%d)", a.Band, a.Score)
-	if reason := glossFactors(a.Factors); reason != "" {
-		line += " — " + reason
-	}
 	if strings.Contains(a.Summary, assessor.TruncationNote) {
 		line += " — scored on partial content (message was truncated during extraction)"
+	}
+	if reason := glossFactors(a.Factors); reason != "" {
+		line += " — " + reason
 	}
 	return line
 }

--- a/internal/telegram/holds_internal_test.go
+++ b/internal/telegram/holds_internal_test.go
@@ -91,6 +91,14 @@ func TestFormatHoldPreservesTruncationCaveat(t *testing.T) {
 	assert.Contains(t, s, "asks the reader to send or confirm a credential", "the gloss is still rendered")
 	assert.NotContains(t, s, "Detected injection-risk factors", "the identifier restatement is still dropped")
 
+	// The caveat is anchored AHEAD of the gloss clauses, so a clamp (clampField, 300
+	// runes) or later prose growth truncates the enumerable factor detail first and never
+	// the trust qualifier (review). Pinning the order keeps that precedence from being
+	// silently reversed back to "caveat last", which would re-arm the very failure this
+	// fix removes.
+	assert.Less(t, strings.Index(s, "partial content"), strings.Index(s, "asks the reader"),
+		"the truncation caveat must precede the factor glosses so a clamp sacrifices the list, not the caveat")
+
 	// A non-truncated assessment carries no caveat.
 	m2 := inbound.Message{ID: "22", Assessment: &inbound.Assessment{
 		Disposition: inbound.AssessmentHeld, Score: 70, Band: "high",


### PR DESCRIPTION
Review-deferred cleanups collected in one PR: the renderer caveat-ordering (#282) and the two listener doc fixes (#284).

## 1. Anchor the truncation caveat ahead of the gloss clauses (`internal/telegram`, `internal/assessor`) — #282

#278 preserved the truncation caveat ("scored on partial content") on the assessment line so it reaches the degraded hold cards (fetch-failed, no readable body) where the fenced-body marker is unreachable — but placed it **last** on that line, which is field-clamped at 300 runes. Worst case measured ~242 runes (~58 headroom), all editable prose, nothing pinning it; a later reword could silently truncate the caveat away on exactly the cards it protects.

- Move the caveat **ahead of** the enumerable factor glosses, so a clamp sacrifices the factor list first and the trust qualifier stays anchored — a shortened list is degraded information, a dropped caveat is misleading.
- Pin the order with a test so it can't be silently reversed (the durable half — the reorder changes what is sacrificed; the guard makes any future violation loud).
- Narrow the doc claim: recognising the note by the exported `assessor.TruncationNote` constant is a compile-time safeguard for the renderer only; records already on disk keep the old wording and would stop matching silently — the residue the structured flag (#280) removes.

## 2. Cross-package touch — `internal/listener` (doc-only) — #284

Two comment/doc fixes deferred from the #266 review, no behaviour change:

- The `storedPrincipal` comment claimed as a side benefit that agent passwords are not held in memory past startup. That is false twice over — the caller's `Principal` slice still carries the plaintext through serve setup, and the password arrives via the environment, which the process retains for its lifetime. Narrowed to the true, smaller-surface claim (`storedPrincipal` holds no plaintext, so `Verify` has none in scope).
- Documented that `Principal.Password` is input-only: read by `NewAuth`/`SingleAuth` to compute the stored MAC, never populated on a `Verify` result — so a verified principal's empty `Password` is empty by design, not misconfiguration.

## Verification

`go build`, `gofmt -l`, `golangci-lint run` (v2.11.4, 0 issues), `go test -race ./internal/listener/... ./internal/telegram/...` all clean.

Closes #282
Closes #284