### PR TITLE
Log an outbound message arriving, not only its decisions

### DIFF
--- a/internal/sluice/bbolt.go
+++ b/internal/sluice/bbolt.go
@@ -148,6 +148,13 @@ func (s *bboltStore) Enqueue(sub Submission) (Message, error) {
 		return Message{}, fmt.Errorf("sluice: enqueue: %w", err)
 	}
 	s.writeAudit(audit.Record{Event: "enqueue", Agent: msg.Agent, Inbox: msg.Inbox, MessageID: msg.ID})
+	// Arrivals are logged as well as audited. Without this the process log is
+	// asymmetric: every decision transition logs, nothing logs a message
+	// arriving, so the log shows decisions on messages it never saw arrive. An
+	// operator reading it concludes the messages appeared from nowhere, and an
+	// absence in the log reads as "nothing happened" rather than "this path
+	// does not log". Recipients are deliberately counted, not named.
+	slog.Info("outbound message held", "message_id", msg.ID, "agent", msg.Agent, "inbox", msg.Inbox, "rcpt_count", len(msg.Rcpt))
 	return msg, nil
 }
 

--- a/internal/sluice/enqueue_log_internal_test.go
+++ b/internal/sluice/enqueue_log_internal_test.go
@@ -1,0 +1,55 @@
+package sluice
+
+import (
+	"bytes"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/audit"
+)
+
+// An arrival must reach the process log, not only the audit log.
+//
+// Before this, every decision transition logged while Enqueue logged nothing,
+// so the log showed decisions on messages it had never seen arrive. Reading it
+// during an incident, the messages looked as though they had appeared from
+// nowhere — an absence that reads as "nothing happened" when it actually means
+// "this path does not log".
+//
+// The audit record alone did not close that gap: the audit log has no read
+// interface, so the one place an operator can look is the process log.
+func TestEnqueueLogsArrival(t *testing.T) {
+	al, err := audit.New("null", "")
+	require.NoError(t, err)
+	ms, err := newBbolt(filepath.Join(t.TempDir(), "sluice.db"), al)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ms.Close(); _ = al.Close() })
+
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+	defer slog.SetDefault(old)
+
+	msg, err := ms.Enqueue(Submission{
+		Agent: "agent-x",
+		Inbox: "inbox-y",
+		Rcpt:  []string{"one@example.test", "two@example.test"},
+		Raw:   []byte("raw"),
+	})
+	require.NoError(t, err)
+
+	got := buf.String()
+	require.Contains(t, got, "outbound message held")
+	require.Contains(t, got, "message_id="+msg.ID)
+	require.Contains(t, got, "agent=agent-x")
+	require.Contains(t, got, "inbox=inbox-y")
+	require.Contains(t, got, "rcpt_count=2")
+
+	// Recipients are counted, never named: the process log is the widest-read
+	// surface here and an address is the one field with no operational use.
+	require.NotContains(t, got, "one@example.test")
+	require.NotContains(t, got, "two@example.test")
+}

--- a/internal/sluice/enqueue_log_internal_test.go
+++ b/internal/sluice/enqueue_log_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,15 +42,26 @@ func TestEnqueueLogsArrival(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	got := buf.String()
-	require.Contains(t, got, "outbound message held")
-	require.Contains(t, got, "message_id="+msg.ID)
-	require.Contains(t, got, "agent=agent-x")
-	require.Contains(t, got, "inbox=inbox-y")
-	require.Contains(t, got, "rcpt_count=2")
+	// Scope every assertion to the arrival line itself, not to the whole
+	// buffer. Buffer-wide Contains would still pass if the fields drifted onto
+	// separate log records — the test would be satisfied while the thing it
+	// exists to protect, one line an operator can grep, had broken.
+	var line string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		if strings.Contains(l, "outbound message held") {
+			require.Empty(t, line, "expected exactly one arrival line")
+			line = l
+		}
+	}
+	require.NotEmpty(t, line, "no arrival line logged")
+
+	require.Contains(t, line, "message_id="+msg.ID)
+	require.Contains(t, line, "agent=agent-x")
+	require.Contains(t, line, "inbox=inbox-y")
+	require.Contains(t, line, "rcpt_count=2")
 
 	// Recipients are counted, never named: the process log is the widest-read
 	// surface here and an address is the one field with no operational use.
-	require.NotContains(t, got, "one@example.test")
-	require.NotContains(t, got, "two@example.test")
+	require.NotContains(t, buf.String(), "one@example.test")
+	require.NotContains(t, buf.String(), "two@example.test")
 }


### PR DESCRIPTION
Closes half of #292 — the half that actively misleads.

## The problem

Every decision transition on a held message logs. `Enqueue` logs nothing. So the process log shows decisions on messages it never saw arrive.

During an incident that reads as though the messages appeared from nowhere: the log is silent across exactly the window in which they were submitted, while being loud either side of it. **An absence in the log gets read as "nothing happened" when it actually means "this path does not log"** — and that sends the reader looking for an external cause.

## Why the audit record was not enough

An audit record *is* written on enqueue, so the data exists. But the audit log has no read interface, only chain verification, so the process log is the one surface an operator can actually consult. Until that read path lands, an unlogged arrival is unreachable in practice.

## The change

One `slog.Info` on the enqueue path, matching the fields the decision paths already use.

**Recipients are counted, not named.** The process log is the widest-read surface here, and a recipient address is the one field with no operational use in it — the count answers "was this a fan-out?" without putting addresses in a log that gets pasted into issues.

## Test

`TestEnqueueLogsArrival` asserts the line, its fields, and that recipient addresses do **not** appear.

Verified it fails without the change — removing the `slog.Info` line gives `"" does not contain "outbound message held"` — so it is a test that can actually fail rather than one that passes by construction.

Full suite green.