### PR TITLE
feat(admin): audit ls — read the audit log live over the admin API

### DIFF
--- a/cmd/darbaan/main.go
+++ b/cmd/darbaan/main.go
@@ -14,6 +14,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -1148,7 +1149,91 @@ func (*VersionCmd) Run() error {
 // AuditCmd groups audit-log inspection subcommands. They open the audit database
 // directly (no running serve), so they operate on the on-disk chain.
 type AuditCmd struct {
+	Ls     AuditLsCmd     `cmd:"" help:"List audit log entries live via the running serve's admin API (ADR 0033)."`
 	Verify AuditVerifyCmd `cmd:"" help:"Verify the audit log's hash chain and sequence integrity (ADR 0011). Non-zero exit on any tampering or truncation."`
+}
+
+// AuditLsCmd lists audit entries through the running serve's admin API (ADR 0033),
+// not by opening the database — a read while serve holds the write lock would have
+// to stop the gate, and the incident case this exists for is a live one. It is a
+// thin admin-API client like the queue subcommands, and needs audit:read.
+type AuditLsCmd struct {
+	After     uint64 `name:"after" help:"Resume strictly after this sequence number (for paging)."`
+	Limit     int    `name:"limit" default:"100" help:"Maximum entries to return (the server caps a page at 1000)."`
+	Agent     string `name:"agent" help:"Only entries acted by this agent."`
+	MessageID string `name:"message-id" help:"Only entries for this message id."`
+	Since     string `name:"since" help:"Only entries at or after this time (RFC3339)."`
+	Until     string `name:"until" help:"Only entries before this time (RFC3339, half-open)."`
+	JSON      bool   `name:"json" help:"Emit line-delimited JSON entries instead of a table."`
+}
+
+func (c *AuditLsCmd) Run(cli *CLI) error {
+	client, err := cli.adminClient()
+	if err != nil {
+		return err
+	}
+	f := admin.AuditFilter{Agent: c.Agent, MessageID: c.MessageID}
+	if c.Since != "" {
+		t, err := time.Parse(time.RFC3339, c.Since)
+		if err != nil {
+			return fmt.Errorf("invalid --since (want RFC3339): %w", err)
+		}
+		f.Since = t
+	}
+	if c.Until != "" {
+		t, err := time.Parse(time.RFC3339, c.Until)
+		if err != nil {
+			return fmt.Errorf("invalid --until (want RFC3339): %w", err)
+		}
+		f.Until = t
+	}
+
+	entries, next, err := client.AuditList(context.Background(), f, c.After, c.Limit)
+	switch {
+	case errors.Is(err, admin.ErrAuditDisabled):
+		// Audit-off and backend-cannot-list are kept distinct on the way out too
+		// (ADR 0033 §4): each is a different operator state, not one generic empty.
+		fmt.Fprintln(os.Stderr, "audit is disabled (no audit backend configured); nothing to read")
+		return nil
+	case errors.Is(err, admin.ErrAuditNotListable):
+		fmt.Fprintln(os.Stderr, "the configured audit backend cannot list entries")
+		return nil
+	case err != nil:
+		return err
+	}
+
+	if len(entries) == 0 {
+		fmt.Fprintln(os.Stderr, "no audit entries match")
+		return nil
+	}
+
+	if c.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		for _, e := range entries {
+			if err := enc.Encode(e); err != nil {
+				return err
+			}
+		}
+	} else {
+		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		_, _ = fmt.Fprintln(w, "SEQ\tTIME\tEVENT\tAGENT\tINBOX\tACTOR\tMESSAGE_ID\tDETAIL")
+		for _, e := range entries {
+			r := e.Record
+			// Detail can carry upstream response text; sanitize the free-text fields
+			// before the operator's terminal like the queue table does (C22).
+			_, _ = fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				e.Seq, e.Time, sanitizeField(r.Event), sanitizeField(r.Agent), sanitizeField(r.Inbox),
+				sanitizeField(r.Actor), sanitizeField(r.MessageID), truncate(sanitizeField(r.Detail), 60))
+		}
+		if err := w.Flush(); err != nil {
+			return err
+		}
+	}
+
+	if next > 0 {
+		fmt.Fprintf(os.Stderr, "more entries; resume with --after %d\n", next)
+	}
+	return nil
 }
 
 // AuditVerifyCmd runs the audit log's integrity check (ADR 0011, C15): the

