### PR TITLE
chore: pin the tri-state truncation invariant with a store round-trip (#289)

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -621,8 +621,9 @@ func outcomeToAssessment(o screener.Outcome) *inbound.Assessment {
 	r := o.Result
 	// Every record this version writes carries a non-nil Truncated, so nil is
 	// reserved to mean "persisted before the field existed" (the legacy cohort the
-	// renderer falls back to prose for). Take the address of a local copy, not of the
-	// value-receiver field, so the pointer is independent of o.
+	// renderer falls back to prose for). The local is just the idiom for taking a
+	// pointer to a value; o is a by-value parameter, so &o.Truncated would be equally
+	// caller-independent — the copy is not needed for that.
 	truncated := o.Truncated
 	return &inbound.Assessment{
 		Disposition: string(r.Disposition),

--- a/internal/inbound/assessment_test.go
+++ b/internal/inbound/assessment_test.go
@@ -51,6 +51,43 @@ func TestSetContentNilAssessmentNotHeld(t *testing.T) {
 	assert.Nil(t, plain.Assessment)
 }
 
+// #289: pin the tri-state truncation invariant. A non-nil false Truncated
+// ("assessed on complete content" — explicitly NOT the legacy/unknown state) must
+// survive a full persist+reload still non-nil AND still false. Both ways the
+// invariant breaks — a future write path leaving the pointer nil, or a non-nil false
+// failing to serialize — land on the same silent outcome: a fresh record reloaded as
+// nil, which assessmentTruncated reads as "legacy" and the prose fallback renders
+// identically, so nothing surfaces it.
+//
+// Level pinned: the STORE. This asserts through SetContentAssessed→Get — the bbolt
+// encoding/json persistence path (the `stored` record) — not a bare struct marshal.
+// Today the persisted record IS the struct under encoding/json with no intermediate
+// representation, so struct-level and store-level coincide; that coincidence is
+// exactly what this must outlive. A later DTO or custom marshaler that dropped the
+// field would leave a struct-level round trip green while reintroducing the defect one
+// layer up — the same silent failure the pin exists to prevent.
+func TestAssessmentTruncatedFalseSurvivesStoreRoundTrip(t *testing.T) {
+	s := newStore(t)
+	_, m, err := s.AddSyncedPending(inbound.Delivery{Owner: "agent", UpstreamUID: 1, UIDValidity: 1})
+	require.NoError(t, err)
+
+	no := false // non-nil false: the state a plain bool cannot distinguish from absent
+	a := &inbound.Assessment{
+		Disposition: inbound.AssessmentAgentHandled, Score: 10, Band: "low",
+		Truncated: &no,
+	}
+	_, err = s.SetContentAssessed("agent", inbound.DefaultInbox, m.ID, []byte("Subject: x\r\n\r\nbody"), a)
+	require.NoError(t, err)
+
+	got, err := s.Get("agent", inbound.DefaultInbox, m.ID)
+	require.NoError(t, err)
+	require.NotNil(t, got.Assessment)
+	require.NotNil(t, got.Assessment.Truncated,
+		"a non-nil false must survive persist+reload still non-nil — else a fresh not-truncated record reloads as nil and is misfiled as legacy (#289)")
+	assert.False(t, *got.Assessment.Truncated,
+		"and still false, so a later swap to a plain bool fails here loudly instead of silently re-entering the legacy cohort")
+}
+
 func TestHeldByAssessment(t *testing.T) {
 	assert.False(t, inbound.Message{}.HeldByAssessment(), "nil assessment is never held")
 	assert.True(t, inbound.Message{Assessment: &inbound.Assessment{Disposition: inbound.AssessmentHeld}}.HeldByAssessment())


### PR DESCRIPTION
## What

Pins the tri-state truncation invariant with a store-level round-trip assertion, and folds #289's second half (the over-stated copy-rationale comment). Closes #289. Not a present defect — the behaviour is correct today; this pins the invariant the whole tri-state design rests on so it fails loudly instead of silently.

## Commit type is `chore:` (hidden) — because the diff has zero runtime content

One `_test.go` file plus a comment-only edit, so a released type (`fix:`/`feat:`) would cut a phantom release for a runtime-identical binary and print a changelog line for a change no operator can observe — the conventional-commit type is a control input to release automation, not a label on effort. Note the rule used: "all files end in `_test.go` → hidden" is **one sufficient test** for zero-runtime, *not* the rule itself (read as a biconditional it wrongly implies a source file can't be hidden — a comment-only source change is hidden too). The rule is: zero runtime content → hidden type, whatever the extension.

## The invariant, and why pin it

`assessmentTruncated` treats a nil `Truncated` flag as "legacy, persisted before the field existed" and falls back to matching the summary prose — which is sound **only while every record this version writes carries a non-nil flag**, so nil means legacy *exactly*. Two ways that breaks, converging on one silent outcome:

1. a future write path leaves the pointer nil (a second construction site forgetting the field);
2. the existing path's non-nil `false` fails to survive serialization (a json-tag tidy, or a type tidy back to plain `bool`).

Both yield **a fresh record reloaded as nil → misfiled as legacy**, and it renders identically today because the fallback finds no note in the summary and emits no caveat — which is exactly why it would sit undetected. It also makes the prose-fallback retirement criterion ("drop it once the pre-field cohort ages out") unsatisfiable if fresh records keep re-entering that cohort.

## The test, and which level it pins

`TestAssessmentTruncatedFalseSurvivesStoreRoundTrip` sets `Truncated` to a non-nil `false`, persists via `SetContentAssessed`, reloads via `Get`, and asserts the field is **still non-nil AND still false**.

It pins the **store** level (the bbolt `encoding/json` path, the `stored` record) rather than a bare struct marshal — because the persisted record is the layer the invariant actually rests on, and a struct-level test would keep passing if a later DTO or custom marshaler dropped the field one layer up, which is the same silent failure this exists to prevent. Struct-level and store-level coincide *today* only because the record is that struct under `encoding/json` with no intermediate representation; the test comment names that coincidence as the thing it must outlive, so "it round-trips" is not later read as a claim about a layer nobody tested.

Both break-directions are covered:
- **swap to plain `bool`** → caught at **compile time** (the test assigns `&no`, a `*bool`).
- **fails to serialize** → caught at **runtime**: verified red under a `json:"-"` mutation on the field (fails on the non-nil assertion with the "misfiled as legacy" message), green on restore.

## Cross-package touch

- `internal/inbound/assessment_test.go` — the round-trip pin (test-only).
- `cmd/darbaan/main.go` — `outcomeToAssessment`: corrects the over-stated copy rationale. The old comment claimed the local copy was needed "so the pointer is independent of `o`", but `o` is a by-value parameter, so `&o.Truncated` would be equally caller-independent — the copy is fine, the stated reason was a constraint past its grounds.

Does **not** add a second `Assessment` construction site outside tests — exactly one is part of what keeps the invariant checkable.

## Verification

Local gate green: `go build ./...`, `go vet`, `gofmt`, `golangci-lint` v2.11.4 (0 issues), `go test -race ./...`.
