### PR TITLE
fix: persist a structured truncation flag on the assessment (#280)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -619,6 +619,11 @@ func (cli *CLI) buildAssessHook(inboxes []inboxcfg.Inbox, resolve inbound.Proven
 // rendered record (only the system-defined Summary crosses to a human).
 func outcomeToAssessment(o screener.Outcome) *inbound.Assessment {
 	r := o.Result
+	// Every record this version writes carries a non-nil Truncated, so nil is
+	// reserved to mean "persisted before the field existed" (the legacy cohort the
+	// renderer falls back to prose for). Take the address of a local copy, not of the
+	// value-receiver field, so the pointer is independent of o.
+	truncated := o.Truncated
 	return &inbound.Assessment{
 		Disposition: string(r.Disposition),
 		NotCleared:  r.NotCleared,
@@ -626,6 +631,7 @@ func outcomeToAssessment(o screener.Outcome) *inbound.Assessment {
 		Band:        string(r.Band),
 		Factors:     factorStrings(r.Factors),
 		Summary:     o.Summary,
+		Truncated:   &truncated,
 	}
 }
 

--- a/internal/assessor/assessor.go
+++ b/internal/assessor/assessor.go
@@ -32,13 +32,20 @@ import (
 	"github.com/yaad-index/darbaan/internal/riskscore"
 )
 
-// Assessment is the assessor's output: the flagged factors and a sanitized
-// summary that is safe to surface. It never carries a score — the scorer composes
-// that from these factors — and its summary never echoes raw attacker text as
-// instructions.
+// Assessment is the assessor's output: the flagged factors, a structural
+// truncation flag, and a sanitized summary that is safe to surface. It never
+// carries a score — the scorer composes that from these factors — and its summary
+// never echoes raw attacker text as instructions.
 type Assessment struct {
 	Factors []riskscore.Factor
-	Summary string
+	// Truncated reports that the extraction feeding this assessment hit its caps, so
+	// the factors were detected on partial content. It carries the same fact the
+	// summary states in prose (see TruncationNote), but as a structured value a
+	// consumer can key on without matching the sentence — the caveat then survives a
+	// reword and cannot be dropped by prose edits (#280). It is the assessor's own
+	// input (mailtext.Content.Truncated), recorded here, never re-derived downstream.
+	Truncated bool
+	Summary   string
 }
 
 // Detector detects risk factors in extracted message content. Implementations
@@ -129,7 +136,7 @@ func (a *Assessor) Assess(ctx context.Context, c mailtext.Content) (Assessment, 
 	// cross the boundary" invariant.
 	factors = a.filterDeclared(factors)
 	factors = dedupeSort(factors)
-	return Assessment{Factors: factors, Summary: summarize(factors, c.Truncated)}, nil
+	return Assessment{Factors: factors, Truncated: c.Truncated, Summary: summarize(factors, c.Truncated)}, nil
 }
 
 // filterDeclared drops any factor the detector did not declare at construction.
@@ -178,10 +185,15 @@ func dedupeSort(factors []riskscore.Factor) []riskscore.Factor {
 // TruncationNote is the caveat summarize appends when the extraction that fed the
 // assessment hit its caps: the record's one statement that the score was computed on
 // partial content, which — unlike the factor list — says how far the verdict can be
-// trusted rather than what fired. Exported so a consumer that re-surfaces the caveat
-// (the operator hold card, #262) can recognise it in the stored summary by constant
-// rather than by matching the prose; a reword is then a compile-time change for that
-// consumer instead of a silent loss.
+// trusted rather than what fired.
+//
+// The authoritative signal a consumer keys on is now the structured Truncated flag
+// (Assessment.Truncated, persisted per #280), not this prose. The constant remains
+// exported as the LEGACY recogniser: records persisted before the flag existed carry
+// no flag, and a consumer falls back to matching this constant in their stored
+// summary to recover the caveat for that cohort. It is a constant rather than a bare
+// string literal so that legacy match is a compile-time reference, and a reword stays
+// a compile-time change for the fallback instead of a silent loss.
 const TruncationNote = "message content was truncated during extraction"
 
 // summarize renders a sanitized, factual summary. Its signature is deliberately

--- a/internal/assessor/assessor_test.go
+++ b/internal/assessor/assessor_test.go
@@ -94,6 +94,19 @@ func TestSummaryTruncationNoted(t *testing.T) {
 	got, err := a.Assess(context.Background(), mailtext.Content{Truncated: true})
 	require.NoError(t, err)
 	assert.Contains(t, got.Summary, "truncated")
+	assert.True(t, got.Truncated, "the structured flag records the same fact the prose states")
+}
+
+// The structured Truncated flag tracks the extraction input, not the prose: a
+// non-truncated assessment reports false and appends no caveat, and the flag mirrors
+// the caps input so a consumer can key on it without matching the summary (#280).
+func TestAssessTruncationFlagTracksInput(t *testing.T) {
+	a, err := New(&fakeDetector{})
+	require.NoError(t, err)
+	got, err := a.Assess(context.Background(), mailtext.Content{Truncated: false})
+	require.NoError(t, err)
+	assert.False(t, got.Truncated, "a non-truncated extraction sets the flag false")
+	assert.NotContains(t, got.Summary, TruncationNote, "and appends no caveat")
 }
 
 // TestSummaryHasZeroAttackerBytes pins the hard invariant: the summary names

--- a/internal/inbound/inbound.go
+++ b/internal/inbound/inbound.go
@@ -146,6 +146,15 @@ type Assessment struct {
 	Band        string   `json:"band,omitempty"`
 	Factors     []string `json:"factors,omitempty"`
 	Summary     string   `json:"summary,omitempty"` // sanitized, safe to surface to a human
+	// Truncated is the structured trust caveat: true means the score was computed on
+	// partial content (an extraction cap was hit). It is a pointer so the store can
+	// distinguish three states, which a plain bool cannot under encoding/json (absent
+	// and false both decode to false): nil = a record persisted before this field
+	// existed (the caveat, if any, survives only in Summary prose — see
+	// assessor.TruncationNote); non-nil = an authoritative flag this version wrote.
+	// A consumer reads the flag when present and falls back to the prose only for the
+	// nil (legacy) cohort, so new records never depend on the summary wording (#280).
+	Truncated *bool `json:"truncated,omitempty"`
 }
 
 // Assessment disposition values. These mirror the scorer's disposition strings;

--- a/internal/screener/screener.go
+++ b/internal/screener/screener.go
@@ -39,6 +39,13 @@ type Outcome struct {
 	// when the content assessor actually ran (not on a short-circuit hold or a
 	// fail-safe not-cleared), and never contains message bytes.
 	Summary string
+	// Truncated reports that the assessed content was extracted on partial bytes
+	// (an extraction cap was hit), so the factors — and the composed score — reflect
+	// only what was read. Like Summary it is meaningful only when the assessor ran;
+	// on a short-circuit hold or a fail-safe not-cleared it stays false, since no
+	// content was scored on those paths. Carried structurally so the persisted
+	// assessment records the trust caveat as a value rather than in prose (#280).
+	Truncated bool
 }
 
 // Screener orchestrates one message's assessment.
@@ -108,8 +115,9 @@ func (s *Screener) Screen(ctx context.Context, raw []byte, trust string, recipie
 		return Outcome{Result: riskscore.NotCleared(fmt.Sprintf("held: assessment did not complete: %v", err))}
 	}
 	return Outcome{
-		Result:  s.scorer.Compose(cheap, assessment.Factors),
-		Summary: assessment.Summary,
+		Result:    s.scorer.Compose(cheap, assessment.Factors),
+		Summary:   assessment.Summary,
+		Truncated: assessment.Truncated,
 	}
 }
 

--- a/internal/screener/screener_test.go
+++ b/internal/screener/screener_test.go
@@ -87,6 +87,7 @@ func TestScreenShortCircuitSkipsAssessor(t *testing.T) {
 	assert.Equal(t, 0, det.calls, "the assessor must not run on a short-circuit")
 	assert.Equal(t, 0, extractCalls, "extraction must not run on a short-circuit")
 	assert.Empty(t, out.Summary)
+	assert.False(t, out.Truncated, "no content was scored on a short-circuit, so the flag stays false")
 }
 
 func TestScreenAgentHandled(t *testing.T) {
@@ -157,6 +158,7 @@ func TestScreenTruncatedButDecodableProceeds(t *testing.T) {
 	out := s.Screen(context.Background(), []byte("raw"), provenance.TrustTrusted, riskscore.RecipientTo)
 	assert.Equal(t, 1, det.calls, "a benign cap truncation still runs the assessor")
 	assert.False(t, out.Result.NotCleared, "a cap hit is not a fail-safe hold")
+	assert.True(t, out.Truncated, "the outcome carries the structured truncation flag when the assessor scored partial content")
 }
 
 func TestScreenAssessorErrorIsNotCleared(t *testing.T) {

--- a/internal/telegram/holds.go
+++ b/internal/telegram/holds.go
@@ -154,18 +154,34 @@ func holdAssessmentLine(a *inbound.Assessment) string {
 	// dropped "scored on partial content" is misleading — the precise failure this change
 	// exists to fix, which must not be re-armed by later prose growth (review).
 	//
-	// The caveat is recognised by the assessor's exported constant, which makes a reword
-	// of the note a compile-time change for THIS renderer. It does NOT protect records
-	// already on disk: those keep the old wording and would silently stop matching after
-	// a reword — the residue a structured flag removes (#280).
+	// The caveat is driven by the stored structured flag (a.Truncated), computed once
+	// at ingest, so the render no longer depends on the summary prose for records this
+	// version wrote — a reword of the note cannot drop it. Records persisted before the
+	// flag existed carry a nil flag; for that legacy cohort only, assessmentTruncated
+	// falls back to matching the assessor's exported constant in the stored summary, so
+	// the caveat still survives on old partial-content cards (#280).
 	line := fmt.Sprintf("%s risk (%d)", a.Band, a.Score)
-	if strings.Contains(a.Summary, assessor.TruncationNote) {
+	if assessmentTruncated(a) {
 		line += " — scored on partial content (message was truncated during extraction)"
 	}
 	if reason := glossFactors(a.Factors); reason != "" {
 		line += " — " + reason
 	}
 	return line
+}
+
+// assessmentTruncated reports whether the score was computed on partial content.
+// It reads the structured flag as authoritative when present (a record this version
+// wrote), and only falls back to the summary prose for the legacy cohort whose
+// records predate the flag (a.Truncated nil) — the state a plain bool could not
+// represent, which is why the stored field is a pointer (#280). A non-nil false is
+// therefore honoured as "not truncated" without consulting the prose, so a new
+// record never depends on the summary wording.
+func assessmentTruncated(a *inbound.Assessment) bool {
+	if a.Truncated != nil {
+		return *a.Truncated
+	}
+	return strings.Contains(a.Summary, assessor.TruncationNote)
 }
 
 // factorGloss maps each system-defined risk factor to one operator-facing clause

--- a/internal/telegram/holds_internal_test.go
+++ b/internal/telegram/holds_internal_test.go
@@ -1,6 +1,7 @@
 package telegram
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -117,6 +118,68 @@ func TestFormatHoldPreservesTruncationCaveat(t *testing.T) {
 	}}
 	assert.NotContains(t, formatHold(m2, nil, false), "partial content")
 }
+
+// #280: the truncation caveat is now driven by the STRUCTURED flag, not the summary
+// prose. This pins the four states that matter, and demonstrates the mutation by its
+// effect on the EMITTED CARD (the caveat clause appears/disappears) rather than by an
+// assertion failing — a negative control is only a control if it is reachable in
+// production and shown to change the output. The factor throughout is secrets_request,
+// which the heuristic detector actually emits, so the rest of the card renders and the
+// mutation exercises a real rendering path.
+func TestFormatHoldTruncationStructuralFlag(t *testing.T) {
+	const gloss = "asks the reader to send or confirm a credential" // secrets_request, emittable
+	card := func(a *inbound.Assessment) string {
+		return formatHold(inbound.Message{ID: "280", Assessment: a}, nil, false)
+	}
+	// base is an ordinary held assessment whose summary carries NO truncation note, so
+	// any caveat on the card can only have come from the structured flag.
+	base := func() *inbound.Assessment {
+		return &inbound.Assessment{
+			Disposition: inbound.AssessmentHeld, Score: 70, Band: "high",
+			Factors: []string{"secrets_request"},
+			Summary: "Detected injection-risk factors: secrets_request.",
+		}
+	}
+
+	// (1) Structural flag true drives the caveat with no help from the prose — the whole
+	// point of #280: the render no longer depends on the summary wording.
+	withFlag := card(func() *inbound.Assessment { a := base(); a.Truncated = boolPtr(true); return a }())
+	assert.Contains(t, withFlag, "partial content", "a true flag renders the caveat though the summary has no note")
+	assert.Contains(t, withFlag, gloss)
+
+	// (2) The mutation: flip the flag true→false on an otherwise identical record. A
+	// false flag is an ordinary non-truncated assessment — reachable in production — so
+	// this control is real. The caveat clause leaves the EMITTED card; the gloss stays.
+	withoutFlag := card(func() *inbound.Assessment { a := base(); a.Truncated = boolPtr(false); return a }())
+	assert.NotContains(t, withoutFlag, "partial content", "flipping the flag to false removes the caveat from the card")
+	assert.Contains(t, withoutFlag, gloss, "only the caveat changes; the rest of the card is identical")
+	require.NotEqual(t, withFlag, withoutFlag, "the mutation must change the emitted output, not merely fail an assertion")
+
+	// (3) A non-nil false flag is AUTHORITATIVE over the prose: even a summary that still
+	// carries the note shows no caveat, so a new record never re-derives truncation from
+	// the wording the flag replaced.
+	authoritative := base()
+	authoritative.Truncated = boolPtr(false)
+	authoritative.Summary = "Detected injection-risk factors: secrets_request. Note: " + assessor.TruncationNote + "."
+	assert.NotContains(t, card(authoritative), "partial content",
+		"a false flag wins over a stray note in the summary — the prose is not consulted for new records")
+
+	// (4) The migration cohort: a record persisted BEFORE the field existed. Built from
+	// JSON with the key OMITTED — not set to false, which is a different input that would
+	// test a new record wearing an old record's name. The flag must decode to nil (the
+	// legacy state), and the caveat must survive via the summary-prose fallback — the
+	// exact partial-content cards the string match protects today, which the fix must not
+	// silently drop.
+	var legacy inbound.Assessment
+	require.NoError(t, json.Unmarshal([]byte(
+		`{"disposition":"held","score":70,"band":"high","factors":["secrets_request"],`+
+			`"summary":"Detected injection-risk factors: secrets_request. Note: `+assessor.TruncationNote+`."}`), &legacy))
+	require.Nil(t, legacy.Truncated, "an omitted key must decode to nil, or this exercises the wrong cohort")
+	assert.Contains(t, card(&legacy), "partial content",
+		"a legacy record with no flag keeps the caveat via the summary-prose fallback")
+}
+
+func boolPtr(b bool) *bool { return &b }
 
 // A fail-safe (not-cleared) hold shows "could not be assessed" with no band/score.
 func TestFormatHoldNotCleared(t *testing.T) {


### PR DESCRIPTION
## What

Persist the truncation caveat as a **structured flag** on the assessment instead of recovering it by matching the summary prose. Closes #280.

0.18.0 recovers *"this score was computed on partial content"* on the operator hold card by string-matching the assessor's truncation note in the stored summary. That recovery is prose-shaped: a reword of the note — or an edit that drops it — silently loses the caveat, and loses it precisely on the fetch-failed / no-readable-body cards, the ones asking the operator to decide **without having seen the message**. The existing guard is real but still string-shaped; this makes the fact structural.

## How

The assessor already knows the fact (`mailtext.Content.Truncated`). Carry it as a value end-to-end:

- `assessor.Assessment.Truncated` — recorded from the extraction input, not re-derived.
- `screener.Outcome.Truncated` — propagated (meaningful only when the assessor ran; false on short-circuit / fail-safe, where nothing was scored).
- `inbound.Assessment.Truncated` — **persisted**, so the renderer keys on the value.
- `telegram` hold card — reads the flag; the prose match survives only as a legacy fallback.

## Migration cohort (the trap this fix must not spring)

Replacing a string match with a flag creates a set of assessments persisted **before the field existed**. Those records have no key, and — established from the storage layer, not the struct — under `encoding/json` a plain `bool` **cannot distinguish absent from false** (both decode to `false`), which would drop the caveat on exactly the old partial-content cards the string match protects today.

The persisted field is therefore a **`*bool` (tri-state)**:

- `nil` = a record written before the field existed → fall back to the summary-prose match **for that cohort only**.
- non-nil = an authoritative flag this version wrote → read directly, never consult the prose.

Every record this version writes sets a non-nil flag, so `nil` means "legacy" exactly. The prose stays in the summary as the legacy recogniser and can be retired once the pre-field cohort ages out.

## Tests

The render guard is pinned on four states and demonstrated **by its effect on the emitted card** — the caveat clause appears/disappears — not merely by an assertion firing:

1. flag `true`, summary carries no note → caveat renders (driven by the flag alone);
2. flip `true → false` on an otherwise-identical record → caveat leaves the card, gloss unchanged (`NotEqual` on the emitted strings — a false flag is an ordinary non-truncated assessment, so the negative control is reachable in production);
3. flag non-nil `false` with a stray note still in the summary → no caveat (flag is authoritative; prose not consulted for new records);
4. **legacy cohort** — built from a fixture with the key **omitted** (asserted to decode to `nil`, so it exercises the pre-field cohort a key-set-to-`false` fixture would not) → caveat survives via the prose fallback.

Verified both directions by mutation: ignoring the flag drops the caveat on a flagged card; dropping the legacy fallback drops it on the omitted-key card. Local gate green — `go build`, `go vet`, `gofmt`, `golangci-lint` v2.11.4 (0 issues), `go test -race ./...`.

## Cross-package touch

The flag threads through four packages beyond `telegram`: `assessor` (source of truth), `screener` (`Outcome` plumbing), `inbound` (persisted schema field), and `cmd/darbaan` (`outcomeToAssessment` sets the non-nil pointer). Each is the minimal carry needed to get the value from extraction to render; no behaviour changes on those paths.

## Release note

Runtime-affecting, so `fix:` per the conventional-commit rule (not a hidden type). Landing this cuts the next release and sweeps up the already-merged test-only change, so the standalone `0.18.1` PR can stay unopened.