--- a/internal/admin/audit_list_test.go
+++ b/internal/admin/audit_list_test.go
@@ -1,0 +1,148 @@
+package admin_test
+
+import (
+	"context"
+	"net/http"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/yaad-index/darbaan/internal/admin"
+	"github.com/yaad-index/darbaan/internal/admincfg"
+	"github.com/yaad-index/darbaan/internal/audit"
+)
+
+// wireAudit gives svc a bbolt audit log and returns it so a test can append.
+func wireAudit(t *testing.T, svc *admin.Service) audit.AuditLog {
+	t.Helper()
+	al, err := audit.New("bbolt", filepath.Join(t.TempDir(), "audit.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = al.Close() })
+	svc.SetAuditLog(al)
+	return al
+}
+
+func auditSeqs(entries []audit.Entry) []uint64 {
+	out := make([]uint64, len(entries))
+	for i, e := range entries {
+		out[i] = e.Seq
+	}
+	return out
+}
+
+// The two no-read states stay distinct (ADR 0033 §4): no sink wired is
+// ErrAuditDisabled; a wired backend that cannot enumerate is ErrAuditNotListable.
+func TestAuditListDisabledVsNotListable(t *testing.T) {
+	svc, _, _ := newSvc(t) // no audit wired
+	_, _, err := svc.AuditList(admin.AuditFilter{}, 0, 10)
+	require.ErrorIs(t, err, admin.ErrAuditDisabled)
+
+	// The null backend appends/verifies but is not a Reader.
+	nl, err := audit.New("null", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nl.Close() })
+	svc.SetAuditLog(nl)
+	_, _, err = svc.AuditList(admin.AuditFilter{}, 0, 10)
+	require.ErrorIs(t, err, admin.ErrAuditNotListable)
+}
+
+func TestAuditListPagingAndFilters(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	al := wireAudit(t, svc)
+	agents := []string{"a", "b", "a", "b", "a"}
+	for i, ag := range agents {
+		require.NoError(t, al.Append(audit.Record{
+			Event: "enqueue", Agent: ag, Inbox: "work", MessageID: string(rune('1' + i)),
+		}))
+	}
+
+	// Paging by resume cursor: no overlap, no gap, and a short final page ends it.
+	p1, next, err := svc.AuditList(admin.AuditFilter{}, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{1, 2}, auditSeqs(p1))
+	assert.Equal(t, uint64(2), next)
+
+	p2, next, err := svc.AuditList(admin.AuditFilter{}, next, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{3, 4}, auditSeqs(p2))
+	assert.Equal(t, uint64(4), next)
+
+	p3, next, err := svc.AuditList(admin.AuditFilter{}, next, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{5}, auditSeqs(p3))
+	assert.Equal(t, uint64(0), next, "exhausted log reports no next")
+
+	// Agent filter selects across the whole chain (seqs 1,3,5 are agent a).
+	byAgent, next, err := svc.AuditList(admin.AuditFilter{Agent: "a"}, 0, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{1, 3, 5}, auditSeqs(byAgent))
+	assert.Equal(t, uint64(0), next)
+
+	// Message-id filter is exact.
+	byMsg, _, err := svc.AuditList(admin.AuditFilter{MessageID: "4"}, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, byMsg, 1)
+	assert.Equal(t, uint64(4), byMsg[0].Seq)
+}
+
+func TestAuditListTimeBounds(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	al := wireAudit(t, svc)
+	require.NoError(t, al.Append(audit.Record{Event: "enqueue", Agent: "a", MessageID: "1"}))
+
+	// The one entry was written ~now. A window in the past excludes it; the same
+	// past instant as an open lower bound includes it; a future lower bound excludes.
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	got, _, err := svc.AuditList(admin.AuditFilter{Since: past}, 0, 10)
+	require.NoError(t, err)
+	assert.Len(t, got, 1, "since in the past includes a now entry")
+
+	got, _, err = svc.AuditList(admin.AuditFilter{Since: future}, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, got, "since in the future excludes a now entry")
+
+	got, _, err = svc.AuditList(admin.AuditFilter{Until: past}, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, got, "until in the past excludes a now entry (half-open upper bound)")
+}
+
+// GET /audit is gated on its own audit:read scope (ADR 0033 §2 / ADR 0029): a
+// client with a different read scope is 403, one with audit:read reaches the
+// handler, an unknown token is 401.
+func TestAuditListRouteScope(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	al := wireAudit(t, svc)
+	require.NoError(t, al.Append(audit.Record{Event: "enqueue", Agent: "a", MessageID: "1"}))
+
+	addr := startScopedServer(t, svc, "root-tok",
+		admin.ScopedClient{Name: "q", Token: "q-tok", Scopes: []string{admincfg.ScopeQueueRead}},
+		admin.ScopedClient{Name: "au", Token: "au-tok", Scopes: []string{admincfg.ScopeAuditRead}},
+	)
+	base := "http://" + addr
+
+	assert.Equal(t, http.StatusUnauthorized, doReq(t, "GET", base+"/audit", "nope-tok"))
+	assert.Equal(t, http.StatusForbidden, doReq(t, "GET", base+"/audit", "q-tok"), "queue:read must not reach audit")
+	assert.Equal(t, http.StatusOK, doReq(t, "GET", base+"/audit", "au-tok"))
+	assert.Equal(t, http.StatusOK, doReq(t, "GET", base+"/audit", "root-tok"))
+}
+
+func TestAuditListClientRoundtrip(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	al := wireAudit(t, svc)
+	for i := 0; i < 3; i++ {
+		require.NoError(t, al.Append(audit.Record{Event: "enqueue", Agent: "a", MessageID: string(rune('1' + i))}))
+	}
+	addr := startScopedServer(t, svc, "root-tok")
+	c := admin.NewClient(addr, "root-tok")
+
+	entries, next, err := c.AuditList(context.Background(), admin.AuditFilter{}, 0, 2)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{1, 2}, auditSeqs(entries))
+	assert.Equal(t, uint64(2), next)
+	assert.Equal(t, "a", entries[0].Record.Agent, "record fields survive the round-trip")
+}

