### PR TITLE
fix: harden hold-card caveat order-guard against a vacuous pass (#285)

### DIFF
--- a/internal/telegram/holds_internal_test.go
+++ b/internal/telegram/holds_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/yaad-index/darbaan/internal/assessor"
 	"github.com/yaad-index/darbaan/internal/inbound"
@@ -93,9 +94,19 @@ func TestFormatHoldPreservesTruncationCaveat(t *testing.T) {
 
 	// The caveat is anchored AHEAD of the gloss clauses, so a clamp (clampField, 300
 	// runes) or later prose growth truncates the enumerable factor detail first and never
-	// the trust qualifier (review). Pinning the order keeps that precedence from being
-	// silently reversed back to "caveat last", which would re-arm the very failure this
-	// fix removes.
+	// the trust qualifier. This is deliberately an ORDERING guard, a stronger substitute
+	// for a raw clamp-survival check: growth in the gloss clauses now sacrifices the list
+	// by construction rather than by a measured margin. It does not cover text inserted
+	// AHEAD of the caveat — remote, since the caveat sits in the first ~100 runes behind
+	// fixed strings — a residual recorded in #285.
+	//
+	// require, not assert: strings.Index returns -1 for a missing substring, and -1 is
+	// less than any real index, so a caveat that stopped rendering entirely would pass the
+	// ordering assertion vacuously. Fail HERE if it is absent, so this check is
+	// self-sufficient rather than relying on the presence assertion several lines above —
+	// which someone could later move, gate behind an early return, or split off without
+	// realising this one depends on it (#285).
+	require.Contains(t, s, "partial content", "the truncation caveat must be present for the ordering check to mean anything")
 	assert.Less(t, strings.Index(s, "partial content"), strings.Index(s, "asks the reader"),
 		"the truncation caveat must precede the factor glosses so a clamp sacrifices the list, not the caveat")
 


### PR DESCRIPTION
Follow-up from the #283 review.

## Problem

The ordering assertion added in #283 (`TestFormatHoldPreservesTruncationCaveat`) compares `strings.Index` of the caveat and a gloss substring. `strings.Index` returns `-1` for a missing substring, and `-1` is less than any real index — so a caveat that stopped rendering entirely would **pass** the ordering check, not fail it. The guard was self-protecting against a *reorder* but not against a *disappearance*; that case was caught only by a separate, non-fatal presence assertion several lines above, which a later refactor could move or gate behind an early return without realising this check depended on it.

## Change (test-only)

- Add `require.Contains(caveat)` immediately before the `assert.Less`, so an absent caveat fails there and the ordering check is self-sufficient regardless of the earlier assertion.
- Record in the comment that this is deliberately an **ordering** guard — a stronger substitute for a raw clamp-survival check, since gloss growth now truncates the factor list by construction rather than by a measured margin — and that it does not cover text inserted *ahead* of the caveat (remote, given the caveat's position in the first ~100 runes behind fixed strings).

## Mutation-verified

Neutered the caveat rendering on this branch and ran the test: it now fails at the `require` line with "the truncation caveat must be present for the ordering check to mean anything". Before this change the ordering assertion passed vacuously on `-1 < index`. A guard shown to go red for its stated reason.

`go build`, `gofmt -l`, `golangci-lint run` (v2.11.4, 0 issues), `go test -race ./internal/telegram/...` all clean.

Closes #285