--- a/internal/admin/audit_list_test.go
+++ b/internal/admin/audit_list_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -86,6 +87,29 @@ func TestAuditListPagingAndFilters(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, byMsg, 1)
 	assert.Equal(t, uint64(4), byMsg[0].Seq)
+}
+
+// The paged filter-fill must advance the cursor across a batch that yields zero
+// matches and fetch the next — the behaviour the whole paged shape exists to
+// provide, and the one a single-batch dataset cannot reach. auditScanBatch is 256,
+// so this crosses it: 256 non-matching entries then 4 matches. If the cursor
+// advanced only on a match, the loop would re-fetch the same all-filtered first
+// batch forever; this pins that it advances on every scanned entry.
+func TestAuditListCrossesBatchBoundary(t *testing.T) {
+	svc, _, _ := newSvc(t)
+	al := wireAudit(t, svc)
+	const common, rare = 256, 4
+	for i := 0; i < common; i++ {
+		require.NoError(t, al.Append(audit.Record{Event: "enqueue", Agent: "common", MessageID: strconv.Itoa(i + 1)}))
+	}
+	for i := 0; i < rare; i++ {
+		require.NoError(t, al.Append(audit.Record{Event: "enqueue", Agent: "rare", MessageID: strconv.Itoa(common + i + 1)}))
+	}
+
+	got, next, err := svc.AuditList(admin.AuditFilter{Agent: "rare"}, 0, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []uint64{257, 258, 259, 260}, auditSeqs(got))
+	assert.Equal(t, uint64(0), next, "all matches returned, log exhausted")
 }
 
 func TestAuditListTimeBounds(t *testing.T) {

--- a/internal/admin/client.go
+++ b/internal/admin/client.go
@@ -8,7 +8,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
+	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
@@ -70,6 +73,71 @@ func (c *Client) List(ctx context.Context) ([]sluice.Meta, error) {
 		return nil, err
 	}
 	return metas, nil
+}
+
+// AuditList reads one page of the audit log's history (ADR 0033), filtered and
+// resuming strictly after `after`. It returns the entries and the next resume
+// position (0 when the log was exhausted). The two no-read states come back as the
+// typed ErrAuditDisabled / ErrAuditNotListable, so a caller can tell "audit off"
+// from "backend cannot list" positively rather than from the HTTP status.
+func (c *Client) AuditList(ctx context.Context, f AuditFilter, after uint64, limit int) ([]audit.Entry, uint64, error) {
+	q := url.Values{}
+	if after > 0 {
+		q.Set("after", strconv.FormatUint(after, 10))
+	}
+	if limit > 0 {
+		q.Set("limit", strconv.Itoa(limit))
+	}
+	if f.Agent != "" {
+		q.Set("agent", f.Agent)
+	}
+	if f.MessageID != "" {
+		q.Set("message_id", f.MessageID)
+	}
+	if !f.Since.IsZero() {
+		q.Set("since", f.Since.Format(time.RFC3339))
+	}
+	if !f.Until.IsZero() {
+		q.Set("until", f.Until.Format(time.RFC3339))
+	}
+	path := "/audit"
+	if enc := q.Encode(); enc != "" {
+		path += "?" + enc
+	}
+	resp, err := c.request(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, auditErrorFrom(resp)
+	}
+	var out auditListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, 0, err
+	}
+	return out.Entries, out.Next, nil
+}
+
+// auditErrorFrom maps the audit listing's typed error codes back to the sentinel
+// errors, so `errors.Is` works across the wire; anything else falls back to the
+// generic message like errorFrom.
+func auditErrorFrom(resp *http.Response) error {
+	var e struct {
+		Error string `json:"error"`
+		Code  string `json:"code"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&e)
+	switch e.Code {
+	case "audit_disabled":
+		return ErrAuditDisabled
+	case "audit_not_listable":
+		return ErrAuditNotListable
+	}
+	if e.Error == "" {
+		e.Error = resp.Status
+	}
+	return fmt.Errorf("admin: %s", e.Error)
 }
 
 // Show returns the raw RFC 822 of a held message.

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -405,13 +405,10 @@ type auditListResponse struct {
 	Next    uint64        `json:"next,omitempty"`
 }
 
-// auditListMaxLimit caps a single page so one request cannot ask the server to
-// materialize an unbounded number of matches; auditListDefaultLimit applies when
-// the caller gives none.
-const (
-	auditListDefaultLimit = 100
-	auditListMaxLimit     = 1000
-)
+// auditListDefaultLimit applies when the caller gives no limit. The upper cap
+// (auditListMaxLimit) lives with the allocation in AuditList so the bound cannot
+// be lost by a caller that skips this handler's clamp.
+const auditListDefaultLimit = 100
 
 func (s *Server) handleAuditList(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -6,11 +6,14 @@ import (
 	"crypto/subtle"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/yaad-index/darbaan/internal/admincfg"
+	"github.com/yaad-index/darbaan/internal/audit"
 	"github.com/yaad-index/darbaan/internal/inbound"
 	"github.com/yaad-index/darbaan/internal/sluice"
 )
@@ -101,6 +104,10 @@ func NewServer(addr, token string, svc *Service) (*Server, error) {
 
 	// Per-account inbound-sync health (#195): is every fronted account syncing?
 	s.register(mux, "GET /sync-status", s.handleSyncStatus)
+
+	// Read the audit log's history live, while serve runs (ADR 0033). Paged so no
+	// read transaction outlives one page; audit:read is its own scope.
+	s.register(mux, "GET /audit", s.handleAuditList)
 
 	s.http = &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
 	return s, nil
@@ -389,6 +396,85 @@ func writeAction(w http.ResponseWriter, out Outcome, err error) {
 	default:
 		writeJSON(w, http.StatusOK, out)
 	}
+}
+
+// auditListResponse is one page of the audit listing (ADR 0033): the entries plus
+// the resume position for the next page (omitted/0 when the log was exhausted).
+type auditListResponse struct {
+	Entries []audit.Entry `json:"entries"`
+	Next    uint64        `json:"next,omitempty"`
+}
+
+// auditListMaxLimit caps a single page so one request cannot ask the server to
+// materialize an unbounded number of matches; auditListDefaultLimit applies when
+// the caller gives none.
+const (
+	auditListDefaultLimit = 100
+	auditListMaxLimit     = 1000
+)
+
+func (s *Server) handleAuditList(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	var after uint64
+	if v := q.Get("after"); v != "" {
+		n, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, fmt.Errorf("invalid after (want a sequence number): %w", err))
+			return
+		}
+		after = n
+	}
+
+	limit := auditListDefaultLimit
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			writeErr(w, http.StatusBadRequest, errors.New("invalid limit (want a positive integer)"))
+			return
+		}
+		if n > auditListMaxLimit {
+			n = auditListMaxLimit
+		}
+		limit = n
+	}
+
+	f := AuditFilter{Agent: q.Get("agent"), MessageID: q.Get("message_id")}
+	if v := q.Get("since"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, fmt.Errorf("invalid since (want RFC3339): %w", err))
+			return
+		}
+		f.Since = t
+	}
+	if v := q.Get("until"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, fmt.Errorf("invalid until (want RFC3339): %w", err))
+			return
+		}
+		f.Until = t
+	}
+
+	entries, next, err := s.svc.AuditList(f, after, limit)
+	switch {
+	case errors.Is(err, ErrAuditDisabled):
+		// Distinct typed codes, not one status: a client tells audit-off from
+		// backend-cannot-list positively (ADR 0033 §4).
+		writeErrWithCode(w, http.StatusNotFound, err, "audit_disabled")
+		return
+	case errors.Is(err, ErrAuditNotListable):
+		writeErrWithCode(w, http.StatusNotImplemented, err, "audit_not_listable")
+		return
+	case err != nil:
+		writeErr(w, http.StatusInternalServerError, err)
+		return
+	}
+	if entries == nil {
+		entries = []audit.Entry{}
+	}
+	writeJSON(w, http.StatusOK, auditListResponse{Entries: entries, Next: next})
 }
 
 func writeJSON(w http.ResponseWriter, code int, v any) {

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -430,10 +430,7 @@ func (s *Server) handleAuditList(w http.ResponseWriter, r *http.Request) {
 			writeErr(w, http.StatusBadRequest, errors.New("invalid limit (want a positive integer)"))
 			return
 		}
-		if n > auditListMaxLimit {
-			n = auditListMaxLimit
-		}
-		limit = n
+		limit = min(n, auditListMaxLimit)
 	}
 
 	f := AuditFilter{Agent: q.Get("agent"), MessageID: q.Get("message_id")}

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -447,11 +447,15 @@ func (s *Service) AuditList(f AuditFilter, after uint64, limit int) ([]audit.Ent
 	if limit <= 0 {
 		return nil, 0, nil
 	}
-	// min() rather than an if-reassignment: same bound, but the form CodeQL's
-	// allocation-size dataflow recognizes as a sanitizer, so the traced bound also
-	// clears the check honestly.
+	// Cap how many one call returns — the bound lives beside the code, not only at
+	// the HTTP caller, since AuditList is exported.
 	limit = min(limit, auditListMaxLimit)
-	out := make([]audit.Entry, 0, limit)
+	// Seed the result capacity from a constant, not the request-derived limit: the
+	// capacity is a pure append-growth hint (nothing reads it back), so this removes
+	// the input→allocation dataflow entirely rather than trusting a static analyzer
+	// to recognize a clamp as a sanitizer. A property of the code cannot regress when
+	// the analyzer's model changes.
+	out := make([]audit.Entry, 0, auditScanBatch)
 	cursor := after
 	for {
 		page, err := r.Page(cursor, auditScanBatch)

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -423,6 +423,13 @@ func (f AuditFilter) match(e audit.Entry) bool {
 // keeps: a narrow filter pages through more batches, never one long-held read.
 const auditScanBatch = 256
 
+// auditListMaxLimit caps the entries one call returns, so the result allocation
+// cannot be driven unbounded. It lives here, with the allocation, rather than only
+// at the HTTP handler: AuditList is exported and must carry its own bound — a
+// second caller that forgets to clamp would otherwise reintroduce the problem
+// silently.
+const auditListMaxLimit = 1000
+
 // AuditList returns up to limit audit entries matching f, with Seq greater than
 // after, in ascending Seq order, plus the resume position for the next page (0 when
 // the log was exhausted). It reads through the backend's paged Reader — one short
@@ -439,6 +446,9 @@ func (s *Service) AuditList(f AuditFilter, after uint64, limit int) ([]audit.Ent
 	}
 	if limit <= 0 {
 		return nil, 0, nil
+	}
+	if limit > auditListMaxLimit {
+		limit = auditListMaxLimit
 	}
 	out := make([]audit.Entry, 0, limit)
 	cursor := after

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -375,6 +375,96 @@ func (s *Service) auditHold(ctx context.Context, m inbound.Message, decision str
 	}
 }
 
+// ErrAuditDisabled and ErrAuditNotListable are the two distinct no-read states an
+// audit listing can hit (ADR 0033 §4). They must not collapse into one message:
+// "audit is off" and "this backend cannot enumerate" send an operator to different
+// places, and conflating them reproduces the absence-reads-as-a-different-absence
+// failure the read path exists to end.
+var (
+	ErrAuditDisabled    = errors.New("admin: audit is disabled (no audit backend configured)")
+	ErrAuditNotListable = errors.New("admin: the configured audit backend cannot list entries")
+)
+
+// AuditFilter narrows an audit listing. A zero value matches every entry; each set
+// field is ANDed. The time bounds are half-open [Since, Until).
+type AuditFilter struct {
+	Agent     string
+	MessageID string
+	Since     time.Time
+	Until     time.Time
+}
+
+func (f AuditFilter) match(e audit.Entry) bool {
+	if f.Agent != "" && e.Record.Agent != f.Agent {
+		return false
+	}
+	if f.MessageID != "" && e.Record.MessageID != f.MessageID {
+		return false
+	}
+	if !f.Since.IsZero() || !f.Until.IsZero() {
+		t, err := time.Parse(time.RFC3339Nano, e.Time)
+		if err != nil {
+			// An unparseable timestamp cannot be shown to satisfy a time bound, so a
+			// time-filtered query excludes it rather than guess.
+			return false
+		}
+		if !f.Since.IsZero() && t.Before(f.Since) {
+			return false
+		}
+		if !f.Until.IsZero() && !t.Before(f.Until) {
+			return false
+		}
+	}
+	return true
+}
+
+// auditScanBatch is how many raw entries one short read transaction pulls per page.
+// It bounds the transaction (ADR 0033 §1a) independently of how many the filter
+// keeps: a narrow filter pages through more batches, never one long-held read.
+const auditScanBatch = 256
+
+// AuditList returns up to limit audit entries matching f, with Seq greater than
+// after, in ascending Seq order, plus the resume position for the next page (0 when
+// the log was exhausted). It reads through the backend's paged Reader — one short
+// transaction per batch — so a slow consumer cannot hold a read open against the
+// running writer (ADR 0033 §1a). A backend with no readable chain surfaces as the
+// distinct ErrAuditDisabled / ErrAuditNotListable states, never one generic error.
+func (s *Service) AuditList(f AuditFilter, after uint64, limit int) ([]audit.Entry, uint64, error) {
+	if s.audit == nil {
+		return nil, 0, ErrAuditDisabled
+	}
+	r, ok := s.audit.(audit.Reader)
+	if !ok {
+		return nil, 0, ErrAuditNotListable
+	}
+	if limit <= 0 {
+		return nil, 0, nil
+	}
+	out := make([]audit.Entry, 0, limit)
+	cursor := after
+	for {
+		page, err := r.Page(cursor, auditScanBatch)
+		if err != nil {
+			return nil, 0, err
+		}
+		for _, e := range page {
+			cursor = e.Seq
+			if !f.match(e) {
+				continue
+			}
+			out = append(out, e)
+			if len(out) == limit {
+				// A full page; more entries may follow, so hand back the resume cursor.
+				return out, cursor, nil
+			}
+		}
+		if len(page) < auditScanBatch {
+			// The batch was short, so the log is exhausted: no more pages.
+			return out, 0, nil
+		}
+	}
+}
+
 // Outcome is the result of an approve/reject action. Status is the committed
 // state (the source of truth); Warn carries a non-fatal downstream issue (a send
 // or bounce-delivery failure) without claiming the verdict itself failed.

--- a/internal/admin/service.go
+++ b/internal/admin/service.go
@@ -447,9 +447,10 @@ func (s *Service) AuditList(f AuditFilter, after uint64, limit int) ([]audit.Ent
 	if limit <= 0 {
 		return nil, 0, nil
 	}
-	if limit > auditListMaxLimit {
-		limit = auditListMaxLimit
-	}
+	// min() rather than an if-reassignment: same bound, but the form CodeQL's
+	// allocation-size dataflow recognizes as a sanitizer, so the traced bound also
+	// clears the check honestly.
+	limit = min(limit, auditListMaxLimit)
 	out := make([]audit.Entry, 0, limit)
 	cursor := after
 	for {

--- a/internal/admincfg/admincfg.go
+++ b/internal/admincfg/admincfg.go
@@ -38,6 +38,12 @@ const (
 	ScopeReconcileRelease = "reconcile:release"
 	ScopeInboxesRead      = "inboxes:read"
 	ScopeSyncRead         = "sync:read"
+	// ScopeAuditRead grants reading the audit log's history (ADR 0033). It is its
+	// own capability, deliberately not folded into queue:read: the audit log is the
+	// record of who-did-what across the deployment's life — a strictly larger
+	// disclosure than the live queue — so a client granted queue:read to triage the
+	// queue does not thereby inherit the whole history.
+	ScopeAuditRead = "audit:read"
 )
 
 // RouteScopes is the authoritative route→required-scope map (ADR 0029): every
@@ -62,6 +68,7 @@ var RouteScopes = map[string]string{
 	"POST /reconcile/{inbox}/release":     ScopeReconcileRelease,
 	"GET /inboxes":                        ScopeInboxesRead,
 	"GET /sync-status":                    ScopeSyncRead,
+	"GET /audit":                          ScopeAuditRead,
 }
 
 // allScopes is the set of valid scopes, derived from the RouteScopes values so it

--- a/internal/admincfg/admincfg_test.go
+++ b/internal/admincfg/admincfg_test.go
@@ -70,7 +70,7 @@ func TestValidate(t *testing.T) {
 
 func TestAllScopesAndValidScope(t *testing.T) {
 	all := admincfg.AllScopes()
-	assert.Len(t, all, 8)
+	assert.Len(t, all, 9)
 	for _, s := range all {
 		assert.True(t, admincfg.ValidScope(s))
 	}
@@ -97,6 +97,7 @@ func TestRouteScopesComplete(t *testing.T) {
 		"POST /reconcile/{inbox}/release",
 		"GET /inboxes",
 		"GET /sync-status",
+		"GET /audit",
 	}
 	assert.Len(t, admincfg.RouteScopes, len(wantRoutes), "no extra/missing routes")
 	for _, r := range wantRoutes {

--- a/internal/audit/audit.go
+++ b/internal/audit/audit.go
@@ -70,6 +70,30 @@ type AuditLog interface {
 	Close() error
 }
 
+// Reader is the read capability over an audit log, kept distinct from AuditLog
+// (append/verify/close) on purpose. A backend that keeps a readable chain
+// implements it; the null backend does not — so a caller can tell "audit is
+// disabled" (a nil log, or a backend that is not a Reader) from "this backend
+// cannot list" and report the two as the different operator states they are
+// (ADR 0033 §4).
+type Reader interface {
+	// Page returns up to limit entries whose Seq is strictly greater than after,
+	// in ascending Seq order, read inside a single short-lived transaction that
+	// does not outlive the call. A slice shorter than limit means the end of the
+	// log was reached; after=0 starts from the first entry. limit <= 0 returns
+	// nothing.
+	//
+	// Paging is by resume position (the caller passes back the last Seq it saw),
+	// never a live cursor: a bbolt cursor's keys are valid only within their
+	// transaction, and — the reason the primitive is paged at all — a single walk
+	// held open at a client's pace would keep a read transaction alive in the
+	// running process, whose pages the writer cannot reclaim and whose lock a
+	// growing append blocks, stalling every subsequent decision write (ADR 0033
+	// §1a). One short View per page keeps the transaction bounded regardless of how
+	// slowly the caller consumes.
+	Page(after uint64, limit int) ([]Entry, error)
+}
+
 // Factory constructs an AuditLog of a given type from a path (ignored by sinks
 // that need no storage, e.g. null).
 type Factory func(path string) (AuditLog, error)

--- a/internal/audit/bbolt.go
+++ b/internal/audit/bbolt.go
@@ -131,6 +131,42 @@ func (l *bboltLog) Verify() error {
 	})
 }
 
+// Page implements Reader: it returns up to limit entries with Seq strictly
+// greater than after, ascending, inside one short-lived View. The transaction is
+// bounded to this call and never spans the caller's consumption — a growing
+// append must not wait on a client-paced reader (ADR 0033 §1a). Filtering is the
+// caller's job; a narrow filter simply pages through more short Views (it walks
+// the whole chain, but never holds one transaction open across the walk).
+func (l *bboltLog) Page(after uint64, limit int) ([]Entry, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
+	out := make([]Entry, 0, limit)
+	err := l.db.View(func(tx *bbolt.Tx) error {
+		b := tx.Bucket(bucketName)
+		if b == nil {
+			return nil
+		}
+		c := b.Cursor()
+		// seqkeys are fixed-width big-endian, so key order is Seq order. Seeking to
+		// after+1 lands on the first entry with Seq > after; after=0 seeks to 1, the
+		// first entry (NextSequence issues 1 first).
+		k, v := c.Seek(seqkey.Encode(after + 1))
+		for ; k != nil && len(out) < limit; k, v = c.Next() {
+			var e Entry
+			if err := json.Unmarshal(v, &e); err != nil {
+				return fmt.Errorf("audit: decode entry at seq %d: %w", seqkey.Decode(k), err)
+			}
+			out = append(out, e)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (l *bboltLog) Close() error { return l.db.Close() }
 
 // OpenReadOnly opens an existing bbolt audit log read-only for offline integrity

--- a/internal/audit/page_test.go
+++ b/internal/audit/page_test.go
@@ -1,0 +1,91 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seqs extracts the Seq of each entry, for order/paging assertions.
+func seqs(entries []Entry) []uint64 {
+	out := make([]uint64, len(entries))
+	for i, e := range entries {
+		out[i] = e.Seq
+	}
+	return out
+}
+
+func TestPageWalksInSeqOrderAndResumes(t *testing.T) {
+	l := newBboltLog(t)
+	for i := 0; i < 5; i++ {
+		require.NoError(t, l.Append(Record{Event: "enqueue", Agent: "a", MessageID: "m"}))
+	}
+	r := l.(Reader)
+
+	// after=0 starts at the first entry; a full page is limit-sized and ascending.
+	p1, err := r.Page(0, 2)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1, 2}, seqs(p1))
+
+	// Resume strictly after the last Seq seen — no overlap, no gap.
+	p2, err := r.Page(2, 2)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3, 4}, seqs(p2))
+
+	// A page shorter than limit is the end of the log.
+	p3, err := r.Page(4, 2)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{5}, seqs(p3))
+
+	// Past the tail: empty, not an error.
+	p4, err := r.Page(5, 2)
+	require.NoError(t, err)
+	require.Empty(t, p4)
+}
+
+func TestPageCarriesRecordFields(t *testing.T) {
+	l := newBboltLog(t)
+	require.NoError(t, l.Append(Record{Event: "enqueue", Agent: "agent-a", Inbox: "work", MessageID: "42"}))
+
+	got, err := l.(Reader).Page(0, 10)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Equal(t, "enqueue", got[0].Record.Event)
+	require.Equal(t, "agent-a", got[0].Record.Agent)
+	require.Equal(t, "work", got[0].Record.Inbox)
+	require.Equal(t, "42", got[0].Record.MessageID)
+	require.NotEmpty(t, got[0].Hash) // a real chained entry, not a zero value
+}
+
+func TestPageEmptyLogAndLimitEdges(t *testing.T) {
+	l := newBboltLog(t)
+	r := l.(Reader)
+
+	// Empty log verifies clean and reads clean.
+	empty, err := r.Page(0, 10)
+	require.NoError(t, err)
+	require.Empty(t, empty)
+
+	require.NoError(t, l.Append(Record{Event: "enqueue"}))
+	// A non-positive limit returns nothing (and never opens an unbounded read).
+	for _, lim := range []int{0, -1} {
+		got, err := r.Page(0, lim)
+		require.NoError(t, err)
+		require.Empty(t, got)
+	}
+}
+
+// The read capability is deliberately separate from AuditLog: the bbolt backend
+// is a Reader, the null backend is not. That type distinction is what lets a
+// caller tell "audit disabled" from "this backend cannot list" (ADR 0033 §4).
+func TestReaderCapabilityIsBackendSpecific(t *testing.T) {
+	bl := newBboltLog(t)
+	_, ok := bl.(Reader)
+	require.True(t, ok, "bbolt backend must be a Reader")
+
+	nl, err := New("null", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = nl.Close() })
+	_, ok = nl.(Reader)
+	require.False(t, ok, "null backend must NOT be a Reader")
+}


### PR DESCRIPTION
Implements the audit-log read path to the shape ADR 0033 records (merged in #294). Builds on the enqueue-arrival log (#293); together they close the incident that started this — an audited arrival that could not be read back.

## What it does
`darbaan audit ls` lists audit entries **live**, through the running serve's loopback admin API (like `queue ls`), so reading the log never means stopping the gate. Filters: `--agent`, `--message-id`, `--since`/`--until` (RFC3339, half-open), `--limit`, `--after` (paging); `--json` for line-delimited output.

## How it holds to the ADR
- **Bounded transaction, not response (§1a).** The `Reader.Page(after, limit)` primitive reads one bounded batch inside a single short `db.View` that never spans the caller's consumption; paging is by resume-seq re-`Seek`'d each call, never a live cursor. A slow client cannot hold a read open and stall a growing append. A narrow filter pages through more short Views (it walks the chain; it never holds one open across the walk).
- **Dedicated `audit:read` scope (§2)** in the ADR 0029 route→scope map — not folded into `queue:read`; the history is a larger disclosure than the live queue. Completeness pins updated.
- **No redaction v1 (§3)** — output carries the record fields; the same surface already serves raw RFC822 bodies.
- **Distinct states (§4):** audit-disabled vs backend-cannot-list are separate typed errors end to end, never one generic empty.
- **verify untouched**, stays offline.
- **Recorded limitation:** no offline enumeration in v1 — a serve-down post-mortem is still unreadable (accepted in the ADR).

## Verification
build, vet, `gofmt -l`, golangci-lint 2.11.4 (0 issues), and `go test -race` all green locally. Tests cover paging boundaries, each filter, the half-open time bound, the route scope gate (403 without `audit:read`, 401 unknown token), the disabled-vs-not-listable split, and a client round-trip.

Standard gate (code-only, no docs/ADR touched): 2-of-2 + CI + operator window.

closes #292